### PR TITLE
Test for issue 145

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -9,4 +9,11 @@ from moviepy.editor import *
 
 @pytest.fixture
 def example_video1():
-	
+    pass
+
+_knights=VideoFileClip("media/knights.mp4")
+_knights10 = _knights.subclip(60,70)
+
+# issue 145
+with pytest.raises(Exception, message="Expecting Exception"):
+     _final = concatenation([_knights10], method = 'composite')


### PR DESCRIPTION
This branch does contain the knights.mp4 file, which is about 50 mb in size.  We could get having this in the repo by placing a few media files at zulko.github.io, and then use the download_file function to download these if they are missing..   For simpility sake, I just added the media file here.

Issue 145 is a request to make sure that the method argument of concatenation_videoclips gives an error if method != chain or compose.   This seemed like an easy test to get the test suite started.