### PR TITLE
ensures int arguments to np.reshape; closes #383

### DIFF
--- a/moviepy/audio/io/readers.py
+++ b/moviepy/audio/io/readers.py
@@ -119,7 +119,7 @@ class FFMPEG_AudioReader:
         dt = {1: 'int8',2:'int16',4:'int32'}[self.nbytes]
         result = np.fromstring(s, dtype=dt)
         result = (1.0*result / 2**(8*self.nbytes-1)).\
-                                 reshape((len(result)/self.nchannels,
+                                 reshape((int(len(result)/self.nchannels),
                                           self.nchannels))
         #self.proc.stdout.flush()
         self.pos = self.pos+chunksize


### PR DESCRIPTION
See #383 for discussion. This just patches `readers.py` to ensure compatibility with numpy 1.12.0.