### PR TITLE
Changed all "== None" and "!= None"

### DIFF
--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -130,7 +130,7 @@ class Clip:
         for attr in apply_to:
             if hasattr(newclip, attr):
                 a = getattr(newclip, attr)
-                if a != None:
+                if a is not None:
                     new_a =  a.fl(fun, keep_duration=keep_duration)
                     setattr(newclip, attr, new_a)
                     
@@ -225,9 +225,9 @@ class Clip:
         """
         
         self.start = t
-        if (self.duration != None) and change_end:
+        if (self.duration is not None) and change_end:
             self.end = t + self.duration
-        elif (self.end !=None):
+        elif (self.end is not None):
             self.duration = self.end - self.start
     
     
@@ -246,7 +246,7 @@ class Clip:
         """
         self.end = t
         if self.start is None:
-            if self.duration != None:
+            if self.duration is not None:
                 self.start = max(0, t - newclip.duration)
         else:
             self.duration = self.end - self.start
@@ -310,7 +310,7 @@ class Clip:
             # is the whole list of t outside the clip ?
             tmin, tmax = t.min(), t.max()
             
-            if (self.end != None) and (tmin >= self.end) :
+            if (self.end is not None) and (tmin >= self.end) :
                 return False
             
             if tmax < self.start:
@@ -318,7 +318,7 @@ class Clip:
             
             # If we arrive here, a part of t falls in the clip
             result = 1 * (t >= self.start)
-            if (self.end != None):
+            if (self.end is not None):
                 result *= (t <= self.end)
             return result
         
@@ -394,7 +394,7 @@ class Clip:
         
         fl = lambda t: t + (t >= ta)*(tb - ta)
         newclip = self.fl_time(fl)
-        if self.duration != None:
+        if self.duration is not None:
             return newclip.set_duration(self.duration - (tb - ta))
         else:
             return newclip

--- a/moviepy/audio/io/ffmpeg_audiowriter.py
+++ b/moviepy/audio/io/ffmpeg_audiowriter.py
@@ -61,12 +61,12 @@ class FFMPEG_AudioWriter:
             '-ar', "%d"%fps_input,
             '-ac',"%d"%nchannels,
             '-i', '-']
