### PR TITLE
Read FFMPEG_BINARY and/or IMAGEMAGICK_BINARY environment variables

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -21,7 +21,7 @@ If you have neither ``setuptools`` nor ``ez_setup`` installed the command above 
 
 MoviePy depends on the Python modules Numpy_, imageio_, Decorator_, and tqdm_, which will be automatically installed during MoviePy's installation. It should work  on Windows/Mac/Linux, with Python 2.7+ and 3 ; if you have trouble installing MoviePy or one of its dependencies, please provide feedback !
 
-MoviePy depends on the software FFMPEG for video reading and writing. You don't need to worry about that, as FFMPEG should be automatically downloaded/installed by ImageIO during your first use of MoviePy (it takes a few seconds). If you want to use a specific version of FFMPEG, follow the instructions in file ``config_defaults.py``.
+MoviePy depends on the software FFMPEG for video reading and writing. You don't need to worry about that, as FFMPEG should be automatically downloaded/installed by ImageIO during your first use of MoviePy (it takes a few seconds). If you want to use a specific version of FFMPEG, you can set the FFMPEG_BINARY environment variable See ``moviepy/config_defaults.py`` for details.
 
 
 Other optional but useful dependencies
@@ -32,6 +32,8 @@ ImageMagick_ is not strictly required, only if you want to write texts. It can a
 Once you have installed it, ImageMagick will be automatically detected by MoviePy, **except on Windows !**. Windows user, before installing MoviePy by hand, go into the ``moviepy/config_defaults.py`` file and provide the path to the ImageMagick binary called `convert`. It should look like this ::
     
     IMAGEMAGICK_BINARY = "C:\\Program Files\\ImageMagick_VERSION\\convert.exe"
+
+You can also set the IMAGEMAGICK_BINARY environment variable See ``moviepy/config_defaults.py`` for details.
 
 PyGame_ is needed for video and sound previews (useless if you intend to work with MoviePy on a server but really essential for advanced video editing *by hand*).
 

--- a/moviepy/config_defaults.py
+++ b/moviepy/config_defaults.py
@@ -6,18 +6,19 @@ This file enables you to specify a configuration for MoviePy. In
 particular you can enter the path to the FFMPEG and ImageMagick
 binaries.
 
-These changes must be done BEFORE installing MoviePy: first make the changes,
+Defaults must be done BEFORE installing MoviePy: first make the changes,
 then install MoviePy with
 
     [sudo] python setup.py install
 
-Note that you can also change the path to the binaries AFTER installation, but
-only for one script at a time, as follows:
+Note that you can also change the path by setting environment variables.
+e.g.
 
->>> import moviepy.config as cf
->>> cf.change_settings({"FFMPEG_BINARY": "some/new/path/to/ffmpeg"})
->>> print( cf.get_setting("FFMPEG_BINARY") )  # prints the current setting
+Linux/Mac:
+   export FFMPEG_BINARY=path/to/ffmpeg
 
+Windows:
+   set FFMPEG_BINARY=path\to\ffmpeg
 
 Instructions
 --------------
@@ -47,5 +48,7 @@ IMAGEMAGICK_BINARY
 
 """
 
-FFMPEG_BINARY = 'ffmpeg-imageio'
-IMAGEMAGICK_BINARY = 'auto-detect'
+import os
+
+FFMPEG_BINARY = os.getenv('FFMPEG_BINARY', 'ffmpeg-imageio')
+IMAGEMAGICK_BINARY = os.getenv('FFMPEG_BINARY', 'auto-detect')

--- a/moviepy/config_defaults.py
+++ b/moviepy/config_defaults.py
@@ -51,4 +51,4 @@ IMAGEMAGICK_BINARY
 import os
 
 FFMPEG_BINARY = os.getenv('FFMPEG_BINARY', 'ffmpeg-imageio')
-IMAGEMAGICK_BINARY = os.getenv('FFMPEG_BINARY', 'auto-detect')
+IMAGEMAGICK_BINARY = os.getenv('IMAGEMAGICK_BINARY', 'auto-detect')


### PR DESCRIPTION
With this change, users can overwrite the values set by config_default.py using environment variables: 

FFMPEG_BINARY and/or IMAGEMAGICK_BINARY

This change should be transparent to everybody else.