### PR TITLE
fixed ffmpeg bug where it would crash if temp_audiofile contains special characters

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -5,7 +5,7 @@ main subclasses:
 - Static image clips: ImageClip, ColorClip, TextClip,
 """
 
-import os
+import os, re
 import subprocess as sp
 import multiprocessing
 import tempfile
@@ -314,7 +314,7 @@ class VideoClip(Clip):
                             "You should report this. In the meantime, you can specify a "
                             "temp_audiofile with the right extension in write_videofile.")
 
-                audiofile = (name + Clip._TEMP_FILES_PREFIX +
+                audiofile = (re.sub('[^a-zA-Z0-9]+', '', name) + Clip._TEMP_FILES_PREFIX +
                              "wvf_snd.%s" % audio_ext)
 
         # enough cpu for multiprocessing ? USELESS RIGHT NOW, WILL COME AGAIN

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -314,7 +314,7 @@ class VideoClip(Clip):
                             "You should report this. In the meantime, you can specify a "
                             "temp_audiofile with the right extension in write_videofile.")
 
-                audiofile = (re.sub('[^a-zA-Z0-9]+', '', name) + Clip._TEMP_FILES_PREFIX +
+                audiofile = (re.sub('[\W_]', '', name) + Clip._TEMP_FILES_PREFIX +
                              "wvf_snd.%s" % audio_ext)
 
         # enough cpu for multiprocessing ? USELESS RIGHT NOW, WILL COME AGAIN


### PR DESCRIPTION
```
[MoviePy] >>>> Building video horses/Horses, Ponies and Fails: Compilation.mp4
[MoviePy] Writing audio in Horses, Ponies and Fails: CompilationTEMP_MPY_wvf_snd.mp3
|----------| 0/684   0% [elapsed: 00:00 left: ?, ? iters/sec]Traceback (most recent call last):
  File "splitter.py", line 67, in <module>
    split_clips()
  File "splitter.py", line 63, in split_clips
    clip.write_videofile(directory+"/"+consume_title()+".mp4", preset='medium', threads=2)
  File "<string>", line 2, in write_videofile
  File "/home/jan/.local/lib/python2.7/site-packages/moviepy/decorators.py", line 54, in requires_duration
    return f(clip, *a, **k)
  File "<string>", line 2, in write_videofile
  File "/home/jan/.local/lib/python2.7/site-packages/moviepy/decorators.py", line 137, in use_clip_fps_by_default
    return f(clip, *new_a, **new_kw)
  File "<string>", line 2, in write_videofile
  File "/home/jan/.local/lib/python2.7/site-packages/moviepy/decorators.py", line 22, in convert_masks_to_RGB
    return f(clip, *a, **k)
  File "/home/jan/.local/lib/python2.7/site-packages/moviepy/video/VideoClip.py", line 331, in write_videofile
    verbose=verbose)
  File "<string>", line 2, in write_audiofile
  File "/home/jan/.local/lib/python2.7/site-packages/moviepy/decorators.py", line 54, in requires_duration
    return f(clip, *a, **k)
  File "/home/jan/.local/lib/python2.7/site-packages/moviepy/audio/AudioClip.py", line 204, in write_audiofile
    verbose=verbose, ffmpeg_params=ffmpeg_params)
  File "<string>", line 2, in ffmpeg_audiowrite
  File "/home/jan/.local/lib/python2.7/site-packages/moviepy/decorators.py", line 54, in requires_duration
    return f(clip, *a, **k)
  File "/home/jan/.local/lib/python2.7/site-packages/moviepy/audio/io/ffmpeg_audiowriter.py", line 162, in ffmpeg_audiowrite
    writer.write_frames(chunk)
  File "/home/jan/.local/lib/python2.7/site-packages/moviepy/audio/io/ffmpeg_audiowriter.py", line 122, in write_frames
    raise IOError(error)
IOError: [Errno 32] Broken pipe

MoviePy error: FFMPEG encountered the following error while writing file Horses, Ponies and Fails: CompilationTEMP_MPY_wvf_snd.mp3:

Horses, Ponies and Fails: CompilationTEMP_MPY_wvf_snd.mp3: Protocol not found
```

Fixes above error.
