### PR TITLE
Fix for cleaning up os calls through Popen

### DIFF
--- a/moviepy/audio/io/AudioFileClip.py
+++ b/moviepy/audio/io/AudioFileClip.py
@@ -77,3 +77,10 @@ class AudioFileClip(AudioClip):
             to the audio file. Use copy when you have different clips
             watching the audio file at different times. """
         return AudioFileClip(self.filename,self.buffersize)
+
+    def __del__(self):
+        """ Close/delete the internal reader. """
+        try:
+            del self.reader
+        except AttributeError:
+            pass

--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -107,3 +107,8 @@ class VideoFileClip(VideoClip):
             del self.reader
         except AttributeError:
             pass
+
+        try:
+            del self.audio
+        except AttributeError:
+            pass


### PR DESCRIPTION
This PR adds the same `_del__` code for AudioFileClip as there is for VideoFileClip:
https://github.com/Zulko/moviepy/blob/master/moviepy/video/io/VideoFileClip.py#L104

Despite using moviepy master I had problems with readers not being closed (leading to OSError: [Errno 24] Too many open files), similar to:
https://github.com/Zulko/moviepy/issues/57
https://github.com/Zulko/moviepy/issues/255

I have a complicated setup with a server that runs a long time and is multi-threaded (and the issue happens after days). To find and fix the issue I wrote a wrapper around Popen to log the calls opened and closed:
https://gist.github.com/gyglim/340c9d276d7f53578eb9673156e556df

This Pull Request together with explicitly calling `video.__del__()` resolved the issue.
Explicitly calling `__del__()` relates to this:
http://stackoverflow.com/questions/1481488/what-is-the-del-method-how-to-call-it/1481512#1481512 

When calling `__del__()` without the fix in this PR, the readers of AudioFileClip would stay open.
