### PR TITLE
fixed ffmpeg error handling

### DIFF
--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -136,7 +136,7 @@ class FFMPEG_VideoWriter:
         try:
             self.proc.stdin.write(img_array.tostring())
         except IOError as err:
-            ffmpeg_error = self.proc.stderr.read()
+            ffmpeg_error = self.proc.stderr.read().decode('utf-8')
             error = (str(err) + ("\n\nMoviePy error: FFMPEG encountered "
                                  "the following error while writing file %s:"
                                  "\n\n %s" % (self.filename, ffmpeg_error)))


### PR DESCRIPTION
`proc.stderr.read()` needs to be `.decode`d, otherwise the subsequent `in` operator with a string will cause an `AttributeError`

Using Python 3