### PR TITLE
Fix `AttributeError: reader`

### DIFF
--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -40,7 +40,9 @@ class VideoFileClip(VideoClip):
       Name of the original video file.
     
     fps:
-      Frames per second in the original file. 
+      Frames per second in the original file.
+      
+    Read docstrings for Clip() and VideoClip() for other, more generic, attributes.
         
     """
 
@@ -60,6 +62,8 @@ class VideoFileClip(VideoClip):
         
         self.fps = self.reader.fps
         self.size = self.reader.size
+        
+        self.filename = self.reader.filename
 
         if has_mask:
 


### PR DESCRIPTION
I get the error

```
Exception ignored in: <bound method VideoFileClip.del of <moviepy.video.io.VideoFileClip.VideoFileClip object at 0x10d347d30>>
  Traceback (most recent call last):
    File "/anaconda/lib/python3.5/site-packages/moviepy/video/io/VideoFileClip.py", line 89, in del
      del self.reader
AttributeError: reader
```

When I run:

```
try:
    clip = VideoFileClip("/Users/path/to/movie.mp4")  # When this movie can't be found, it outputs the error above
except OSError:
    print("Video not found")
```

The error doesn't actually stop the program, but it is an annoying output.