### PR TITLE
Allow resizing frames in ffmpeg when reading

### DIFF
--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -32,6 +32,17 @@ class VideoFileClip(VideoClip):
     audio:
       Set to `False` if the clip doesn't have any audio or if you do not
       wish to read the audio.
+
+    target_resolution:
+      Set to (desired_height, desired_width) to have ffmpeg resize the frames before return them.
+      This is much faster than streaming in high-res and then resizing.
+      if either size is None, the frames are resized by keeping the existing aspect ratio.
+
+    resize_algorithm:
+      The algorithm used for resizing. Default: "bicubic", other popular options include "bilinear"
+      and "fast_bilinear".
+      For more information, see https://ffmpeg.org/ffmpeg-scaler.html
+
       
     Attributes
     -----------
@@ -48,14 +59,17 @@ class VideoFileClip(VideoClip):
 
     def __init__(self, filename, has_mask=False,
                  audio=True, audio_buffersize = 200000,
+                 target_resolution=None, resize_algorithm='bicubic',
                  audio_fps=44100, audio_nbytes=2, verbose=False):
         
         VideoClip.__init__(self)
-        
+
         # Make a reader
         pix_fmt= "rgba" if has_mask else "rgb24"
-        self.reader = None #need this just in case FFMPEG has issues (__del__ complains)
-        self.reader = FFMPEG_VideoReader(filename, pix_fmt=pix_fmt)
+        self.reader = None # need this just in case FFMPEG has issues (__del__ complains)
+        self.reader = FFMPEG_VideoReader(filename, pix_fmt=pix_fmt,
+                                         target_resolution=target_resolution, resize_algo=resize_algorithm)
+
         # Make some of the reader's attributes accessible from the clip
         self.duration = self.reader.duration
         self.end = self.reader.duration

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -23,12 +23,28 @@ import os
 class FFMPEG_VideoReader:
 
     def __init__(self, filename, print_infos=False, bufsize = None,
-                 pix_fmt="rgb24", check_duration=True):
+                 pix_fmt="rgb24", check_duration=True,
+                 target_resolution=None, resize_algo='bicubic'):
 
         self.filename = filename
         infos = ffmpeg_parse_infos(filename, print_infos, check_duration)
         self.fps = infos['video_fps']
         self.size = infos['video_size']
+
+        if target_resolution:
+            # revert the order, as ffmpeg used (width, height)
+            target_resolution = target_resolution[1], target_resolution[0]
+
+            if None in target_resolution:
+                ratio = 1
+                for idx, target in enumerate(target_resolution):
+                    if target:
+                        ratio = min(ratio, float(target) / self.size[idx])
+                self.size = (int(self.size[0] * ratio), int(self.size[1] * ratio))
+            else:
+                self.size = target_resolution
+        self.resize_algo = resize_algo
+
         self.duration = infos['video_duration']
         self.ffmpeg_duration = infos['duration']
         self.nframes = infos['video_nframes']
@@ -66,13 +82,13 @@ class FFMPEG_VideoReader:
         else:
             i_arg = [ '-i', self.filename]
 
-
-        cmd = ([get_setting("FFMPEG_BINARY")]+ i_arg +
-                ['-loglevel', 'error',
+        cmd = ([get_setting("FFMPEG_BINARY")] + i_arg +
+               ['-loglevel', 'error',
                 '-f', 'image2pipe',
+                '-vf', 'scale=%d:%d' % tuple(self.size),
+                '-sws_flags', self.resize_algo,
                 "-pix_fmt", self.pix_fmt,
                 '-vcodec', 'rawvideo', '-'])
-
         popen_params = {"bufsize": self.bufsize,
                         "stdout": sp.PIPE,
                         "stderr": sp.PIPE,

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -38,8 +38,8 @@ class FFMPEG_VideoReader:
             if None in target_resolution:
                 ratio = 1
                 for idx, target in enumerate(target_resolution):
-                    if target:
-                        ratio = min(ratio, float(target) / self.size[idx])
+                    if target:  
+                        ratio = target / self.size[idx]
                 self.size = (int(self.size[0] * ratio), int(self.size[1] * ratio))
             else:
                 self.size = target_resolution

--- a/tests/test_VideoFileClip.py
+++ b/tests/test_VideoFileClip.py
@@ -18,5 +18,22 @@ def test_setup():
     assert clip.fps == 30
     assert clip.size == [1024*3, 800]
 
+def test_ffmpeg_resizing():
+    target_resolution = (128,128)
+    video = VideoFileClip("media/big_buck_bunny_432_433.webm", target_resolution=target_resolution)
+    frame = video.get_frame(0)
+    assert frame.shape[0:2] == target_resolution
+
+    target_resolution = (128, None)
+    video = VideoFileClip("media/big_buck_bunny_432_433.webm", target_resolution=target_resolution)
+    frame = video.get_frame(0)
+    assert frame.shape[0] == target_resolution[0]
+
+    target_resolution = (None, 128)
+    video = VideoFileClip("media/big_buck_bunny_432_433.webm", target_resolution=target_resolution)
+    frame = video.get_frame(0)
+    assert frame.shape[1] == target_resolution[1]
+
+
 if __name__ == '__main__':
    pytest.main()

--- a/tests/test_VideoFileClip.py
+++ b/tests/test_VideoFileClip.py
@@ -19,6 +19,7 @@ def test_setup():
     assert clip.size == [1024*3, 800]
 
 def test_ffmpeg_resizing():
+    # Test downscaling
     target_resolution = (128,128)
     video = VideoFileClip("media/big_buck_bunny_432_433.webm", target_resolution=target_resolution)
     frame = video.get_frame(0)
@@ -34,6 +35,11 @@ def test_ffmpeg_resizing():
     frame = video.get_frame(0)
     assert frame.shape[1] == target_resolution[1]
 
+    # Test upscaling
+    target_resolution = (None, 2048)
+    video = VideoFileClip("media/big_buck_bunny_432_433.webm", target_resolution=target_resolution)
+    frame = video.get_frame(0)
+    assert frame.shape[1] == target_resolution[1]
 
 if __name__ == '__main__':
    pytest.main()


### PR DESCRIPTION
This PR is adds the possibility to read videos frames that have been resized in ffmpeg.
This is much faster than streaming in high-res and then resizing in python and important for applications where speed is crucial