### PR TITLE
Fixes Windows permission error

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -237,7 +237,13 @@ def ffmpeg_parse_infos(filename, print_infos=False, check_duration=True):
     proc = sp.Popen(cmd, **popen_params)
 
     proc.stdout.readline()
-    proc.terminate()
+    # Terminating the process on windows will cause you to 
+    # get a Permission denied error. You can however safely 
+    # ignore that error and continue as normal.
+    try:
+        proc.terminate()
+    except:
+        pass
     infos = proc.stderr.read().decode('utf8')
     del proc
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "test_downloader.py", line 30, in <module>
    main()
  File "test_downloader.py", line 27, in main
    download('_UfYjd50c6I')
  File "test_downloader.py", line 22, in download
    le_file = (VideoFileClip(_file))
  File "C:\Python27\lib\site-packages\moviepy\video\io\VideoFileClip.py", line 5
5, in __init__
    reader = FFMPEG_VideoReader(filename, pix_fmt=pix_fmt)
  File "C:\Python27\lib\site-packages\moviepy\video\io\ffmpeg_reader.py", line 3
2, in __init__
    infos = ffmpeg_parse_infos(filename, print_infos, check_duration)
  File "C:\Python27\lib\site-packages\moviepy\video\io\ffmpeg_reader.py", line 2
40, in ffmpeg_parse_infos
    proc.terminate()
  File "C:\Python27\lib\subprocess.py", line 1002, in terminate
    _subprocess.TerminateProcess(self._handle, 1)
WindowsError: [Error 5] Access is denied
Exception AttributeError: "VideoFileClip instance has no attribute 'reader'" in
<bound method VideoFileClip.__del__ of <moviepy.video.io.VideoFileClip.VideoFile
Clip instance at 0x03E5FBC0>> ignored
```
