### PR TITLE
Convert old Youtube embeds to iframes

### DIFF
--- a/_sources/cookbook/blurred_face.txt
+++ b/_sources/cookbook/blurred_face.txt
@@ -6,27 +6,19 @@ Tracking and blurring someone's face
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/FWCKYTRCrBI&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/FWCKYTRCrBI&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/FWCKYTRCrBI&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 First we will need to track the face, i.e. to get two functions ``fx`` and ``fy`` such that ``(fx(t),fy(t))`` gives the position of the center of the head at time ``t``. This will be easily done with
 :ref:`VideoClip.manual_tracking`. Then we will need to blur the area of the video around the center of the head.
 
 To track an object in a video you write: ::
-    
+
     txy = myClip.manual_tracking(0,5,fps=5)
 
 This will display the frames of ``myClip`` between t=0s and t=5s and on each frame it will wait for you to click on the face. It then returns a list ``[(t1,x1,y1),(t2,x2,y2)]`` of the positions that you have clicked.
 
 The next snippet uses these data to make the two functions ``(fx(t),fy(t))`` discussed above: ::
-    
+
     from scipy.interpolate import interp1d
 
     def txy2functions(txyList):
@@ -40,9 +32,9 @@ The next snippet uses these data to make the two functions ``(fx(t),fy(t))`` dis
         return fx,fy
 
 And the coming function makes a filter that blurs the regions around ``(fx(t),fy(t))``: ::
-    
+
     import cv2
-    
+
     def blur_filter(fx,fy,r_zone,r_blur=None):
         """
         Returns a filter that will blurr a moving part of
@@ -50,9 +42,9 @@ And the coming function makes a filter that blurs the regions around ``(fx(t),fy
         defined by (fx(t), fy(t)), the radius of the blurring
         by r_zone and the intensity of the blurring by r_blur.
         """
-        
+
         if r_blur==None: r_blur = 2*r_zone/3
-        
+
         def fl(gf,t):
             im = gf(t)
             h,w,d = im.shape
