### PR TITLE
added support for aac audio codec

### DIFF
--- a/moviepy/audio/io/ffmpeg_audiowriter.py
+++ b/moviepy/audio/io/ffmpeg_audiowriter.py
@@ -52,6 +52,7 @@ class FFMPEG_AudioWriter:
                  [ "-i", input_video, '-vcodec', 'copy'])
             + ['-acodec', codec]
             + ['-ar', "%d"%fps_input]
+            + ['-strict', '-2']  # needed to support codec 'aac'
             + (['-ab',bitrate] if (bitrate!=None) else [])
             + [ filename ])
         

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -192,6 +192,7 @@ class VideoClip(Clip):
                 D_ext = {'libmp3lame': 'mp3',
                        'libvorbis':'ogg',
                        'libfdk_aac':'m4a',
+                       'aac':'m4a',
                        'pcm_s16le':'wav',
                        'pcm_s32le': 'wav'}
                 


### PR DESCRIPTION
My ffmpeg binaries don't have support for the libfdk_aac audio codec. I downloaded my binaries directly from ffmpeg.org, for both OSX and Ubuntu. Neither had libfdk_aac support.

So this changes lets moviepy support the native ffmpeg aac audio codec. The only wrinkle is that if you use aac, you need to tell ffmpeg it's allowed to use "experimental features", hence the addition of the "-strict -2" arguments to the ffmpeg command line.
