### PR TITLE
fix issue 448; AudioFileClip 90k tbr error

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -273,8 +273,6 @@ def ffmpeg_parse_infos(filename, print_infos=False, check_duration=True):
     result['video_found'] = ( lines_video != [] )
 
     if result['video_found']:
-
-
         try:
             line = lines_video[0]
 
@@ -295,9 +293,14 @@ def ffmpeg_parse_infos(filename, print_infos=False, check_duration=True):
 
         try:
             match = re.search("( [0-9]*.| )[0-9]* tbr", line)
-            tbr = float(line[match.start():match.end()].split(' ')[1])
-            result['video_fps'] = tbr
 
+            s_tbr = line[match.start():match.end()].split(' ')[1]
+            if "k" in s_tbr:
+                tbr = float(s_tbr.replace("k", "")) * 1000
+            else:
+                tbr = float(s_tbr)
+
+            result['video_fps'] = tbr
         except:
             match = re.search("( [0-9]*.| )[0-9]* fps", line)
             result['video_fps'] = float(line[match.start():match.end()].split(' ')[1])


### PR DESCRIPTION
some audio files (such as mp3) have a tbr represented as something like 90k instead of 90000.  so this fix looks for values containing a k and substituting 000.