### PR TITLE
Fix #164 - Resolve ffmpeg zombie processes

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -169,6 +169,7 @@ class FFMPEG_VideoReader:
             self.proc.terminate()
             self.proc.stdout.close()
             self.proc.stderr.close()
+            self.proc.wait()
             del self.proc
 
     def __del__(self):


### PR DESCRIPTION
Resolves the ffmpeg `defunct` processes resulting from clip reading mentioned in #164.