### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu
+
+# Install numpy using system package manager
+RUN apt-get -y update && apt-get -y install python-numpy python-pip
+
+# Add optional but recommended libraries (scipy and friends)
+RUN apt-get -y install python-scipy python-sklearn
+
+# MoviePy requires the ffmpeg binary. Ubuntu PPA doesn't work at the
+# moment, so install directly from official static binary release.
+ADD http://johnvansickle.com/ffmpeg/releases/ffmpeg-2.4-64bit-static.tar.xz /f.tar.xz
+RUN cd / && tar xvfJ f.tar.xz
+RUN ls -l /ffmpeg*
+RUN ln -s /ffmpeg-*/ffmpeg /usr/bin/
+RUN ln -s /ffmpeg-*/ffprobe /usr/bin/
+# Verify that ffmpeg works.
+RUN /usr/bin/ffmpeg || true
+
+ADD . /moviepy
+WORKDIR /moviepy
+RUN pip install .


### PR DESCRIPTION
Docker is becoming one of the most popular ways to install things. I built a docker image for moviepy so that I can install it (on my Mac) easily using a single command:

```
docker pull srid/moviepy
```

The above image comes from a "trusted build" I setup here https://registry.hub.docker.com/u/srid/moviepy/ - which automatically runs whenever my fork changes. Should this pull request be accepted, I imagine the maintainers of this repo would setup a similar "Zulko/moviepy" trusted build and recommend its use from the README. Or, the image can be created manually on demand during releases.

Any project that uses moviepy can leverage docker to build itself, using its own Dockerfile like for instance:

```
FROM srid/moviepy

ADD requirements.txt /app/requirements.txt
WORKDIR /app
RUN pip install -r requirements.txt

ADD . /app
RUN mkdir /app/output
```

Input and output videos can be managed using docker volumes.
