### PR TITLE
Fix mixed content

### DIFF
--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -1,30 +1,30 @@
 FAQ and troubleshooting
 =========================
 
-This section will fill up as MoviePy advances through the next steps of 
-development (currently on the roadmap: MoviePy Studio, MoviePy WebApp, MoviePy OS, MoviePy 
+This section will fill up as MoviePy advances through the next steps of
+development (currently on the roadmap: MoviePy Studio, MoviePy WebApp, MoviePy OS, MoviePy
 Trust Inc., and the MoviePy Charity Fundation).
 
 Common errors that are not bugs
 --------------------------------
 
-These are very common errors which are not considered as bugs to be 
-solved (but you can still ask for this to change). If these answers 
+These are very common errors which are not considered as bugs to be
+solved (but you can still ask for this to change). If these answers
 don't work for you, please open a bug report on Github_, or on the dedicated forum on Reddit_, or on the librelist_.
 
 MoviePy generated a video that cannot be read by my favorite player.
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 
-Known reason : one of the video's dimensions were not even, 
-for instance 720x405, and you used a MPEG4 codec like libx264 (default 
-in MoviePy). In this case the video generated uses a format that is 
+Known reason: one of the video's dimensions were not even,
+for instance 720x405, and you used a MPEG4 codec like libx264 (default
+in MoviePy). In this case the video generated uses a format that is
 readable only on some readers like VLC.
 
 I can't seem to read any video with MoviePy
 """"""""""""""""""""""""""""""""""""""""""""""
 
-Known reason: you have a deprecated version of FFMPEG, install a recent version from the 
+Known reason: you have a deprecated version of FFMPEG, install a recent version from the
 website, not from your OS's repositories ! (see :ref:`installation`).
 
 Previewing videos make them slower than they are
@@ -33,6 +33,6 @@ Previewing videos make them slower than they are
 It means that your computer is not good enough to render the clip in real time. Don't hesitate to play with the options of ``preview``: for instance, lower the fps of the sound (11000 Hz is still fine) and the video. Also, downsizing your video with ``resize`` can help.
 
 .. _Github: https://github.com/Zulko/moviepy
-.. _Reddit: http://www.reddit.com/r/moviepy/
+.. _Reddit: https://www.reddit.com/r/moviepy/
 .. _librelist: mailto:moviepy@librelist.com
 

--- a/docs/gallery.rst
+++ b/docs/gallery.rst
@@ -13,7 +13,7 @@ Videos edited with Moviepy
 The Cup Song Covers Mix
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-This mix of 60 covers of the Cup Song demonstrates the non-linear video editing capabilities of MoviePy. Here is `the (undocumented) MoviePy code <http://nbviewer.ipython.org/github/Zulko/--video-editing---Cup-Song-Covers-Mix/blob/master/CupSongsCovers.ipynb>`_ that generated the video.
+This mix of 60 covers of the Cup Song demonstrates the non-linear video editing capabilities of MoviePy. Here is `the (undocumented) MoviePy code <https://nbviewer.ipython.org/github/Zulko/--video-editing---Cup-Song-Covers-Mix/blob/master/CupSongsCovers.ipynb>`_ that generated the video.
 
 .. raw:: html
 
@@ -47,22 +47,22 @@ GIFs made from videos
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This  `tutorial
-<http://zulko.github.io/blog/2014/01/23/making-animated-gifs-from-video-files-with-python/>`_ gives you the basics to make gifs from video files (cutting, croping, adding text...). The last example shows how to remove a (still) background to keep only the animated part of a video.
+<https://zulko.github.io/blog/2014/01/23/making-animated-gifs-from-video-files-with-python/>`_ gives you the basics to make gifs from video files (cutting, croping, adding text...). The last example shows how to remove a (still) background to keep only the animated part of a video.
 
 
 .. raw:: html
 
-         <a href="http://imgur.com/Fo2BxBK"><img src="http://i.imgur.com/Fo2BxBK.gif" title="Hosted by imgur.com"
+         <a href="https://imgur.com/Fo2BxBK"><img src="https://i.imgur.com/Fo2BxBK.gif" title="Hosted by imgur.com"
             style="max-width:50%; height:'auto'; display:block; margin-left: auto;margin-right: auto; margin-bottom:30px;" /></a>
 
 Vector Animations
 ~~~~~~~~~~~~~~~~~~~
 
-This `tutorial <http://zulko.github.io/blog/2014/09/20/vector-animations-with-python/>`_ shows how to combine MoviePy with Gizeh to create animations:
+This `tutorial <https://zulko.github.io/blog/2014/09/20/vector-animations-with-python/>`_ shows how to combine MoviePy with Gizeh to create animations:
 
 .. raw:: html
 
-         <a href="http://imgur.com/2YdW9yf"><img src="http://i.imgur.com/2YdW9yf.gif"
+         <a href="https://imgur.com/2YdW9yf"><img src="https://i.imgur.com/2YdW9yf.gif"
          style="max-width:50%; height:'auto'; display:block; margin-left: auto;margin-right: auto; margin-bottom:30px;" /></a>
 
 
@@ -72,11 +72,11 @@ It is also possible to combine MoviePy with other graphic librairies like matplo
 3D animations
 ~~~~~~~~~~~~~~~~~~~
 
-This `tutorial <http://zulko.github.io/blog/2014/11/13/things-you-can-do-with-python-and-pov-ray/>`_ shows how to combine MoviePy with Vapory, a library to render 3D scenes using the free ray-tracer POV-Ray
+This `tutorial <https://zulko.github.io/blog/2014/11/13/things-you-can-do-with-python-and-pov-ray/>`_ shows how to combine MoviePy with Vapory, a library to render 3D scenes using the free ray-tracer POV-Ray
 
 .. raw:: html
 
-         <a href="http://imgur.com/2YdW9yf"><img src="http://i.imgur.com/XN7e2IP.gif"
+         <a href="https://imgur.com/2YdW9yf"><img src="https://i.imgur.com/XN7e2IP.gif"
          style="max-width:70%; height:'auto'; display:block; margin-left: auto;margin-right: auto; margin-bottom:30px;" /></a>
 
 
@@ -96,7 +96,7 @@ Or render the result of this physics simulation made with PyODE (`script <https:
 
 .. raw:: html
 
-         <a href="http://imgur.com/2YdW9yf"><img src="http://i.imgur.com/TdhxwGz.gif"
+         <a href="https://imgur.com/2YdW9yf"><img src="https://i.imgur.com/TdhxwGz.gif"
          style="max-width:70%; height:'auto'; display:block; margin-left: auto;margin-right: auto; margin-bottom:30px;" /></a>
 
 
@@ -114,7 +114,7 @@ Or use `this script <https://gist.github.com/Zulko/b910c8b22e8e1c01fae6>`_ to ma
 Data animations
 ----------------
 
-This `tutorial <http://zulko.github.io/blog/2014/11/13/things-you-can-do-with-python-and-pov-ray/>`_ shows how to use MoviePy to animate the different Python vizualization libraries: Mayavi, Vispy, Scikit-image, Matplotlib, etc.
+This `tutorial <https://zulko.github.io/blog/2014/11/13/things-you-can-do-with-python-and-pov-ray/>`_ shows how to use MoviePy to animate the different Python vizualization libraries: Mayavi, Vispy, Scikit-image, Matplotlib, etc.
 
 
 Scientific or technological projects
@@ -124,7 +124,7 @@ Scientific or technological projects
 Piano rolls transcription to sheet music
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This `blog post <http://zulko.github.io/blog/2014/02/12/transcribing-piano-rolls/>`_ explains how to transform a video of a piano roll performance into playable sheet music. MoviePy is used for the frame-by-frame analysis of the piano roll video. The last video is also edited with MoviePy:
+This `blog post <https://zulko.github.io/blog/2014/02/12/transcribing-piano-rolls/>`_ explains how to transform a video of a piano roll performance into playable sheet music. MoviePy is used for the frame-by-frame analysis of the piano roll video. The last video is also edited with MoviePy:
 
 .. raw:: html
 
@@ -148,7 +148,7 @@ MoviePy is used to add transitions, titles and music to the videos.
 
 .. raw:: html
 
-         <a href="http://imgur.com/2YdW9yf"><img src="https://pbs.twimg.com/media/B2_NlnwCMAAingW.jpg"
+         <a href="https://imgur.com/2YdW9yf"><img src="https://pbs.twimg.com/media/B2_NlnwCMAAingW.jpg"
          style="max-width:70%; height:'auto'; display:block; margin-left: auto;margin-right: auto; margin-bottom:30px;" /></a>
 
 
@@ -170,7 +170,7 @@ Here are `Videogrep's introductory blog post
 
 If you liked it, also have a look at these Videogrep-inspired projects:
 
-This `blog post <http://zulko.github.io/blog/2014/06/21/some-more-videogreping-with-python/>`_ attempts to cut a video precisely at the beginning and end of sentences or words: ::
+This `blog post <https://zulko.github.io/blog/2014/06/21/some-more-videogreping-with-python/>`_ attempts to cut a video precisely at the beginning and end of sentences or words: ::
 
     words = ["Americans", "must", "develop", "open ", "source",
               " software", "for the", " rest ", "of the world",
@@ -189,7 +189,7 @@ This `blog post <http://zulko.github.io/blog/2014/06/21/some-more-videogreping-w
         </div>
 
 
-This `other post <http://zulko.github.io/blog/2014/07/04/automatic-soccer-highlights-compilations-with-python/>`_ uses MoviePy to automatically cut together all the highlights of a soccer game, based on the fact that the crowd cheers louder when something interesting happens. All in under 30 lines of Python:
+This `other post <https://zulko.github.io/blog/2014/07/04/automatic-soccer-highlights-compilations-with-python/>`_ uses MoviePy to automatically cut together all the highlights of a soccer game, based on the fact that the crowd cheers louder when something interesting happens. All in under 30 lines of Python:
 
 .. raw:: html
 

--- a/docs/getting_started/clips.rst
+++ b/docs/getting_started/clips.rst
@@ -6,7 +6,7 @@ Creating and exporting video clips
 Video and audio clips are the central objects of MoviePy. In this section we present the different sorts of clips, how to create them, and how to write them to a file. For informations on modifying a clip (cuts, effects, etc.), see :ref:`effects`. For how to put clips together see :ref:`CompositeVideoClips` and to see how to preview clips before writing a file, refer to :ref:`efficient`.
 
 The following code summarizes the base clips that you can create with moviepy: ::
-    
+
     # VIDEO CLIPS
     clip = VideoClip(make_frame, duration=4) # for custom animations (see below)
     clip = VideoFileClip("my_video_file.mp4") # or .avi, .webm, .gif ...
@@ -14,23 +14,23 @@ The following code summarizes the base clips that you can create with moviepy: :
     clip = ImageClip("my_picture.png") # or .jpeg, .tiff, ...
     clip = TextClip("Hello !", font="Amiri-Bold", fontsize=70, color="black")
     clip = ColorClip(size=(460,380), color=[R,G,B])
-    
+
     # AUDIO CLIPS
     clip = AudioFileClip("my_audiofile.mp3") # or .ogg, .wav... or a video !
     clip = AudioArrayClip(numpy_array, fps=44100) # from a numerical array
-    clip = AudioClip(make_frame, duration=3) # uses a function make_frame(t) 
+    clip = AudioClip(make_frame, duration=3) # uses a function make_frame(t)
 
 
 
 The best to understand these clips is to read the full documentation for each in the :ref:`reference_manual`. The next sections
-In this section we see how to create clips, (for instance from video or audio files), how to mix them together, and how to write them to a file. 
+In this section we see how to create clips, (for instance from video or audio files), how to mix them together, and how to write them to a file.
 
 
 
 Categories of video clips
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Video clips are the building blocks of longer videos. Technically, they are clips with a ``clip.get_frame(t)`` method which outputs a HxWx3 numpy array representing the frame of the clip at time *t*. There are two main categories: animated clips (made with ``VideoFileClip`` and ``VideoClip``) and unanimated clips which show the same picture for an a-priori infinite duration (``ImageClip``, ``TextClip``,``ColorClip``). There are also special video clips call masks, which belong to the categories above but output greyscale frames indicating which parts of another clip are visible or not. A video clip can carry around an audio clip (``clip.audio``) which is its *soundtrack*, and a mask clip. 
+Video clips are the building blocks of longer videos. Technically, they are clips with a ``clip.get_frame(t)`` method which outputs a HxWx3 numpy array representing the frame of the clip at time *t*. There are two main categories: animated clips (made with ``VideoFileClip`` and ``VideoClip``) and unanimated clips which show the same picture for an a-priori infinite duration (``ImageClip``, ``TextClip``,``ColorClip``). There are also special video clips call masks, which belong to the categories above but output greyscale frames indicating which parts of another clip are visible or not. A video clip can carry around an audio clip (``clip.audio``) which is its *soundtrack*, and a mask clip.
 
 VideoClip
 """"""""""
@@ -61,12 +61,12 @@ VideoFileClip
 """""""""""""""
 
 A VideoFileClip is a clip read from a video file (most formats are supported) or a GIF file. You load the video as follows: ::
-    
+
     myclip = VideoFileClip("some_video.avi")
     myclip = VideoFileClip("some_animation.gif")
 
 Note that these clips will have an ``fps`` (frame per second) attribute, which will be transmitted if you do small modifications of the clip, and will be used by default in ``write_videofile``, ``write_gif``, etc. For instance: ::
-    
+
     myclip = VideoFileClip("some_video.avi")
     print (myclip.fps) # prints for instance '30'
     # Now cut the clip between t=10 and 25 secs. This conserves the fps.
@@ -92,7 +92,7 @@ ImageClip
 """"""""""
 
 An ImageClip is a video clip that always displays the same image. You can create one as follows: ::
-    
+
     myclip = ImageClip("some_picture.jpeg")
     myclip = ImageClip(somme_array) # a (height x width x 3) RGB numpy array
     myclip = some_video_clip.to_ImageClip(t='01:00:00') # frame at t=1 hour.
@@ -109,16 +109,16 @@ TextClip
 Generating a TextClip requires to have ImageMagick installed and (for windows users) linked to MoviePy, see the installation instructions.
 
 Here is how you make a textclip (you won't need all these options all the time): ::
-    
+
     myclip = TextClip("Hello", font='Amiri-Bold')
 
 
 The font can be any font installed on your computer, but ImageMagick will have specific names for it. For instance the *normal* Amiri font will be called ``Amiri-Regular`` while the Impact font will be called ``Impact-Normal``. To get a list of the possible fonts, type ``TextClip.list('fonts')``. To find all the font names related to a given font, use for instance ::
-    
+
     TextClip.search('Amiri', 'fonts') # Returns all font names containing Amiri
 
 Note also that the use of a stroke (or contour) will not work well on small letters, so if you need a small text with a contour, it is better to generate a big text, then downsize it: ::
-    
+
     myclip = TextClip("Hello", fontsize=70, stroke_width=5).resize(height=15)
 
 
@@ -161,12 +161,12 @@ Video files (.mp4, .webm, .ogv...)
 """"""""""""""""""""""""""""""""""""
 
 To write a clip as a video file, use ::
-    
+
     my_clip.write_videofile("movie.mp4") # default codec: 'libx264', 24 fps
     my_clip.write_videofile("movie.mp4",fps=15)
     my_clip.write_videofile("movie.webm") # webm format
     my_clip.write_videofile("movie.webm",audio=False) # don't render audio.
-    
+
 MoviePy has default codec names for the most common file extensions. If you want to use exotic formats or if you are not happy with the defaults you can provide the codec with ``codec='mpeg4'`` for instance. There are many many options when you are writing a video (bitrate, parameters of the audio writing, file size optimization, number of processors to use, etc.). Please refer to :py:meth:`~moviepy.video.VideoClip.VideoClip.write_videofile` for more.
 
 
@@ -187,19 +187,19 @@ To write your video as an animated GIF, use ::
 
 Note that this requires ImageMagick installed. Otherwise you can also create the GIF with ffmpeg by adding the option ``program='ffmpeg'``, it will be much faster but won't look as nice and won't be optimized.
 
-If the clip has a mask it will be used for transparency. 
+If the clip has a mask it will be used for transparency.
 
 There are many options to optimize the quality and size of a gif (see :py:meth:`~moviepy.video.VideoClip.VideoClip.write_gif`)
 
 Note that when editing gifs the best way to preview them is in the notebook as explained here: :ref:`ipython_display`
 
-For examples of use, see `this blog post <http://zulko.github.io/blog/2014/01/23/making-animated-gifs-from-video-files-with-python>`_ for informations on making GIFs from video files, and `this other post <http://zulko.github.io/blog/2014/09/20/vector-animations-with-python/>`_ for GIF animations with vector graphics.
+For examples of use, see `this blog post <https://zulko.github.io/blog/2014/01/23/making-animated-gifs-from-video-files-with-python>`_ for informations on making GIFs from video files, and `this other post <https://zulko.github.io/blog/2014/09/20/vector-animations-with-python/>`_ for GIF animations with vector graphics.
 
 Export images
 """""""""""""""
 
 You can write a frame to an image file with ::
-    
+
     myclip.save_frame("frame.png") # by default the first frame is extracted
     myclip.save_frame("frame.jpeg", t='01:00:00') # frame at time t=1h
 

--- a/docs/getting_started/quick_presentation.rst
+++ b/docs/getting_started/quick_presentation.rst
@@ -37,25 +37,25 @@ Example code
 ~~~~~~~~~~~~~~
 
 In a typical MoviePy script, you load video or audio files, modify them, put them together, and write the final result to a new video file. As an example, let us load a video of my last holidays, lower the volume, add a title in the center of the video for the first ten seconds, and write the result in a file: ::
-    
+
     # Import everything needed to edit video clips
     from moviepy.editor import *
-    
+
     # Load myHolidays.mp4 and select the subclip 00:00:50 - 00:00:60
     clip = VideoFileClip("myHolidays.mp4").subclip(50,60)
 
     # Reduce the audio volume (volume x 0.8)
-    clip = clip.volumex(0.8) 
-    
+    clip = clip.volumex(0.8)
+
     # Generate a text clip. You can customize the font, color, etc.
     txt_clip = TextClip("My Holidays 2013",fontsize=70,color='white')
-    
+
     # Say that you want it to appear 10s at the center of the screen
     txt_clip = txt_clip.set_pos('center').set_duration(10)
-    
+
     # Overlay the text clip on the first video clip
     video = CompositeVideoClip([clip, txt_clip])
-    
+
     # Write the result to a file (many options available !)
     video.write_videofile("myHolidays_edited.webm")
 
@@ -72,7 +72,7 @@ MoviePy uses the software ``ffmpeg`` to read and to export video and audio files
 Basic concepts
 ~~~~~~~~~~~~~~~
 
-The central objects of MoviePy are *clips*, which can be ``AudioClips`` or ``VideoClips``. They can be modified (cut, slowed down, darkened...) or put mixed with clips to form new clips, they can be previewed (using either PyGame or the IPython Notebook) and rendered to a file (as a MP4, a GIF, a MP3, etc.). ``VideoClips`` for instance can be created from a video file, an image, a text, or a custom animation. They can have an audio track (which is an ``AudioClip``) and a mask (a special ``VideoClip`` indicating which parts of the clip to hide when the clip is mixed with other clips). See :ref:`clips` and :ref:`CompositeVideoClips` for more details. 
+The central objects of MoviePy are *clips*, which can be ``AudioClips`` or ``VideoClips``. They can be modified (cut, slowed down, darkened...) or put mixed with clips to form new clips, they can be previewed (using either PyGame or the IPython Notebook) and rendered to a file (as a MP4, a GIF, a MP3, etc.). ``VideoClips`` for instance can be created from a video file, an image, a text, or a custom animation. They can have an audio track (which is an ``AudioClip``) and a mask (a special ``VideoClip`` indicating which parts of the clip to hide when the clip is mixed with other clips). See :ref:`clips` and :ref:`CompositeVideoClips` for more details.
 
 A clip can be modified using one of moviepy's numerous effects (like in ``clip.resize(width="360")``, ``clip.subclip(t1,t2)``, or ``clip.fx(vfx.black_white)``) or using a user-implemented effect. MoviePy implements many functions (like ``clip.fl``, ``clip.fx``, etc.) which make it very easy to code your own effect in a few lines. See :ref:`effects` for more.
 
@@ -80,8 +80,8 @@ You will also find a few advanced goodies in ``moviepy.video.tools`` to track ob
 
 Finally, although MoviePy has no graphical user interface, there are many ways to preview a clip which allow you to fine-tune your scripts and be sure that everything is perfect when you render you video in high quality. See :ref:`efficient`.
 
-.. _imageio: http://imageio.github.io/
-.. _OpenCV: http://opencv.org/ 
+.. _imageio: https://imageio.github.io/
+.. _OpenCV: http://opencv.org/
 
 
 

--- a/docs/getting_started/videoclips.rst
+++ b/docs/getting_started/videoclips.rst
@@ -6,30 +6,30 @@ Creating and exporting video clips
 Video au audio clips are the central objects of MoviePy. In this section we present the different sorts of clips, how to create them, and how to write them to a file. For informations on modifying a clip (cuts, effects, etc.), see :ref:`effects`. For how to put clips together see :ref:`CompositeVideoClips` and to see how to preview clips before writing a file, refer to :ref:`efficient`.
 
 The following code summarizes the base clips that you can create with moviepy: ::
-    
+
     # VIDEO CLIPS
     clip = VideoClip(make_frame, duration=4) # for custom animations (see below)
     clip = VideoFileClip("my_video_file.mp4") # or .avi, .webm, .gif ...
     clip = ImageClip("my_picture.png") # or .jpeg, .tiff, ...
     clip = TextClip("Hello !", font="Amiri-Bold", fontsize=70, color="black")
     clip = ColorClip(size=(460,380), color=[R,G,B])
-    
+
     # AUDIO CLIPS
     clip = AudioFileClip("my_audiofile.mp3") # or .ogg, .wav... or a video !
     clip = AudioArrayClip(numpy_array, fps=44100) # from a numerical array
-    clip = AudioClip(make_frame, duration=3) # uses a function make_frame(t) 
+    clip = AudioClip(make_frame, duration=3) # uses a function make_frame(t)
 
 
 
 The best to understand these clips is to read the full documentation for each in the :ref:`reference_manual`. The next sections
-In this section we see how to create clips, (for instance from video or audio files), how to mix them together, and how to write them to a file. 
+In this section we see how to create clips, (for instance from video or audio files), how to mix them together, and how to write them to a file.
 
 
 
 Categories of video clips
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Video clips are the building blocks of longer videos. Technically, they are clips with a ``clip.get_frame(t)`` method which outputs a HxWx3 numpy array representing the frame of the clip at time *t*. There are two main categories: animated clips (made with ``VideoFileClip`` and ``VideoClip``) and unanimated clips which show the same picture for an a-priori infinite duration (``ImageClip``, ``TextClip``,``ColorClip``). There are also special video clips call masks, which belong to the categories above but output greyscale frames indicating which parts of another clip are visible or not. A video clip can carry around an audio clip (``clip.audio``) which is its *soundtrack*, and a mask clip. 
+Video clips are the building blocks of longer videos. Technically, they are clips with a ``clip.get_frame(t)`` method which outputs a HxWx3 numpy array representing the frame of the clip at time *t*. There are two main categories: animated clips (made with ``VideoFileClip`` and ``VideoClip``) and unanimated clips which show the same picture for an a-priori infinite duration (``ImageClip``, ``TextClip``,``ColorClip``). There are also special video clips call masks, which belong to the categories above but output greyscale frames indicating which parts of another clip are visible or not. A video clip can carry around an audio clip (``clip.audio``) which is its *soundtrack*, and a mask clip.
 
 VideoClip
 """"""""""
@@ -80,7 +80,7 @@ When you create or load a clip that you will use as a mask you need to declare i
     mclip = VideoClip(makeframe, duration=4, ismask=True)
     mclip = ImageClip("my_mask.jpeg", ismask=True)
     mclip = VideoClip("myvideo.mp4", ismask=True)
-    
+
 In the case of video and image files, if these are not already black and white they will be converted automatically.
 
 Any video clip can be turned into a mask with ``clip.to_mask()``, and a mask can be turned to a standard RGB video clip with ``my_mask_clip.to_RGB()``.
@@ -97,12 +97,12 @@ Video files (.mp4, .webm, .ogv...)
 """"""""""""""""""""""""""""""""""""
 
 To write a clip as a video file, use ::
-    
+
     my_clip.write_videofile("movie.mp4") # default codec: 'libx264', 24 fps
     my_clip.write_videofile("movie.mp4",fps=15)
     my_clip.write_videofile("movie.webm") # webm format
     my_clip.write_videofile("movie.webm",audio=False) # don't render audio.
-    
+
 MoviePy has default codec names for the most common file extensions. If you want to use exotic formats or if you are not happy with the defaults you can provide the codec with ``codec='mpeg4'`` for instance. There are many many options when you are writing a video (bitrate, parameters of the audio writing, file size optimization, number of processors to use, etc.). Please refer to :py:meth:`~moviepy.video.VideoClip.VideoClip.write_videofile` for more.
 
 
@@ -127,7 +127,7 @@ There are many options to optimize the quality and size of a gif. Please refer t
 
 Note that for editing gifs the best way is to preview them in the notebook as explained here: :ref:`ipython_display`
 
-See `this blog post <http://zulko.github.io/blog/2014/01/23/making-animated-gifs-from-video-files-with-python>`_ for informations on making GIFs from video files, and `this other post <http://zulko.github.io/blog/2014/09/20/vector-animations-with-python/>`_ for GIF animations with vector graphics.
+See `this blog post <https://zulko.github.io/blog/2014/01/23/making-animated-gifs-from-video-files-with-python>`_ for informations on making GIFs from video files, and `this other post <https://zulko.github.io/blog/2014/09/20/vector-animations-with-python/>`_ for GIF animations with vector graphics.
 
 .. _CCaudioClips:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ MoviePy is an open source software originally written by Zulko_ and released und
     fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
     </script>
 
-    <iframe type="text/html" src="http://ghbtns.com/github-btn.html?user=Zulko&repo=moviepy&type=watch&count=true&size=large"
+    <iframe type="text/html" src="https://ghbtns.com/github-btn.html?user=Zulko&repo=moviepy&type=watch&count=true&size=large"
     allowtransparency="true" frameborder="0" scrolling="0" width="152px" height="30px"></iframe>
 ..    <a href="https://github.com/Zulko/moviepy">
 ..    <img style="position: absolute; top: 0; right: 0; border: 0;"
@@ -53,7 +53,7 @@ MoviePy is an open source software originally written by Zulko_ and released und
 
 .. _PyPI: https://pypi.python.org/pypi/moviepy
 .. _Zulko: https://github.com/Zulko/
-.. _Stackoverflow: http://stackoverflow.com/
+.. _Stackoverflow: https://stackoverflow.com/
 .. _Github: https://github.com/Zulko/moviepy
-.. _Reddit: http://www.reddit.com/r/moviepy/
+.. _Reddit: https://www.reddit.com/r/moviepy/
 .. _librelist: mailto:moviepy@librelist.com

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,7 +8,7 @@ Installation
 --------------
 
 **Method with pip:** if you have ``pip`` installed, just type this in a terminal (it will install ez_setup if you don't already have it) ::
-    
+
     (sudo) pip install moviepy
 
 If you have neither ``setuptools`` nor ``ez_setup`` installed the command above will fail, is this case type this before installing: ::
@@ -16,7 +16,7 @@ If you have neither ``setuptools`` nor ``ez_setup`` installed the command above 
     (sudo) pip install ez_setup
 
 **Method by hand:** download the sources, either on PyPI_ or (if you want the development version) on Github_, unzip everything in one folder, open a terminal and type ::
-    
+
     (sudo) python setup.py install
 
 MoviePy depends on the Python modules Numpy_, imageio_, Decorator_, and tqdm_, which will be automatically installed during MoviePy's installation. It should work  on Windows/Mac/Linux, with Python 2.7+ and 3 ; if you have trouble installing MoviePy or one of its dependencies, please provide feedback !
@@ -30,7 +30,7 @@ Other optional but useful dependencies
 ImageMagick_ is not strictly required, only if you want to write texts. It can also be used as a backend for GIFs but you can do GIFs with MoviePy without ImageMagick.
 
 Once you have installed it, ImageMagick will be automatically detected by MoviePy, **except on Windows !**. Windows user, before installing MoviePy by hand, go into the ``moviepy/config_defaults.py`` file and provide the path to the ImageMagick binary called `convert`. It should look like this ::
-    
+
     IMAGEMAGICK_BINARY = "C:\\Program Files\\ImageMagick_VERSION\\convert.exe"
 
 You can also set the IMAGEMAGICK_BINARY environment variable See ``moviepy/config_defaults.py`` for details.
@@ -44,25 +44,25 @@ For advanced image processing you will need one or several of these packages. Fo
 - `Scikit Image`_ may be needed for some advanced image manipulation.
 - `OpenCV 2.4.6`_ or more recent (provides the package ``cv2``) or more recent may be needed for some advanced image manipulation.
 
-If you are on linux, these softwares will surely be in your repos.    
+If you are on linux, these softwares will surely be in your repos.
 
-.. _`Numpy`: http://www.scipy.org/install.html
+.. _`Numpy`: https://www.scipy.org/install.html
 .. _Decorator: https://pypi.python.org/pypi/decorator
 .. _tqdm: https://pypi.python.org/pypi/tqdm
 
-.. _ffmpeg: http://www.ffmpeg.org/download.html 
+.. _ffmpeg: https://www.ffmpeg.org/download.html
 
 
-.. _imageMagick: http://www.imagemagick.org/script/index.php
-.. _Pygame: http://www.pygame.org/download.shtml
-.. _imageio: http://imageio.github.io/
+.. _imageMagick: https://www.imagemagick.org/script/index.php
+.. _Pygame: https://www.pygame.org/download.shtml
+.. _imageio: https://imageio.github.io/
 
-.. _Pillow: http://pillow.readthedocs.org/en/latest/
-.. _Scipy: http://www.scipy.org/
+.. _Pillow: https://pillow.readthedocs.org/en/latest/
+.. _Scipy: https://www.scipy.org/
 .. _`Scikit Image`: http://scikit-image.org/download.html
 
 .. _Github: https://github.com/Zulko/moviepy
 .. _PyPI: https://pypi.python.org/pypi/moviepy
-.. _`OpenCV 2.4.6`: http://sourceforge.net/projects/opencvlibrary/files/
+.. _`OpenCV 2.4.6`: https://sourceforge.net/projects/opencvlibrary/files/
 
 


### PR DESCRIPTION
Fixes remaining insecure content embedded in secure pages (images embedded in MoviePy docs) which gets rejected by browsers. (Continuation of PR #446 prompted by issue described in #421.)

Additionally replaces *all other* insecure links with secure versions for websites that offer `https` (almost all of them).