@@ -60,8 +52,8 @@ And the coming function makes a filter that blurs the regions around ``(fx(t),fy
             x1,x2 = max(0,x-r_zone),min(x+r_zone,w)
             y1,y2 = max(0,y-r_zone),min(y+r_zone,h)
             reg_res = y2-y1,x2-x1
-            
-            # We will now make a circled mask. 
+
+            # We will now make a circled mask.
             # IN older OpenCV, instead of the next two lines, write
             # mask = cv2.circle(np.zeros(reg_res).astype('uint8'),
             #   (r_zone,r_zone),r_zone,255,-1, lineType=cv2.LINE_AA)
@@ -69,24 +61,24 @@ And the coming function makes a filter that blurs the regions around ``(fx(t),fy
             cv2.circle(mask, (r_zone,r_zone),r_zone,255,-1,
                                    lineType=cv2.CV_AA)
             #-----
-            
+
             mask = np.dstack(3*[(1.0/255)*mask])
-            
+
             orig = im[y1:y2,x1:x2]
             blurred = cv2.blur(orig,(r_blur,r_blur))
             im[y1:y2,x1:x2] = mask*blurred + (1-mask)*orig
             return im
-        
+
         return fl
 
 Finally, here is the script: ::
-    
+
     from moviepy import *
     import pickle
-    
+
     # Because we will work with sound and we do not want to carry around
     # the sound of the whole original movie, we first extract the
-    # interesting part of the movie (run this line only once): 
+    # interesting part of the movie (run this line only once):
 
     ffmpeg.extract_subclip("./videos/chaplin.mp4",411.7,421.7+3,
                            "charlotSub.mp4")
@@ -121,14 +113,14 @@ Finally, here is the script: ::
     # Concatenate the clip with the blur and the clip with text
     # Set the audio of concat so that there will also be music
     # when the text is playing.
-    
+
     final = concat([clip_blurred,txt.set_duration(3)])
     final = final.set_audio(chaplin.audio)
 
     # write to a file. Here we use the 'XVID' codec because
     # 'raw' is too heavy and 'DIVX' is too ugly.
-    
+
     final.to_videofile('blurredChaplin.avi',fps=24, codec='XVID')
-    
+
     # This 13s movie with sound and special effects was generated
     # in six seconds.

--- a/_sources/cookbook/compoFromImage.txt
+++ b/_sources/cookbook/compoFromImage.txt
@@ -6,15 +6,7 @@ So how do you do some complex compositing like this ?
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/1hdgNxX-tas&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/1hdgNxX-tas&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/1hdgNxX-tas&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 It takes a lot of bad taste and... the right tools !
 
@@ -23,7 +15,7 @@ So we first make a picture that indicates the regions where the clips will be. T
 .. figure:: motif.jpeg
 
 The next function finds the regions in the picture. For each region found it returns a mask that defines the region, and a tuple ``(x1,y1,x2,y2)`` defining a bounding rectangle giving the position of the region in the picture. ::
-    
+
     import scipy.ndimage as spim
     from pylab import *
 
@@ -35,9 +27,9 @@ The next function finds the regions in the picture. For each region found it ret
         the region. The resolution of maskClip is that of 'pic'
         if crop=True, else, it is the size of the region.
         render=True pops a picture rendering which region has
-        which number    
+        which number
         """
-        
+
         if len(pic.shape)>2:
             pic = pic[:,:,0]
         objects, num = spim.label(pic)
@@ -50,14 +42,14 @@ The next function finds the regions in the picture. For each region found it ret
         YYc = [ YY*c for c in mamasks]
         boxes = [ map(int,(xxc.min(),yyc.min(),xxc.max(),yyc.max()))
                   for xxc, yyc in zip(XXc, YYc)]
-        
+
         if crop:
-            masks = [ m[y1:y2,x1:x2] 
-                      for m,(x1,y1,x2,y2) in zip (masks,boxes)] 
+            masks = [ m[y1:y2,x1:x2]
+                      for m,(x1,y1,x2,y2) in zip (masks,boxes)]
         print [m.shape for m in masks]
-        
+
         maskClips = [ImageClip(m) for m in masks]
-        
+
         if render:
             print "found %d objects"%(num)
             fig,ax = subplots(2)
@@ -65,12 +57,12 @@ The next function finds the regions in the picture. For each region found it ret
             ax[0].imshow(objects)
             ax[1].imshow([range(num)],interpolation='nearest')
             ax[1].set_yticks([])
-            
+
         return zip(maskClips,boxes)
-        
+
 This function returns a list of the regions found. To help visualize which element of the list corresponds to which region in the picture, ``pic2regions`` splashes a Matplotlib figure giving the index of each region. For our picture, it returned this: ::
-    
-    im = imread("./ultracompositing/motif.png")    
+
+    im = imread("./ultracompositing/motif.png")
     regs = pic2regions(im)
 
 .. figure:: matplotlibCompo.jpeg
@@ -82,7 +74,7 @@ Finally, we load 8 different video clips that we assign to the different regions
 - Giving to each clip a mask that will shape it like the region.
 
 So here is the final script: ::
-    
+
     # We load height clips from the US National Parks.
     # These are public domain. :D
     clips = [VideoFileClip(n).subclip(20,25) for n in
@@ -100,7 +92,7 @@ So here is the final script: ::
     regs = pic2regions(im,crop=True)
     # eliminate the first region found (it is the border)
     regs = regs[1:]
-    masks = [r[0] for r in regs] 
+    masks = [r[0] for r in regs]
     poss = [(x1,y1) for m,(x1,y1,x2,y2) in regs]
     comp_clips =  [c.resize(m.size).set_mask(m).set_pos(p)
                    for c,m,p in zip(clips,masks,poss)]

--- a/_sources/examples/compo_from_image.txt
+++ b/_sources/examples/compo_from_image.txt
@@ -7,15 +7,7 @@ So how do you do some complex compositing like this ?
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/1hdgNxX-tas&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/1hdgNxX-tas&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/1hdgNxX-tas&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 It takes a lot of bad taste, and a segmenting tool
 

--- a/_sources/examples/dancing_knights.txt
+++ b/_sources/examples/dancing_knights.txt
@@ -6,9 +6,9 @@ And now for something very silly...
 
 .. raw:: html
 
-        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; 
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden;
          margin-left: 5%;">
-        <iframe src="http://youtube.com/v/Qu7HJrsEYFg?rel=0" frameborder="0" allowfullscreen
+        <iframe src="https://youtube.com/embed/Qu7HJrsEYFg?rel=0" frameborder="0" allowfullscreen
         style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;">
         </iframe>
         </div>

--- a/_sources/examples/example_with_sound.txt
+++ b/_sources/examples/example_with_sound.txt
@@ -7,15 +7,7 @@ An example of using MoviePy to assemble movie clips with sounds. Here are two sc
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/gtyFuIoH7W0&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/gtyFuIoH7W0&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/gtyFuIoH7W0&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 Here is the code:
 

--- a/_sources/examples/freezepainting.txt
+++ b/_sources/examples/freezepainting.txt
@@ -6,15 +6,7 @@ That's an effect that we have seen a lot in westerns and such.
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/aC5CifkacSI&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/aC5CifkacSI&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/aC5CifkacSI&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 Before
 starting let us see how to make a photo look more like a painting. It
@@ -23,10 +15,10 @@ can be done easy as follows:
 - Find the edges of the image with the Sobel algorithm. What you obtain
   is what looks like a hand-drawing of the photo.
 - Multiply the image to make the colors flashier, and add the contours
-  obtained at the previous step. 
+  obtained at the previous step.
 
 Which is implemented in just a few lines of code: ::
-    
+
     from moviepy import *
     from skimage.filter import sobel
 
@@ -36,7 +28,7 @@ Which is implemented in just a few lines of code: ::
         darkening =  black*(255*np.dstack(3*[edges]))
         painting = saturation*image-darkening
         return np.maximum(0,np.minimum(255,painting)).astype('uint8')
-        
+
 Now let us see the actual script. We work on an Audrey Hepburn clip taken
 from *Charade*, a movie which is not copyrighted due to a copyright
 omission (good for us).
@@ -51,18 +43,18 @@ The part with the effect is obtained as follows:
   disappear with a fading effect.
 
 Here you are for the code: ::
-    
+
     charade = VideoFileClip("./videos/charade.mp4", audio=False)
     tf = 19*60+21.0 # Time of the freeze, 19'21
 
     # WE TAKE THE SUBCLIPS WHICH ARE 2 SECONDS BEFORE & AFTER THE FREEZE
-    
+
     clip_before = charade.subclip(tf -2,tf )
     clip_after = charade.subclip(tf ,tf +2)
 
-    
+
     # THE FRAME TO FREEZE
-    
+
     im_freeze = charade.get_frame(tf)
     painting = ImageClip(to_painting(im_freeze))
     txt = TextClip('Audrey',font='Amiri-regular',fontsize=35)
@@ -70,17 +62,17 @@ Here you are for the code: ::
                     [painting,txt.set_pos((10,180))])
 
     # FADEIN/FADEOUT EFFECT ON THE PAINTED IMAGE
-    
+
     painting_fading = CompositeVideoClip(charade.size,
                         [ImageClip(im_freeze),
                          painting_txt.with_mask().fadein(0.3).
                                              set_duration(3).
                                                 fadeout(0.3)])
-    
+
     # FINAL CLIP AND RENDERING
-    
+
     final_clip =  concat([ clip_before,
                            painting_fading.set_duration(3.6),
                            clip_after])
-    
+
     final_clip.to_videofile('audrey.avi',fps=charade.fps)

--- a/_sources/examples/headblur.txt
+++ b/_sources/examples/headblur.txt
@@ -4,15 +4,7 @@ Tracking and blurring someone's face
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/FWCKYTRCrBI&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/FWCKYTRCrBI&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/FWCKYTRCrBI&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 First we will need to track the face, i.e. to get two functions ``fx`` and ``fy`` such that ``(fx(t),fy(t))`` gives the position of the center of the head at time ``t``. This will be easily done with
 `manual_tracking`. Then we will need to blur the area of the video around the center of the head.

--- a/_sources/examples/logo.txt
+++ b/_sources/examples/logo.txt
@@ -3,16 +3,8 @@ MoviePy logo with a moving shadow
 =================================
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/TG86KzL18NA&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/TG86KzL18NA&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/TG86KzL18NA&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 Here the logo is a picture, while the shadow is actually a black rectangle taking the whole screen, overlaid over the logo, but with a moving mask composed of a bi-gradient, such that only one (moving) part of the rectangle is visible. See :ref:`gradients` for the code of the function `biGradient`: ::
-    
+
 

--- a/_sources/examples/masked_credits.txt
+++ b/_sources/examples/masked_credits.txt
@@ -5,29 +5,13 @@ Partially Hidden credits
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/NsTgBah6Ebk&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/NsTgBah6Ebk&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/NsTgBah6Ebk&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 First, see in :ref:`autocredits` how to make credits automatically with MoviePy. Before seeing the code for this video, here is a tutorial video that explains the different steps (also made with MoviePy):
- 
+
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/7tKABfc0Yzw&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/7tKABfc0Yzw&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/7tKABfc0Yzw&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 
 

--- a/_sources/examples/mountainMask.txt
+++ b/_sources/examples/mountainMask.txt
@@ -5,51 +5,35 @@ Partially Hidden credits
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/NsTgBah6Ebk&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/NsTgBah6Ebk&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/NsTgBah6Ebk&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 First, see in :ref:`autocredits` how to make credits automatically with MoviePy. Before seeing the code for this video, here is a tutorial video that explains the different steps (also made with MoviePy):
- 
+
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/7tKABfc0Yzw&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/7tKABfc0Yzw&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/7tKABfc0Yzw&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 
 
 
 
 And here is the code: ::
-    
+
     from moviepy import *
-    
+
     # Load the mountains clip, cut it, slow it down, make it look darker
     clip = VideoFileClip('./mountain.mov',audio=False).subclip(37,46).speedx(0.4)
     clip = clip.fl_image(lambda pic: (0.7*pic).astype('uint8'))
-    
+
     # Save the first frame to later make a mask with GIMP (only once)
     # clip.save_frame('mountain.png')
-    
+
     # Load the mountain mask made with GIMP
     mountainmask = ImageClip('./credits/mountainMask2.png',ismask=True)
-    
+
     # Generate the credits from a text file
     credits = make_credits('./credits/credits.txt',3*clip.w/4)
-    
+
     # Make the credits scroll. Here, 10 pixels per second
     mov_credits= CompositeVideoClip(clip.size,[
                     clip,

--- a/_sources/examples/moving_letters.txt
+++ b/_sources/examples/moving_letters.txt
@@ -6,15 +6,7 @@ I think this example illustrates well the interest of script-based editing (imag
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/jj5qrHl5ZS0&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/jj5qrHl5ZS0&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/jj5qrHl5ZS0&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 
 Here is the code:

--- a/_sources/examples/musicVideo.txt
+++ b/_sources/examples/musicVideo.txt
@@ -4,22 +4,14 @@ A simple music video
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/AqGZ4JFkQTU&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/AqGZ4JFkQTU&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/AqGZ4JFkQTU&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 
 This is an example, with no sound (lame for a music video), soon to be
 replaced with a real music video example (the code will be 99% the same).
 The philosophy of MoviePy is that for each new music video I will make,
 I will just have to copy/paste this code, and modify a few lines. ::
-    
+
     from moviepy import *
 
 

--- a/_sources/examples/painting_effect.txt
+++ b/_sources/examples/painting_effect.txt
@@ -6,15 +6,7 @@ That's an effect that we have seen a lot in westerns and such.
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/aC5CifkacSI&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/aC5CifkacSI&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/aC5CifkacSI&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 The recipe used to make a photo look like a painting:
 

--- a/_sources/examples/severalCharacters.txt
+++ b/_sources/examples/severalCharacters.txt
@@ -6,15 +6,7 @@ Character duplication in a video
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/sZMyzzGlsc0&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/sZMyzzGlsc0&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/sZMyzzGlsc0&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 
 So blabla

--- a/_sources/examples/soundExample.txt
+++ b/_sources/examples/soundExample.txt
@@ -7,21 +7,13 @@ An example of using MoviePy to assemble movie clips with sounds. Here are two sc
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/gtyFuIoH7W0&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/gtyFuIoH7W0&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/gtyFuIoH7W0&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 Here is the code: ::
-    
+
     from moviepy import *
     import numpy as np
-    
+
     # LOAD MOVIE
 
     charade = VideoFileClip("./charadePhone.mp4",audio=True)
@@ -44,7 +36,7 @@ Here is the code: ::
     v1 = 2*v1/np.linalg.norm(v1)
     c1b = c1a- v1
     g1 = gradient(clip_left.size,c1a,c1b,col1=0,col2=1.0)
-    clip_left.mask = ImageClip(g1,ismask=True)             
+    clip_left.mask = ImageClip(g1,ismask=True)
 
 
 
@@ -60,8 +52,8 @@ Here is the code: ::
     c2b = c2a+v1
     g2 = gradient(clip_right.size,c2a,c2b,col1=0,col2=1.0)
     clip_right.mask = ImageClip(g2,ismask=True)
-    
-    
+
+
     # ASSEMBLE AND WRITE THE MOVIE
 
     cc = CompositeVideoClip(charade.size,
@@ -70,17 +62,17 @@ Here is the code: ::
 
     cc.to_videofile("biphone.avi")
 
- 
+
 A few remarks:
 
 - In this script we never explicitly consider the sound. MoviePy does all the cutting and the mixing automatically.
 - We do not load the whole movie but just a part of it (never load a 2h00 movie when you are going to use its sound, see the remark in :ref:`goodPractices`). Rather, we first extract the part of interest with ::
-      
+
       import moviepy.ffmpeg as ff
       t1 = 3050 #seconds
       t2 = 3095
       ff.extract_subclip("charade.mp4",t1,t2,"charadePhone.mp4")
-      
+
 - We use a nerdy and complicated way of cutting the clips with the ``gradient`` function (defined in :ref:`gradients`) but you could have done it with masks from images for instance.
 
 

--- a/_sources/examples/star_worms.txt
+++ b/_sources/examples/star_worms.txt
@@ -5,30 +5,8 @@ This is an approximate effect (the perspective would require some more complex t
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/5euLdo8L0o0&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/5euLdo8L0o0&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/5euLdo8L0o0&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
-Let us also have a look at this tutorial which shows the different steps:
-
-.. raw:: html
-
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/dGrP7GhzWEE&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/dGrP7GhzWEE&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
-        
 And here you are for the code, and for the code of the tutorial.
 
 .. literalinclude:: ../../examples/star_worms.py

--- a/_sources/examples/starwarslike.txt
+++ b/_sources/examples/starwarslike.txt
@@ -5,30 +5,8 @@ This is an approximate effect (the perspective would require some more complex t
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/5euLdo8L0o0&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/5euLdo8L0o0&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/5euLdo8L0o0&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
-Let us also have a look at this tutorial which shows the different steps:
-
-.. raw:: html
-
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/dGrP7GhzWEE&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/dGrP7GhzWEE&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
-        
 And here you are for the code, and for the code of the tutorial.
 
 .. literalinclude:: ../../examples/starWorms.py

--- a/_sources/examples/textmovingletters.txt
+++ b/_sources/examples/textmovingletters.txt
@@ -6,15 +6,7 @@ I think this example illustrates well the interest of script-based editing (imag
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/jj5qrHl5ZS0&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/jj5qrHl5ZS0&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/jj5qrHl5ZS0&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 
 Here is the code:

--- a/_sources/examples/the_end.txt
+++ b/_sources/examples/the_end.txt
@@ -4,21 +4,13 @@
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/sZMyzzGlsc0&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/sZMyzzGlsc0&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
-        
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/sZMyzzGlsc0&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
+
 So let's explain this one: there is a clip with "The End" written in the middle, and *above* this
 clip there is the actual movie. The actual movie has a mask which represents
 a white (=opaque) circle on a black (=transparent) background. At the begining,
 that circle is so large that you see all the actual movie and you don't see
 the "The End" clip. Then the circle becomes progressively smaller and as a
 consequence you see less of the actual movie and more of the "The End" clip.
-    
+
 .. literalinclude:: ../../examples/the_end.py

--- a/_sources/examples/ukulele_concerto.txt
+++ b/_sources/examples/ukulele_concerto.txt
@@ -4,15 +4,7 @@ A simple music video
 
 .. raw:: html
 
-        <center>
-        <object><param name="movie"
-        value="http://www.youtube.com/v/AqGZ4JFkQTU&hl=en_US&fs=1&rel=0">
-        </param><param name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param><embed
-        src="http://www.youtube.com/v/AqGZ4JFkQTU&hl=en_US&fs=1&rel=0"
-        type="application/x-shockwave-flash" allowscriptaccess="always"
-        allowfullscreen="true" width="550" height="450"></embed></object>
-        </center>
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe src="https://youtube.com/embed/AqGZ4JFkQTU&hl=en_US&fs=1&rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;"></iframe></div>
 
 
 This is an example, with no sound (lame for a music video), soon to be

--- a/_sources/gallery.txt
+++ b/_sources/gallery.txt
@@ -17,9 +17,9 @@ This mix of 60 covers of the Cup Song demonstrates the non-linear video editing 
 
 .. raw:: html
 
-        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; 
+        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden;
          margin-left: 5%;">
-        <iframe src="http://youtube.com/v/rIehsqqYFEM&hl?rel=0" frameborder="0" allowfullscreen
+        <iframe src="https://youtube.com/embed/rIehsqqYFEM&hl?rel=0" frameborder="0" allowfullscreen
         style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;">
         </iframe>
         </div>
@@ -33,7 +33,7 @@ in the :ref:`examples`.
 .. raw:: html
 
        <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;">
-       <iframe src="http://youtube.com/v/zGhoZ4UBxEQ&hl?rel=0" frameborder="0" allowfullscreen
+       <iframe src="https://youtube.com/embed/zGhoZ4UBxEQ&hl?rel=0" frameborder="0" allowfullscreen
        style="position: absolute; top: 0; bottom: 10; left: 0; width: 90%; height: 100%;">
        </iframe>
        </div>
@@ -86,7 +86,7 @@ With Vapory and MoviePy you can for instance embed a movie in a 3D scene:
 .. raw:: html
 
         <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; height: 0; margin-bottom:30px; overflow: hidden; margin-left: 5%;">
-        <iframe src="http://youtube.com/v/M9R21SquDSk?rel=0" frameborder="0" allowfullscreen
+        <iframe src="https://youtube.com/embed/M9R21SquDSk?rel=0" frameborder="0" allowfullscreen
         style="position: absolute; top: 0; bottom: 10; left: 0; width: 90%; height: 100%;">
         </iframe>
         </div>
@@ -106,7 +106,7 @@ Or use `this script <https://gist.github.com/Zulko/b910c8b22e8e1c01fae6>`_ to ma
 .. raw:: html
 
         <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; height: 0; margin-bottom:30px; overflow: hidden; margin-left: 5%;">
-        <iframe src="http://youtube.com/v/tCqQhmuwgMg?rel=0" frameborder="0" allowfullscreen
+        <iframe src="https://youtube.com/embed/tCqQhmuwgMg?rel=0" frameborder="0" allowfullscreen
         style="position: absolute; top: 0; bottom: 10; left: 0; width: 90%; height: 100%;">
         </iframe>
         </div>
@@ -124,7 +124,7 @@ This `blog post <http://zulko.github.io/blog/2014/02/12/transcribing-piano-rolls
 .. raw:: html
 
         <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; height: 0; margin-bottom:30px; overflow: hidden; margin-left: 5%;">
-        <iframe src="http://youtube.com/v/V2XCJNZjm4w&hl?rel=0" frameborder="0" allowfullscreen
+        <iframe src="https://youtube.com/embed/V2XCJNZjm4w&hl?rel=0" frameborder="0" allowfullscreen
         style="position: absolute; top: 0; bottom: 10; left: 0; width: 90%; height: 100%;">
         </iframe>
         </div>
@@ -137,7 +137,7 @@ Misc. Programs and Scripts using MoviePy
 Rinconcam
 ----------
 
-`Rincomcam <http://www.rinconcam.com/month/2014-03>`_ is a camera which films surfers on the Californian beach of Point Rincon. At the end of each day it cuts together a video, puts it online, and tweets it. Everything is entirely automatized with Python. 
+`Rincomcam <http://www.rinconcam.com/month/2014-03>`_ is a camera which films surfers on the Californian beach of Point Rincon. At the end of each day it cuts together a video, puts it online, and tweets it. Everything is entirely automatized with Python.
 MoviePy is used to add transitions, titles and music to the videos.
 
 
@@ -155,7 +155,7 @@ Videogrep is a python script written by Sam Lavigne, that goes through the subti
 .. raw:: html
 
         <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;">
-        <iframe src="http://youtube.com/v/D7pymdCU5NQ&hl?rel=0" frameborder="0" allowfullscreen
+        <iframe src="https://youtube.com/embed/D7pymdCU5NQ&hl?rel=0" frameborder="0" allowfullscreen
         style="position: absolute; top: 0; bottom: 10; left: 0; width: 90%; height: 100%;">
         </iframe>
         </div>
@@ -166,7 +166,7 @@ Here are `Videogrep's introductory blog post
 If you liked it, also have a look at these Videogrep-inspired projects:
 
 This `blog post <http://zulko.github.io/blog/2014/06/21/some-more-videogreping-with-python/>`_ attempts to cut a video precisely at the beginning and end of sentences or words: ::
-    
+
     words = ["Americans", "must", "develop", "open ", "source",
               " software", "for the", " rest ", "of the world",
               "instead of", " soldiers"]
@@ -178,7 +178,7 @@ This `blog post <http://zulko.github.io/blog/2014/06/21/some-more-videogreping-w
 .. raw:: html
 
         <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;">
-        <iframe src="http://youtube.com/v/iWRYGULFd_c?rel=0" frameborder="0" allowfullscreen
+        <iframe src="https://youtube.com/embed/iWRYGULFd_c?rel=0" frameborder="0" allowfullscreen
         style="position: absolute; top: 0; bottom: 10; left: 0; width: 90%; height: 100%;">
         </iframe>
         </div>
@@ -189,7 +189,7 @@ This `other post <http://zulko.github.io/blog/2014/07/04/automatic-soccer-highli
 .. raw:: html
 
         <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;">
-        <iframe src="http://youtube.com/v/zJtWPFX2bA0?rel=0" frameborder="0" allowfullscreen
+        <iframe src="https://youtube.com/embed/zJtWPFX2bA0?rel=0" frameborder="0" allowfullscreen
         style="position: absolute; top: 0; bottom: 10; left: 0; width: 90%; height: 100%;">
         </iframe>
         </div>

--- a/_sources/getting_started/compositing.txt
+++ b/_sources/getting_started/compositing.txt
@@ -8,7 +8,7 @@ Video composition, also known as non-linear editing, is the fact of playing seve
 .. raw:: html
 
         <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left:15%;">
-        <iframe src="http://youtube.com/v/rIehsqqYFEM&hl?rel=0" frameborder="0" allowfullscreen
+        <iframe src="https://youtube.com/embed/rIehsqqYFEM&hl?rel=0" frameborder="0" allowfullscreen
         style="position: absolute; top: 0; bottom: 10; width: 70%; height: 100%; ">
         </iframe>
         </div>
@@ -21,7 +21,7 @@ Stacking and concatenating clips
 Two simple ways of putting clips together is to concatenate them (to play them one after the other in a single long clip) or to stack them (to them side by side in a single larger clip).
 
 Concatenation is done with the function ``concatenate_videoclips``: ::
-    
+
     from moviepy.editor import VideoFileClip, concatenate_videoclips
     clip1 = VideoFileClip("myvideo.mp4")
     clip2 = VideoFileClip("myvideo2.mp4").subclip(50,60)
@@ -33,7 +33,7 @@ Concatenation is done with the function ``concatenate_videoclips``: ::
 The ``final_clip`` is a clip that plays the clips 1, 2, and 3 one after the other. Note that the clips do not need to be the same size. If they arent's they will all appear centered in a clip large enough to contain the biggest of them, with optionnally a color of your choosing to fill the borders. You have many other options there (see the doc of the function). You can for instance play a transition clip between the clips with the option ``transition=my_clip``.
 
 Stacking is done with ``clip_array``: ::
-    
+
     from moviepy.editor import VideoFileClip, clips_array, vfx
     clip1 = VideoFileClip("myvideo.mp4").margin(10) # add 10px contour
     clip2 = clip1.fx( vfx.mirror_x)
@@ -53,9 +53,9 @@ CompositeVideoClips
 ~~~~~~~~~~~~~~~~~~~~~
 
 The `CompositeVideoClip` class provides a very flexible way to compose clips, but is more complex than ``concatenate_videoclips`` and ``clips_array`` ::
-    
+
     video = CompositeVideoClip([clip1,clip2,clip3])
- 
+
 Now ``video`` plays ``clip1``, and ``clip2`` *on top of* ``clip1``, and ``clip3`` on top of ``clip1``, and ``clip2``. For instance, if ``clip2`` and ``clip3`` have the same size as ``clip1``, then only ``clip3``, which is on top, will be visible in the video... unless  ``clip3`` and ``clip2`` have masks which hide parts of them. Note that by default the composition has the size of its first clip (as it is generally a *background*). But sometimes you will want to make your clips *float* in a bigger composition, so you will specify the size of the final composition as follows ::
 
     video = CompositeVideoClip([clip1,clip2,clip3], size=(720,460))
@@ -64,8 +64,8 @@ Starting and stopping times
 """"""""""""""""""""""""""""
 
 In a CompositionClip, all the clips start to play at a time that is specified by the ``clip.start`` attribute. You can set this starting time as follows: ::
-    
-    clip1 = clip1.set_start(5) # start after 5 seconds 
+
+    clip1 = clip1.set_start(5) # start after 5 seconds
 
 So for instance your composition will look like ::
 
@@ -74,7 +74,7 @@ So for instance your composition will look like ::
                                 clip3.set_start(9)]) # start at t=9s
 
 In the example above, maybe ``clip2`` will start before ``clip1`` is over. In this case you can make ``clip2`` appear with a *fade-in* effect of one second: ::
