### PR TITLE
Document inherited members in reference documentation

### DIFF
--- a/docs/ref/AudioClip.rst
+++ b/docs/ref/AudioClip.rst
@@ -9,6 +9,7 @@ AudioClip
 
 .. autoclass:: moviepy.audio.AudioClip.AudioClip
    :members:
+   :inherited-members:
    :show-inheritance:
 
 :class:`AudioFileClip`
@@ -16,6 +17,7 @@ AudioClip
 
 .. autoclass:: moviepy.audio.io.AudioFileClip.AudioFileClip
    :members:
+   :inherited-members:
    :show-inheritance:
    
 
@@ -24,5 +26,6 @@ AudioClip
 
 .. autoclass:: moviepy.audio.AudioClip.CompositeAudioClip
    :members:
+   :inherited-members:
    :show-inheritance:
 

--- a/docs/ref/Clip.rst
+++ b/docs/ref/Clip.rst
@@ -7,4 +7,5 @@ Clip
 
 .. autoclass:: Clip.Clip
    :members:
+   :inherited-members:
    :show-inheritance:

--- a/docs/ref/VideoClip/VideoClip.rst
+++ b/docs/ref/VideoClip/VideoClip.rst
@@ -11,6 +11,7 @@
 
 .. autoclass:: moviepy.video.VideoClip.VideoClip
    :members:
+   :inherited-members:
    :show-inheritance:
    
 
@@ -20,6 +21,7 @@
 
 .. autoclass:: moviepy.video.io.VideoFileClip.VideoFileClip
    :members:
+   :inherited-members:
    :show-inheritance:
 
 
@@ -29,6 +31,7 @@
 
 .. autoclass:: moviepy.video.VideoClip.ImageClip
    :members:
+   :inherited-members:
    :show-inheritance:
 
 
@@ -38,6 +41,7 @@
 
 .. autoclass::  moviepy.video.VideoClip.ColorClip
    :members:
+   :inherited-members:
    :show-inheritance:
    
    
@@ -46,6 +50,7 @@
 
 .. autoclass::  moviepy.video.VideoClip.TextClip
    :members:
+   :inherited-members:
    :show-inheritance:
 
 
@@ -55,5 +60,6 @@
 
 .. autoclass::  moviepy.video.compositing.CompositeVideoClip.CompositeVideoClip
    :members:
+   :inherited-members:
    :show-inheritance:
 

--- a/docs/ref/decorators.rst
+++ b/docs/ref/decorators.rst
@@ -7,4 +7,5 @@ These decorators are implemented to ease the writing of methods and effects in M
 
 .. automodule:: moviepy.decorators
    :members:
+   :inherited-members:
    :show-inheritance:

--- a/docs/ref/ffmpeg.rst
+++ b/docs/ref/ffmpeg.rst
@@ -5,5 +5,6 @@ FFMPEG tools
 
 .. automodule:: moviepy.video.io.ffmpeg_tools
    :members:
+   :inherited-members:
    :undoc-members:
    :show-inheritance:

--- a/docs/ref/videotools.rst
+++ b/docs/ref/videotools.rst
@@ -11,30 +11,35 @@ Credits
 --------
 .. automodule:: moviepy.video.tools.credits
    :members:
+   :inherited-members:
    :show-inheritance:
 
 Drawing
 --------
 .. automodule:: moviepy.video.tools.drawing
    :members:
+   :inherited-members:
    :show-inheritance:
 
 Segmenting
 ----------
 .. automodule:: moviepy.video.tools.segmenting
    :members:
+   :inherited-members:
    :show-inheritance:
 
 Subtitles
 ----------
 .. automodule:: moviepy.video.tools.subtitles
    :members:
+   :inherited-members:
    :show-inheritance:
 
 Tracking
 --------
 .. automodule:: moviepy.video.tools.tracking
    :members:
+   :inherited-members:
    :show-inheritance:
 
 


### PR DESCRIPTION
This should make it significantly easier to skim the reference for a class and view all its methods and attributes. Other projects, such as [flask](https://raw.githubusercontent.com/mitsuhiko/flask/7f3867491570746a4c14bdaa5bd59ec1b64cbfea/docs/api.rst), also do this.
