### PR TITLE
fixes #357.  confusing error about coreader, when media file does not exist

### DIFF
--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -54,8 +54,8 @@ class VideoFileClip(VideoClip):
         
         # Make a reader
         pix_fmt= "rgba" if has_mask else "rgb24"
-        reader = FFMPEG_VideoReader(filename, pix_fmt=pix_fmt)
-        self.reader = reader
+        self.reader = None #need this just in case FFMPEG has issues (__del__ complains)
+        self.reader = FFMPEG_VideoReader(filename, pix_fmt=pix_fmt)
         # Make some of the reader's attributes accessible from the clip
         self.duration = self.reader.duration
         self.end = self.reader.duration


### PR DESCRIPTION
del function creates a messy error that hides the real issue.  The media file does not exist.   I set self.reader = None so that if ffmpeg has issues,  del function will execute without complaining.  Then real error message is easier to read.