### PR TITLE
added check for resolution before processing video stream

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -270,7 +270,7 @@ def ffmpeg_parse_infos(filename, print_infos=False, check_duration=True):
                               filename, infos))
 
     # get the output line that speaks about video
-    lines_video = [l for l in lines if ' Video: ' in l]
+    lines_video = [l for l in lines if ' Video: ' in l and re.search('\d+x\d+', l)]
 
     result['video_found'] = ( lines_video != [] )
 


### PR DESCRIPTION
Fixes https://github.com/Zulko/moviepy/issues/158

A simple fix, and not perhaps the most efficient, but prevents errors for me.
I added a check that there is resolution info attached to a video stream before attempting to process it.