### PR TITLE
Added hasFFMPEGSupport to tools.py

### DIFF
--- a/moviepy/tools.py
+++ b/moviepy/tools.py
@@ -66,7 +66,7 @@ def hasFFMPEGSupport(ffmpeg_switch, query):
     >>> result = hasFFMPEGSupport('encoders', 'libx264')
     >>> result = hasFFMPEGSupport('encoders', 'libvorbis')
     """
-    process = subprocess.Popen(str('ffmpeg -' + ffmpeg_switch), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = sp.Popen(str('ffmpeg -' + ffmpeg_switch), shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
     supported = dict((line.split()[1], line.split()[0]) for line in (process.communicate()[0]).split('\n') if len(line.split())>=3)
     query_result = supported.get(query)
     if query_result is not None:

--- a/moviepy/tools.py
+++ b/moviepy/tools.py
@@ -53,3 +53,23 @@ def cvsecs(*args):
         return 60*args[0]+args[1]
     elif len(args) ==3:
         return 3600*args[0]+60*args[1]+args[2]
+
+        
+def hasFFMPEGSupport(ffmpeg_switch, query):
+    """
+    ffmpeg_switch = 'codecs', 'formats' (file extensions), 'encoders' or 'decoders' depending
+    on what you want to check.
+    
+    Returns True if supported, False if not.
+    
+    Example usage:
+    >>> result = hasFFMPEGSupport('encoders', 'libx264')
+    >>> result = hasFFMPEGSupport('encoders', 'libvorbis')
+    """
+    process = subprocess.Popen(str('ffmpeg -' + ffmpeg_switch), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    supported = dict((line.split()[1], line.split()[0]) for line in (process.communicate()[0]).split('\n') if len(line.split())>=3)
+    query_result = supported.get(query)
+    if query_result is not None:
+        return True
+    else:
+        return False


### PR DESCRIPTION
This is the tool I mentioned on one of the videogrep issues. It will check which codecs. formats, encoders and decoders your FFMPEG build supports. I've implemented it as a utility function. Hope its of use.