### PR TITLE
Change `verbose_print`

### DIFF
--- a/moviepy/tools.py
+++ b/moviepy/tools.py
@@ -11,16 +11,10 @@ import os
 from .compat import DEVNULL
 
 
-def sys_write_flush(s):
-    """ Writes and flushes without delay a text in the console """
-    sys.stdout.write(s)
-    sys.stdout.flush()
-
-
-def verbose_print(verbose, s):
-    """ Only prints s (with sys_write_flush) if verbose is True."""
+def verbose_print(verbose, *args):
+    """ Prints everything passed execpt the first arguement if verbose is True."""
     if verbose:
-        sys_write_flush(s)
+        print(*args)
 
 
 def subprocess_call(cmd, verbose=True, errorprint=True):

--- a/tests/test_PR.py
+++ b/tests/test_PR.py
@@ -7,6 +7,7 @@ import os
 import pytest
 
 from moviepy.editor import *
+import moviepy.tools as tools
 
 
 def test_PR_306():
@@ -45,6 +46,13 @@ def test_PR_424():
 def test_PR_458():
     clip = ColorClip([1000, 600], color=(60, 60, 60), duration=10)
     clip.write_videofile("test.mp4", progress_bar=False, fps=30)
+    
+    
+def test_PR_485():
+    tools.verbose_print(False, "test1")  # Should not print anything
+    tools.verbose_print(True, "test2")  # Should print normally
+    tools.verbose_print(True, 59, "test3", ["test4", 23])  # Should print "59 test3 ["test4", 23]"
+    
 
 if __name__ == '__main__':
    pytest.main()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -56,17 +56,18 @@ def test_4a():
         .format(b'hello bytes',left, right)
     assert left == right, message
 
-def test_5():
-    '''Tests for sys_write-flush function
-        1) checks that this works quickly,
-        2) checks that stdout has no content after flushing
-    '''
-    start = time.time()
-    tools.sys_write_flush("hello world")
-    myTime = time.time() - start
-    assert myTime <  0.001
-    file = sys.stdout.read()
-    assert file == b""
+# test_5 commented out because PR #485 removed sys_write_flush
+#def test_5():
+#    '''Tests for sys_write-flush function
+#        1) checks that this works quickly,
+#        2) checks that stdout has no content after flushing
+#    '''
+#    start = time.time()
+#    tools.sys_write_flush("hello world")
+#    myTime = time.time() - start
+#    assert myTime <  0.001
+#    file = sys.stdout.read()
+#    assert file == b""
 
 def test_6():
     '''


### PR DESCRIPTION
I don't see why we need the fancy `sys.stout` when `print` prints to `stout` by default, and flushes automatically. This also means we can use `verbose_print` just like `print` except with the `verbose` parameter before anything to be printed. e.g. `verbose_print(True, var1, var2) which would have failed with the old `verbose_print`.

I tried to use `verbose_print` in my application, but acted very weirdly, hence the change.