### PR TITLE
Small improvements to docs pages, docs usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,5 @@ nosetests.xml
 # JetBrains
 .idea
 
+# Tests
 tests/media

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,11 +26,11 @@ import sys, os
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.todo',
-              'sphinx.ext.viewcode', 'sphinx.ext.autosummary','numpydoc']
+              'sphinx.ext.viewcode', 'sphinx.ext.autosummary', 'numpydoc']
 
-numpydoc_class_members_toctree= False
-numpydoc_show_class_members= False
-autosummary_generate= True
+numpydoc_class_members_toctree = False
+numpydoc_show_class_members = False
+autosummary_generate = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/makehtml.sh
+++ b/docs/makehtml.sh
@@ -1,2 +1,8 @@
 make html
-firefox ../../docs/html/index.html
+
+# open generated HTML files
+if [[ $(uname) == 'Darwin' ]]; then
+    open '../../docs/html/index.html' -a Firefox
+elif [[ $(uname) == 'Linux' ]]; then
+    firefox ../../docs/html/index.html
+fi

--- a/docs/ref/videofx.rst
+++ b/docs/ref/videofx.rst
@@ -5,27 +5,26 @@ moviepy.video.fx (vfx)
 ***********************
 The module ``moviepy.video.fx`` regroups functions meant to be used with ``videoclip.fx()``.
 
-Because this module is starting to be large and will be larger in the future, it allows two kinds of import.
-You can either im
-For all the other modifications, we use ``clip.fx`` and ``clip.fl``. ``clip.fx`` is meant to make it easy to use already-written transformation functions, while  ``clip.fl`` makes it easy to write new transformation functions.
-port a single function like this: ::
-    
+For all other modifications, we use ``clip.fx`` and ``clip.fl``. ``clip.fx`` is meant to make it easy to use already-written transformation functions, while  ``clip.fl`` makes it easy to write new transformation functions.
+
+Because this module is starting to get large and will only get larger in the future, it allows two kinds of imports. You can either import a single function like this: ::
+
     from moviepy.video.fx.scroll import crop
     newclip = myclip.fx( vfx.crop, x1=15)
 
 Or import everything: ::
-    
+
     import moviepy.video.fx.all as vfx
     newclip = (myclip.fx( vfx.crop, x1=15)
                      .fx( vfx.resize, width=200)
                      .fx( vfx.freeze_at_end, 1))
 
 
-When you type ::
-    
+When you type: ::
+
     from moviepy.editor import *
 
-the module ``video.fx`` is loaded as ``vfx`` and you can use ``vfx.colorx``, ``vfx.resize``, etc.
+the module ``video.fx`` is loaded as ``vfx`` and you can use ``vfx.colorx``, ``vfx.resize`` etc.
 
 
 .. currentmodule:: moviepy.video.fx.all
@@ -33,7 +32,7 @@ the module ``video.fx`` is loaded as ``vfx`` and you can use ``vfx.colorx``, ``v
 .. autosummary::
     :toctree: videofx
     :nosignatures:
-    
+
     accel_decel
     blackwhite
     blink
@@ -66,4 +65,4 @@ the module ``video.fx`` is loaded as ``vfx`` and you can use ``vfx.colorx``, ``v
     time_symmetrize
 
 
-   
+


### PR DESCRIPTION
`makehtml.sh` can now also be used on Mac (automatically opens the generated HTML in Firefox).