### PR TITLE
Fixed write_logfile/verbose arguments

### DIFF
--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -91,7 +91,7 @@ class AudioClip(Clip):
     @requires_duration
     def to_audiofile(self,filename, fps=44100, nbytes=2,
                      buffersize=2000, codec='libvorbis',
-                     bitrate=None, verbose=True):
+                     bitrate=None, write_logfile=False, verbose=True):
         """ 
         codecs  = {        'libmp3lame': 'mp3',
                        'libvorbis':'ogg',
@@ -101,7 +101,7 @@ class AudioClip(Clip):
         """
                          
         return ffmpeg_audiowrite(self, filename, fps, nbytes, buffersize,
-                      codec=codec, bitrate=bitrate, verbose=verbose)
+                      codec=codec, bitrate=bitrate, write_logfile=write_logfile, verbose=verbose)
 
 
 class AudioArrayClip(AudioClip):

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -271,8 +271,8 @@ class VideoClip(Clip):
             if make_audio:
                 self.audio.to_audiofile(temp_audiofile,audio_fps,
                                         audio_nbytes, audio_bufsize,
-                                        audio_codec, audio_bitrate,
-                                        verbose)
+                                        audio_codec, bitrate=audio_bitrate, write_logfile=write_logfile,
+                                        verbose=verbose)
 
             ffmpeg_write_video(self,
                                videofile, fps, codec,


### PR DESCRIPTION
The audiowriter would write a logfile if verbose was set to true in VideoClip.to_videofile (ignoring _write_logfile_)

In AudioClip.py:
`return ffmpeg_audiowrite(self,filename, fps, nbytes, buffersize, codec, bitrate, verbose)`

The _verbose_ argument is given too early. Here's ffmpeg_audiowrite definition:
`def ffmpeg_audiowrite(clip, filename, fps, nbytes, buffersize, codec='libvorbis', bitrate=None, write_logfile = False, verbose=True):`
