### PR TITLE
Fix for python 3

### DIFF
--- a/moviepy/audio/io/ffmpeg_audiowriter.py
+++ b/moviepy/audio/io/ffmpeg_audiowriter.py
@@ -84,7 +84,7 @@ class FFMPEG_AudioWriter:
         try:
             self.proc.stdin.write(frames_array.tostring())
         except IOError as err:
-            ffmpeg_error = self.proc.stderr.read()
+            ffmpeg_error = str(self.proc.stderr.read())
             error = (str(err)+ ("\n\nMoviePy error: FFMPEG encountered "
                      "the following error while writing file %s:"%self.filename
                      + "\n\n"+ffmpeg_error))

--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -136,7 +136,7 @@ class FFMPEG_VideoWriter:
         try:
             self.proc.stdin.write(img_array.tostring())
         except IOError as err:
-            ffmpeg_error = self.proc.stderr.read()
+            ffmpeg_error = str(self.proc.stderr.read())
             error = (str(err) + ("\n\nMoviePy error: FFMPEG encountered "
                                  "the following error while writing file %s:"
                                  "\n\n %s" % (self.filename, ffmpeg_error)))


### PR DESCRIPTION
Fix for `TypeError: 'str' does not support the buffer interface` when there's an ffmpeg error 
