### PR TITLE
Fix issue #464, repeated/skipped frames in ImageSequenceClip

### DIFF
--- a/moviepy/video/io/ImageSequenceClip.py
+++ b/moviepy/video/io/ImageSequenceClip.py
@@ -78,8 +78,10 @@ class ImageSequenceClip(VideoClip):
         self.fps = fps
         if fps is not None:
             durations = [1.0/fps for image in sequence]
+            self.images_starts = [1.0*i/fps-np.finfo(np.float32).eps for i in range(len(sequence))]
+        else:
+            self.images_starts = [0]+list(np.cumsum(durations))
         self.durations = durations
-        self.images_starts = [0]+list(np.cumsum(durations))
         self.duration = sum(durations)
         self.end = self.duration
         self.sequence = sequence

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -125,6 +125,15 @@ def test_issue_417():
     final = CompositeVideoClip([myclip], size=(1280, 720))
     #final.set_duration(7).write_videofile("test.mp4", fps=30)
 
+def test_issue_464():
+    import numpy as np
+    original_frames = [i*np.ones((32, 32, 3), dtype=np.uint8) for i in range(50)]
+    clip = ImageSequenceClip(original_frames, fps=30)
+    for original_frame, clip_frame in zip(original_frames, clip.iter_frames()):
+        # The retrieved frames should be equal to the original ones
+        # Since the frames are constant color, it suffices to compare one pixel
+        assert original_frame[0,0,0] == clip_frame[0,0,0]
+
 def test_issue_467():
     cad = 'media/python_logo.png'
     clip = ImageClip(cad)


### PR DESCRIPTION
This PR fixes the occasional repeating and skipping of frames mentioned in issue #464 due to floating point inaccuracies in images_starts.