### PR TITLE
fix deprecation message

### DIFF
--- a/moviepy/video/compositing/concatenate.py
+++ b/moviepy/video/compositing/concatenate.py
@@ -115,4 +115,4 @@ def concatenate_videoclips(clips, method="chain", transition=None,
     return result
 
 
-concatenate = deprecated_version_of(concatenate_videoclips, "concatenate_videoclips")
+concatenate = deprecated_version_of(concatenate_videoclips, oldname="concatenate")


### PR DESCRIPTION
currently, the docstring is nonsense. 

```
The function ``concatenate_videoclips`` is deprecated and is kept temporarily for backwards compatibility.
Please use the new name, ``concatenate_videoclips``, instead.
```
