### PR TITLE
Add a test case.

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,12 +1,15 @@
 """
-Tests meant to be run with pytest
+To run the tests:
+    py.test tests.py
 """
-
-import pytest
 
 from moviepy.editor import *
 
-
-@pytest.fixture
-def example_video1():
-	
+#@pytest.fixture
+def test_if_TextClip_crashes():
+    overlay = TextClip(txt='foo',
+                       color='white',
+                       size=(640, 480),
+                       method='caption',
+                       align='center',
+                       fontsize=25)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,10 +6,13 @@ To run the tests:
 from moviepy.editor import *
 
 #@pytest.fixture
-def test_if_TextClip_crashes():
+def test_if_TextClip_crashes_in_caption_mode():
     overlay = TextClip(txt='foo',
                        color='white',
                        size=(640, 480),
                        method='caption',
                        align='center',
                        fontsize=25)
+
+def test_if_TextClip_crashes_in_label_mode():
+    overlay = TextClip(txt='foo', method='label')


### PR DESCRIPTION
On my Ubuntu 14.04 machine, TextClip crashes in ImageMagick's convert. Perhaps this is a permissions issue?

```
E           IOError: MoviePy Error: creation of None failed because of the following error:
E           
E           convert.im6: not authorized `@/tmp/tmpXz0_GE.txt' @ error/property.c/InterpretImageProperties/2959.
E           .
E           
E           .This error can be due to the fact that ImageMagick is not installed on your computer, or (for Windows users) that you didn't specify the path to the ImageMagick binary in file conf.py, or.that the path you specified is incorrect

```