-    
+
     video = CompositeVideoClip([clip1, # starts at t=0
                                 clip2.set_start(5).crossfadein(1),
                                 clip3.set_start(9).crossfadein(1.5)])
@@ -83,15 +83,15 @@ Positioning clips
 """"""""""""""""""
 
 If ``clip2`` and ``clip3`` are smaller than ``clip1``, you can decide where they will appear in the composition by setting their position. Here we indicate the coordinates of the top-left pixel of the clips: ::
-    
+
     video = CompositeVideoClip([clip1,
                                clip2.set_pos((45,150)),
                                clip3.set_pos((90,100))])
 
 There are many ways to specify the position: ::
-    
+
     clip2.set_pos((45,150)) # x=45, y=150 , in pixels
-    
+
     clip2.set_pos("center") # automatically centered
 
     # clip2 is horizontally centered, and at the top of the picture
@@ -99,10 +99,10 @@ There are many ways to specify the position: ::
 
     # clip2 is vertically centered, at the left of the picture
     clip2.set_pos(("left","center"))
-    
+
     # clip2 is at 40% of the width, 70% of the height of the screen:
     clip2.set_pos((0.4,0.7), relative=True)
-    
+
     # clip2's position is horizontally centered, and moving down !
     clip2.set_pos(lambda t: ('center', 50+t) )
 
@@ -113,7 +113,7 @@ When indicating the position keep in mind that the ``y`` coordinate has its zero
 .. Transitions
 .. ------------
 
-.. Everyone loves transitions between clips: fade-ins, fade-out, clips that slide in front of the previous one... everything is good to impress your grandparents. 
+.. Everyone loves transitions between clips: fade-ins, fade-out, clips that slide in front of the previous one... everything is good to impress your grandparents.
 
 .. In MoviePy, transitions are effects (see :ref:`effects`_) from the module moviepy.video.compositing.
 


### PR DESCRIPTION
Follow-up to #342.

Replaces all remaining deprecated Youtube "AS3 object embeds" (see [documentation](https://developers.google.com/youtube/player_parameters#Manual_IFrame_Embeds)) in the `.txt` files of moviepy's documentation with new `<iframe>` embeds.

I copied the formatting of the `iframe` and surrounding `div` from the already existing Youtube iframes in the documentation.
