### PR TITLE
fix typo in close_proc

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -168,5 +168,5 @@ def ffmpeg_read_image(filename, with_mask=True):
     else:
         pix_fmt = "rgb24"
     vf = FFMPEG_VideoReader(filename, pix_fmt=pix_fmt)
-    vf.close()
+    vf.close_proc()
     return vf.lastread


### PR DESCRIPTION
I think there's a typo. This was causing an issue when trying to read an image in ffmpeg.
