### PR TITLE
Changed .tostring() over to .tobyte()

### DIFF
--- a/moviepy/video/fx/resize.py
+++ b/moviepy/video/fx/resize.py
@@ -37,6 +37,8 @@ except ImportError:
             resized_pil = pilim.resize(newsize[::-1], Image.ANTIALIAS)
             #arr = np.fromstring(resized_pil.tostring(), dtype='uint8')
             #arr.reshape(newshape)
+            arr = np.fromstring(resized_pil.tobyte(), dtype='uint8')
+            arr.reshape(newshape)
             return np.array(resized_pil)
             
         resizer.origin = "PIL"


### PR DESCRIPTION
Running moviepy on debian with my own compiled ffmpeg and python 2.7.12

Have tested it and moviepy successfully exported the composite video with the new code.
I was taking a Simpsons clip and simply putting it in a clips_array x3, then resizing the array before writing the file.

`from moviepy.editor import *`
`lennyclip = VideoFileClip("./lenny.mp4").margin(10)`
`memes = clips_array([[lennyclip, lennyclip, lennyclip]])`
`memes.resize(width=480).write_videofile("lennymeme.mp4")`

Can confirm above works with tobytes() at least