### PR TITLE
Fixes `AttributeError: reader`

### DIFF
--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -87,4 +87,7 @@ class VideoFileClip(VideoClip):
 
     def __del__(self):
       """ Close/delete the internal reader. """
-      del self.reader
+        try:
+            del self.reader
+        except AttributeError:
+            pass

--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -86,7 +86,7 @@ class VideoFileClip(VideoClip):
                                        nbytes = audio_nbytes)
 
     def __del__(self):
-      """ Close/delete the internal reader. """
+        """ Close/delete the internal reader. """
         try:
             del self.reader
         except AttributeError:


### PR DESCRIPTION
I get the error

```
Exception ignored in: <bound method VideoFileClip.del of <moviepy.video.io.VideoFileClip.VideoFileClip object at 0x10d347d30>>
  Traceback (most recent call last):
    File "/anaconda/lib/python3.5/site-packages/moviepy/video/io/VideoFileClip.py", line 89, in del
      del self.reader
AttributeError: reader
```

When I run:

```
try:
    clip = VideoFileClip("/Users/path/to/movie.mp4")  # When this movie can't be found, it outputs the error above
except OSError:
    print("Video not found")
```

The error doesn't actually stop the program, but it is an annoying output.

See #419 for discussion. I messed up which branch to pull from.