### PR TITLE
Use of communicate() and explicit str cast for python 3

### DIFF
--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -136,7 +136,7 @@ class FFMPEG_VideoWriter:
         try:
             self.proc.stdin.write(img_array.tostring())
         except IOError as err:
-            ffmpeg_error = self.proc.stderr.read()
+            ffmpeg_error = str(self.proc.communicate()[1])
             error = (str(err) + ("\n\nMoviePy error: FFMPEG encountered "
                                  "the following error while writing file %s:"
                                  "\n\n %s" % (self.filename, ffmpeg_error)))


### PR DESCRIPTION
Replacing stderr.read() call with safer communicate(). Also in python 3.4.3 I found a byte object is returned and not a string so an explicit cast is also required. I put in the necessary cast before the underlying ffmpeg error can be dealt with in the expected manner so this also fixes an existing defect for moviepy on python 3.
