### PR TITLE
poor error message from ffmpeg_reader.py

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -285,7 +285,7 @@ def ffmpeg_parse_infos(filename, print_infos=False, check_duration=True):
             s = list(map(int, line[match.start():match.end()-1].split('x')))
             result['video_size'] = s
         except:
-            raise (("MoviePy error: failed to read video dimensions in file %s.\n"
+            raise IOError(("MoviePy error: failed to read video dimensions in file %s.\n"
                            "Here are the file infos returned by ffmpeg:\n\n%s")%(
                               filename, infos))
 


### PR DESCRIPTION
Per [http://stackoverflow.com/questions/11497234/typeerrorexceptions-must-be-old-style-classes-or-derived-from-baseexception-no](http://stackoverflow.com/questions/11497234/typeerrorexceptions-must-be-old-style-classes-or-derived-from-baseexception-no), as of python 2.6, you can't raise just a string.  If this particular error is triggered, you just get a message

    {TypeError} exceptions must be old-style classes or derived from BaseException, not unicode

The nearby exceptions are IOErrors, so I made this one an IOError as well.  Now it shows the real exception, instead of the cryptic message above.