### PR TITLE
on_color function docstring has wrong parameter

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -604,7 +604,7 @@ class VideoClip(Clip):
           Size (width, height) in pixels of the final clip.
           By default it will be the size of the current clip.
 
-        bg_color
+        color
           Background color of the final clip ([R,G,B]).
 
         pos


### PR DESCRIPTION
The docstring for the on_color method has a parameter of bg_color but
the function uses color as the parameter.
