### PR TITLE
Fix a typo in a ValueError message

### DIFF
--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -191,7 +191,7 @@ class AudioClip(Clip):
             except KeyError:
                 raise ValueError("MoviePy couldn't find the codec associated "
                        "with the filename. Provide the 'codec' parameter in "
-                       "write_fideofile.")
+                       "write_videofile.")
 
         return ffmpeg_audiowrite(self, filename, fps, nbytes, buffersize,
                       codec=codec, bitrate=bitrate, write_logfile=write_logfile,

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -273,7 +273,7 @@ class VideoClip(Clip):
             except KeyError:
                 raise ValueError("MoviePy couldn't find the codec associated "
                                  "with the filename. Provide the 'codec' parameter in "
-                                 "write_fideofile.")
+                                 "write_videofile.")
 
         if audio_codec is None:
             if (ext in ['ogv', 'webm']):


### PR DESCRIPTION
Hi,
this just fixes two typo's in the message of a `ValueError`.
