### PR TITLE
Fixing parsing error on mp3 with video stream (cover image)

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -297,7 +297,13 @@ def ffmpeg_parse_infos(filename, print_infos=False, check_duration=True):
 
         try:
             match = re.search("( [0-9]*.| )[0-9]* tbr", line)
-            tbr = float(line[match.start():match.end()].split(' ')[1])
+
+            s_tbr = line[match.start():match.end()].split(' ')[1]
+            if "k" in s_tbr:
+                tbr = float(s_tbr.replace("k", "")) * 1000
+            else:
+                tbr = float(s_tbr)
+
             result['video_fps'] = tbr
 
         except:


### PR DESCRIPTION
Should fix #213 and the infos parsing error if I did understand correctly that the 48k was indeed a shorten version of 48000.