### PR TITLE
Add `self.filename` as a `VideoFileClip` attribute

### DIFF
--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -40,7 +40,9 @@ class VideoFileClip(VideoClip):
       Name of the original video file.
     
     fps:
-      Frames per second in the original file. 
+      Frames per second in the original file.
+      
+    Read docstrings for Clip() and VideoClip() for other, more generic, attributes.
         
     """
 
@@ -60,6 +62,8 @@ class VideoFileClip(VideoClip):
         
         self.fps = self.reader.fps
         self.size = self.reader.size
+        
+        self.filename = self.reader.filename
 
         if has_mask:
 


### PR DESCRIPTION
Docstring on lines 39-40 state that `VideoFileClip` has an object `self.filename`. This is not currently correct, as only its `reader` has that attribute. This PR adds `filename` as an attribute of the actual clip as well.
Current usage:
`my_clip.reader.filename``
Proposed usage:
`my_clip.filename

Also added line 45 to explain that a `VideoFileClip` does actually have more than 2 useful attributes.