### PR TITLE
fixing region parameter on freeze_region

### DIFF
--- a/moviepy/video/fx/freeze_region.py
+++ b/moviepy/video/fx/freeze_region.py
@@ -35,9 +35,9 @@ def freeze_region(clip, t=0, region=None, outside_region=None, mask=None):
 
         x1, y1, x2, y2 = region
         freeze = (clip.fx(crop, *region)
-                      .set_position((x1,y1))
                       .to_ImageClip(t=t)
-                      .set_duration(clip.duration))
+                      .set_duration(clip.duration)
+                      .set_position((x1,y1)))
         return CompositeVideoClip([clip, freeze])
     
     elif outside_region is not None:


### PR DESCRIPTION
I was having trouble with getting good results from the freeze_region function when I specified a region. Specifying an outer_region gave exactly the expected response, but specifying a region positioned the region at 0,0 regardless of the values of x1 and y1. I get the correct results when I rewrote and tested the function by setting the position last instead of first (lines 38 - 40). Issue [here](https://github.com/Zulko/moviepy/issues/146#issuecomment-85999861)