### PR TITLE
include requirements file for docs

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,0 +1,3 @@
+Sphinx>=1.5.2
+sphinx_rtd_theme>=0.1.10b0
+numpydoc>=0.6.0


### PR DESCRIPTION
As mentioned in #482, building the documentation requires some additional packages to be installed, which are excluded when using `setup.py`.

This requirements file contains the packages needed for doc building.
They can be installed by running `$ pip install -r requirements_docs.txt` 