### PR TITLE
Fixed syntax error in io/imageMagick_tools.py

### DIFF
--- a/moviepy/video/io/imageMagick_tools.py
+++ b/moviepy/video/io/imageMagick_tools.py
@@ -9,22 +9,22 @@ def gif_to_directory(gif_file,dirName=None):
     is not provided, the directory has the same name
     as the .gif file. Supports transparency.
     Returns the directory name.
-    
+
     Example:
 
     >>> d = gif_to_directory("animated-earth.gif")
     >>> clip = DirectoryClip(d,fps=3)
-        
+
     """
-    
+
     if dirName is None:
         name, ext = os.path.splitext(gif_file)
         dirName = name
-    
+
     try:
         os.mkdir(dirName)
     except:
         pass
-    
-    subprocess_call ["convert", "-coalesce", gif_file,
+
+    subprocess_call(["convert", "-coalesce", gif_file,
              os.path.join(dirName,"%04d.png")])


### PR DESCRIPTION
There's a missing parenthesis in imageMagick_tools which causes an syntax error.
