### PR TITLE
FIX Ffmpeg writer error display in py3

### DIFF
--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -136,7 +136,7 @@ class FFMPEG_VideoWriter:
         try:
             self.proc.stdin.write(img_array.tostring())
         except IOError as err:
-            ffmpeg_error = self.proc.stderr.read()
+            ffmpeg_error = str(self.proc.stderr.read())
             error = (str(err) + ("\n\nMoviePy error: FFMPEG encountered "
                                  "the following error while writing file %s:"
                                  "\n\n %s" % (self.filename, ffmpeg_error)))


### PR DESCRIPTION
This fixes a `TypeError` due to the bytes <-> unicode transition in Python 3, at the error display of the ffmpeg writer.