-            + (['-vn'] if input_video==None else
+            + (['-vn'] if input_video is None else
                  [ "-i", input_video, '-vcodec', 'copy'])
             + ['-acodec', codec]
             + ['-ar', "%d"%fps_input]
             + ['-strict', '-2']  # needed to support codec 'aac'
-            + (['-ab',bitrate] if (bitrate!=None) else [])
+            + (['-ab',bitrate] if (bitrate is not None) else [])
             + [ filename ])
 
         popen_params = {"stdout": DEVNULL,

--- a/moviepy/audio/io/preview.py
+++ b/moviepy/audio/io/preview.py
@@ -49,7 +49,7 @@ def preview(clip, fps=22050,  buffersize=4000, nbytes= 2,
     sndarray = clip.to_soundarray(tt,nbytes=nbytes, quantize=True)
     chunk = pg.sndarray.make_sound(sndarray)
     
-    if (audioFlag !=None) and (videoFlag!= None):
+    if (audioFlag is not None) and (videoFlag is not None):
         audioFlag.set()
         videoFlag.wait()
         

--- a/moviepy/audio/io/readers.py
+++ b/moviepy/audio/io/readers.py
@@ -216,7 +216,7 @@ class FFMPEG_AudioReader:
         new_bufferstart = max(0,  framenumber - self.buffersize // 2)
 
 
-        if (self.buffer!=None):
+        if (self.buffer is not None):
             current_f_end  = self.buffer_startframe + self.buffersize
             if (new_bufferstart <
                         current_f_end  <

--- a/moviepy/decorators.py
+++ b/moviepy/decorators.py
@@ -26,7 +26,7 @@ def apply_to_mask(f, clip, *a, **k):
         the clip created with f """
         
     newclip = f(clip, *a, **k)
-    if hasattr(newclip, 'mask') and (newclip.mask != None):
+    if hasattr(newclip, 'mask') and (newclip.mask is not None):
         newclip.mask = f(newclip.mask, *a, **k)
     return newclip
 
@@ -38,7 +38,7 @@ def apply_to_audio(f, clip, *a, **k):
         the clip created with f """
         
     newclip = f(clip, *a, **k)
-    if hasattr(newclip, 'audio') and (newclip.audio != None):
+    if hasattr(newclip, 'audio') and (newclip.audio is not None):
         newclip.audio = f(newclip.audio, *a, **k)
     return newclip
 
@@ -65,7 +65,7 @@ def audio_video_fx(f, clip, *a, **k):
     
     if hasattr(clip, "audio"):
         newclip = clip.copy()
-        if clip.audio != None:
+        if clip.audio is not None:
             newclip.audio =  f(clip.audio, *a, **k)
         return newclip
     else:

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -483,7 +483,7 @@ class VideoClip(Clip):
         center = self.subclip(ta, tb).fx(fx, **kwargs)
         right = None if (tb is None) else self.subclip(t_start=tb)
 
-        clips = [c for c in [left, center, right] if c != None]
+        clips = [c for c in [left, center, right] if c is not None]
 
         # beurk, have to find other solution
         from moviepy.video.compositing.concatenate import concatenate_videoclips
@@ -881,7 +881,7 @@ class ImageClip(VideoClip):
         for attr in apply_to:
             if hasattr(self, attr):
                 a = getattr(self, attr)
-                if a != None:
+                if a is not None:
                     new_a = a.fl_image(image_func)
                     setattr(self, attr, new_a)
 
@@ -901,7 +901,7 @@ class ImageClip(VideoClip):
         for attr in apply_to:
             if hasattr(self, attr):
                 a = getattr(self, attr)
-                if a != None:
+                if a is not None:
                     new_a = a.fl_time(time_func)
                     setattr(self, attr, new_a)
 
@@ -1033,7 +1033,7 @@ class TextClip(ImageClip):
             # use a file instead of a text.
             txt = "@%" + filename
 
-        if size != None:
+        if size is not None:
             size = ('' if size[0] is None else str(size[0]),
                     '' if size[1] is None else str(size[1]))
 
@@ -1042,18 +1042,18 @@ class TextClip(ImageClip):
                "-fill", color,
                "-font", font])
 
-        if fontsize != None:
+        if fontsize is not None:
             cmd += ["-pointsize", "%d" % fontsize]
-        if kerning != None:
+        if kerning is not None:
             cmd += ["-kerning", "%0.1f" % kerning]
-        if stroke_color != None:
+        if stroke_color is not None:
             cmd += ["-stroke", stroke_color, "-strokewidth",
                     "%.01f" % stroke_width]
-        if size != None:
+        if size is not None:
             cmd += ["-size", "%sx%s" % (size[0], size[1])]
-        if align != None:
+        if align is not None:
             cmd += ["-gravity", align]
-        if interline != None:
+        if interline is not None:
             cmd += ["-interline-spacing", "%d" % interline]
 
         if tempfilename is None:

--- a/moviepy/video/compositing/CompositeVideoClip.py
+++ b/moviepy/video/compositing/CompositeVideoClip.py
@@ -66,7 +66,7 @@ class CompositeVideoClip(VideoClip):
             self.end = max(ends)
 
         # compute audio
-        audioclips = [v.audio for v in self.clips if v.audio != None]
+        audioclips = [v.audio for v in self.clips if v.audio is not None]
         if len(audioclips) > 0:
             self.audio = CompositeAudioClip(audioclips)
 
@@ -102,9 +102,9 @@ def clips_array(array, rows_widths=None, cols_widths=None,
     array = np.array(array)
     sizes_array = np.array([[c.size for c in line] for line in array])
     
-    if rows_widths == None:
+    if rows_widths is None:
         rows_widths = sizes_array[:,:,1].max(axis=1)
-    if cols_widths == None:
+    if cols_widths is None:
         cols_widths = sizes_array[:,:,0].max(axis=0)
     
     xx = np.cumsum([0]+list(cols_widths)) 

--- a/moviepy/video/compositing/concatenate.py
+++ b/moviepy/video/compositing/concatenate.py
@@ -59,7 +59,7 @@ def concatenate_videoclips(clipslist, method="chain", transition=None, bg_color=
            
     """
 
-    if transition != None:
+    if transition is not None:
         l = [[v, transition] for v in clipslist[:-1]]
         clipslist = reduce(lambda x, y: x + y, l) + [clipslist[-1]]
         transition = None
@@ -98,7 +98,7 @@ def concatenate_videoclips(clipslist, method="chain", transition=None, bg_color=
     result.start_times = tt[:-1]
     result.start, result.duration, result.end = 0, tt[-1] , tt[-1]
     
-    audio_t = [(c.audio,t) for c,t in zip(clipslist,tt) if c.audio!=None]
+    audio_t = [(c.audio,t) for c,t in zip(clipslist,tt) if c.audio is not None]
     if len(audio_t)>0:
         result.audio = CompositeAudioClip([a.set_start(t)
                                 for a,t in audio_t])

--- a/moviepy/video/compositing/on_color.py
+++ b/moviepy/video/compositing/on_color.py
@@ -23,4 +23,4 @@ def on_color(clip, size=None, color=(0, 0, 0), pos=None, col_opacity=None):
         colorclip = colorclip.with_mask().set_opacity(col_opacity)
 
     return CompositeVideoClip([colorclip, clip.set_pos(pos)],
-                              transparent=(col_opacity != None))
+                              transparent=(col_opacity is not None))

--- a/moviepy/video/fx/headblur.py
+++ b/moviepy/video/fx/headblur.py
@@ -21,7 +21,7 @@ def headblur(clip,fx,fy,r_zone,r_blur=None):
     offscreen.
     """
     
-    if r_blur==None: r_blur = 2*r_zone/3
+    if r_blur is None: r_blur = 2*r_zone/3
     
     def fl(gf,t):
         

--- a/moviepy/video/fx/margin.py
+++ b/moviepy/video/fx/margin.py
@@ -25,7 +25,7 @@ def margin(clip, mar=None, left=0, right=0, top=0,
     if (opacity != 1.0) and (clip.mask is None) and not (clip.ismask):
         clip = clip.add_mask()
 
-    if mar != None:
+    if mar is not None:
         left = right = top = bottom = mar
     
     def make_bg(w,h):

--- a/moviepy/video/fx/resize.py
+++ b/moviepy/video/fx/resize.py
@@ -79,7 +79,7 @@ def resize(clip, newsize=None, height=None, width=None, apply_to_mask=True):
 
     w, h = clip.size
     
-    if newsize != None:
+    if newsize is not None:
         
         def trans_newsize(ns):
             
@@ -109,7 +109,7 @@ def resize(clip, newsize=None, height=None, width=None, apply_to_mask=True):
             newsize = trans_newsize(newsize)
         
 
-    elif height != None:
+    elif height is not None:
         
         if hasattr(height, "__call__"):
             fun = lambda t : 1.0*int(height(t))/h
@@ -120,7 +120,7 @@ def resize(clip, newsize=None, height=None, width=None, apply_to_mask=True):
 
             newsize = [w * height / h, height]
         
-    elif width != None:
+    elif width is not None:
 
         if hasattr(width, "__call__"):
             fun = lambda t : 1.0*width(t)/w

--- a/moviepy/video/fx/speedx.py
+++ b/moviepy/video/fx/speedx.py
@@ -15,7 +15,7 @@ def speedx(clip, factor = None, final_duration=None):
         
     newclip = clip.fl_time(lambda t: factor * t, apply_to=['mask', 'audio'])
     
-    if clip.duration != None:
+    if clip.duration is not None:
         newclip = newclip.set_duration(1.0 * clip.duration / factor)
     
     return newclip

--- a/moviepy/video/io/preview.py
+++ b/moviepy/video/io/preview.py
@@ -14,7 +14,7 @@ pg.display.set_caption('MoviePy')
 def imdisplay(imarray, screen=None):
     """Splashes the given image array on the given pygame screen """
     a = pg.surfarray.make_surface(imarray.swapaxes(0, 1))
-    if screen == None:
+    if screen is None:
         screen = pg.display.set_mode(imarray.shape[:2][::-1])
     screen.blit(a, (0, 0))
     pg.display.flip()
@@ -40,7 +40,7 @@ def show(clip, t=0, with_mask=True, interactive=False):
     if isinstance(t, tuple):
         t = cvsecs(*t)
 
-    if with_mask and (clip.mask != None):
+    if with_mask and (clip.mask is not None):
         import moviepy.video.compositing.CompositeVideoClip as cvc
         clip = cvc.CompositeVideoClip([clip.set_pos((0,0))])
     img = clip.get_frame(t)
@@ -93,7 +93,7 @@ def preview(clip, fps=15, audio=True, audio_fps=22050,
     # compute and splash the first image
     screen = pg.display.set_mode(clip.size)
     
-    audio = audio and (clip.audio != None)
+    audio = audio and (clip.audio is not None)
     
     if audio:
         # the sound will be played in parrallel. We are not

--- a/moviepy/video/tools/drawing.py
+++ b/moviepy/video/tools/drawing.py
@@ -34,7 +34,7 @@ def blit(im1, im2, pos=[0, 0], mask=None, ismask=False):
 
     new_im2 = +im2
 
-    if mask != None:
+    if mask is not None:
         mask = mask[y1:y2, x1:x2]
         if len(im1.shape) == 3:
             mask = np.dstack(3 * [mask])
@@ -134,14 +134,14 @@ def color_gradient(size,p1,p2=None,vector=None, r=None, col1=0,col2=1.0,
     p1 = np.array(p1[::-1]).astype(float)
     
     if vector is None:
-        if p2 != None:
+        if p2 is not None:
             p2 = np.array(p2[::-1])
             vector = p2-p1
     else:
         vector = np.array(vector[::-1])
         p2 = p1 + vector
     
-    if vector != None:    
+    if vector is not None:    
         norm = np.linalg.norm(vector)
     
     M = np.dstack(np.meshgrid(range(w),range(h))[::-1]).astype(float)
@@ -221,7 +221,7 @@ def color_split(size,x=None,y=None,p1=None,p2=None,vector=None,
     """
     
     if grad_width or ( (x is None) and (y is None)):
-        if p2 != None:
+        if p2 is not None:
             vector = (np.array(p2) - np.array(p1))
         elif x is not None:
             vector = np.array([0,-1.0])

--- a/moviepy/video/tools/segmenting.py
+++ b/moviepy/video/tools/segmenting.py
@@ -14,7 +14,7 @@ def findObjects(clip,rem_thr=500, preview=False):
     """
     
     image = clip.get_frame(0)
-    if clip.mask == None:
+    if clip.mask is None:
         clip = clip.add_mask()
         
     mask = clip.mask.get_frame(0)


### PR DESCRIPTION
Changed all "== None" and "!= None" occurrences to comply to PEP8 and stop python 2.7 from giving FutureWarning: comparison to `None` will result in an elementwise object comparison in the future.

Hi Zulko, just a small "style" change, if you find it useful...
