### PR TITLE
Support for SRT files with any kind of newline

### DIFF
--- a/moviepy/video/tools/subtitles.py
+++ b/moviepy/video/tools/subtitles.py
@@ -158,7 +158,7 @@ def file_to_subtitles(filename):
         times = re.findall("([0-9]*:[0-9]*:[0-9]*,[0-9]*)", line)
         if times != []:
             current_times = map(cvsecs, times)
-        elif line == '\n':
+        elif line.strip() == '':
             times_texts.append((current_times, current_text.strip('\n')))
             current_times, current_text = None, ""
         elif current_times is not None:


### PR DESCRIPTION
Fixes bug where an SRT file with Windows newlines ("\r\n") was not properly parsed on OSes that do not use Windows newlines. After this change, successfully parses my The Big Lebowski SRT on OS X.

