### PR TITLE
FX: Allows modify the volume by arrays

### DIFF
--- a/moviepy/audio/fx/audio_levels.py
+++ b/moviepy/audio/fx/audio_levels.py
@@ -56,12 +56,12 @@ def audio_levels(clip, levels, fast=False):
             return np.vstack([factor, factor]).T * gft
 
         def not_scalar(t):
-            gft = gf(t)
             prv, nxt, final = get_range_levels(t[0])
 
             if t[-1] < nxt[0] or final:
                 return not_scalar_fast(t, prv, nxt)
 
+            gft = gf(t)
             for it in range(len(t)):
                 if t[it] >= nxt[0] and not final:
                     prv, nxt, final = get_range_levels(t[it])

--- a/moviepy/audio/fx/audio_levels.py
+++ b/moviepy/audio/fx/audio_levels.py
@@ -35,9 +35,11 @@ def audio_levels(clip, levels, fast=False):
             factor = pos * sig[1] + (1 - pos) * ant[1]
             return np.array([factor, factor]) * gft
 
-        def not_scalar_fast(t):
+        def not_scalar_fast(t, ant=False, sig=False):
             gft = gf(t)
-            ant, sig = get_range_levels(t[0])
+
+            if not ant or not sig:
+                ant, sig = get_range_levels(t[0])
 
             pos = (t - ant[0]) / (sig[0] - ant[0])
             factor = pos * sig[1] + (1 - pos) * ant[1]
@@ -46,9 +48,11 @@ def audio_levels(clip, levels, fast=False):
         def not_scalar(t):
             gft = gf(t)
             ant, sig = get_range_levels(t[0])
+            if not t[-1] >= sig[0]:
+                return not_scalar_fast(t, ant, sig)
 
             for it in range(len(t)):
-                if sig[0] <= t[it]:
+                if t[it] >= sig[0]:
                     ant, sig = get_range_levels(t[it])
 
                 pos = (t[it] - ant[0]) / (sig[0] - ant[0])

--- a/moviepy/audio/fx/audio_levels.py
+++ b/moviepy/audio/fx/audio_levels.py
@@ -11,55 +11,63 @@ def audio_levels(clip, levels, fast=False):
                        levels=[(0, 1), (5, 0), (10, 1)],
                        fast=True)  # fast is imprecise
     """
+    def get_range_levels(t):
+        if t >= cache['prv'][0] and t < cache['nxt'][0]:
+            return cache['prv'], cache['nxt'], cache['final']
+        elif t >= cache['nxt'][0] and cache['final']:
+            # final point not defined
+            return cache['prv'], cache['nxt'], cache['final']
+
+        match_next = False
+        for l in levels:
+            if l[0] <= t:
+                cache['prv'] = l
+            else:
+                cache['nxt'] = l
+                match_next = True
+                break
+        if not match_next:
+            cache['nxt'] = cache['prv'][0] + 1, cache['prv'][1]
+            cache['final'] = True
+
+        elif cache['prv'] == cache['nxt']:
+            # init point not defined
+            cache['prv'] = cache['prv'][0] - 1, cache['prv'][1]
+
+        return cache['prv'], cache['nxt'], cache['final']
 
     def level(gf, t):
-        def get_range_levels(t):
-            ant = levels[0]
-            sig = None
-            final = False
-
-            for l in levels:
-                if l[0] <= t:
-                    ant = l
-                else:
-                    sig = l
-                    break
-            if not sig:  # hack time
-                sig = ant[0] + 1, ant[1]
-                final = True
-            return ant, sig, final
-
         def scalar(t):
             gft = gf(t)
-            ant, sig, final = get_range_levels(t)
+            prv, nxt, final = get_range_levels(t)
 
-            pos = (t - ant[0]) / (sig[0] - ant[0])
-            factor = pos * sig[1] + (1 - pos) * ant[1]
+            pos = (t - prv[0]) / (nxt[0] - prv[0])
+            factor = pos * nxt[1] + (1 - pos) * prv[1]
             return np.array([factor, factor]) * gft
 
-        def not_scalar_fast(t, ant=False, sig=False):
+        def not_scalar_fast(t, prv=False, nxt=False):
             gft = gf(t)
 
-            if not ant or not sig:
-                ant, sig, final = get_range_levels(t[0])
+            if not prv or not nxt:
+                prv, nxt, final = get_range_levels(t[0])
 
-            pos = (t - ant[0]) / (sig[0] - ant[0])
-            factor = pos * sig[1] + (1 - pos) * ant[1]
+            pos = (t - prv[0]) / (nxt[0] - prv[0])
+            factor = pos * nxt[1] + (1 - pos) * prv[1]
             return np.vstack([factor, factor]).T * gft
 
         def not_scalar(t):
             gft = gf(t)
-            ant, sig, final = get_range_levels(t[0])
+            prv, nxt, final = get_range_levels(t[0])
 
-            if not t[-1] >= sig[0] or final:
-                return not_scalar_fast(t, ant, sig)
+            if t[-1] < nxt[0] or final:
+                return not_scalar_fast(t, prv, nxt)
 
             for it in range(len(t)):
-                if t[it] >= sig[0] and not final:
-                    ant, sig, final = get_range_levels(t[it])
+                if t[it] >= nxt[0] and not final:
+                    prv, nxt, final = get_range_levels(t[it])
 
-                pos = (t[it] - ant[0]) / (sig[0] - ant[0])
-                factor = pos * sig[1] + (1 - pos) * ant[1]
+                pos = (t[it] - prv[0]) / (nxt[0] - prv[0])
+                factor = pos * nxt[1] + (1 - pos) * prv[1]
                 gft[it] *= np.array([factor, factor])
             return gft
 
@@ -69,4 +77,6 @@ def audio_levels(clip, levels, fast=False):
             return np.array(not_scalar_fast(t))
         return np.array(not_scalar(t))
 
+    cache = {'prv': levels[0], 'nxt': levels[0], 'final': False}
+    get_range_levels(0)
     return clip.fl(level, keep_duration=True)

--- a/moviepy/audio/fx/audio_levels.py
+++ b/moviepy/audio/fx/audio_levels.py
@@ -48,7 +48,7 @@ def audio_levels(clip, levels, fast=False):
             ant, sig = get_range_levels(t[0])
 
             for it in range(len(t)):
-                if t[it] > sig[0]:
+                if sig[0] <= t[it]:
                     ant, sig = get_range_levels(t[it])
 
                 pos = (t[it] - ant[0]) / (sig[0] - ant[0])

--- a/moviepy/audio/fx/audio_levels.py
+++ b/moviepy/audio/fx/audio_levels.py
@@ -1,0 +1,65 @@
+from moviepy.decorators import audio_video_fx
+import numpy as np
+
+
+@audio_video_fx
+def audio_levels(clip, levels, fast=False):
+    """ Return an audio clip (or video) by leveling
+        the audio with the received array.
+
+        clip = clip.fx(audio_levels,
+                       levels=[(0, 1), (5, 0), (10, 1)],
+                       fast=True)  # fast is imprecise
+    """
+
+    def level(gf, t):
+        def get_range_levels(t):
+            ant = levels[0]
+            sig = None
+
+            for l in levels:
+                if l[0] <= t:
+                    ant = l
+                else:
+                    sig = l
+                    break
+            if not sig:  # hack time
+                sig = ant[0] + 1, ant[1]
+            return ant, sig
+
+        def scalar(t):
+            gft = gf(t)
+            ant, sig = get_range_levels(t)
+
+            pos = (t - ant[0]) / (sig[0] - ant[0])
+            factor = pos * sig[1] + (1 - pos) * ant[1]
+            return np.array([factor, factor]) * gft
+
+        def not_scalar_fast(t):
+            gft = gf(t)
+            ant, sig = get_range_levels(t[0])
+
+            pos = (t - ant[0]) / (sig[0] - ant[0])
+            factor = pos * sig[1] + (1 - pos) * ant[1]
+            return np.vstack([factor, factor]).T * gft
+
+        def not_scalar(t):
+            gft = gf(t)
+            ant, sig = get_range_levels(t[0])
+
+            for it in range(len(t)):
+                if t[it] > sig[0]:
+                    ant, sig = get_range_levels(t[it])
+
+                pos = (t[it] - ant[0]) / (sig[0] - ant[0])
+                factor = pos * sig[1] + (1 - pos) * ant[1]
+                gft[it] *= np.array([factor, factor])
+            return gft
+
+        if np.isscalar(t):
+            return scalar(t)
+        if fast:
+            return np.array(not_scalar_fast(t))
+        return np.array(not_scalar(t))
+
+    return clip.fl(level, keep_duration=True)

--- a/moviepy/audio/fx/audio_levels.py
+++ b/moviepy/audio/fx/audio_levels.py
@@ -16,6 +16,7 @@ def audio_levels(clip, levels, fast=False):
         def get_range_levels(t):
             ant = levels[0]
             sig = None
+            final = False
 
             for l in levels:
                 if l[0] <= t:
@@ -25,11 +26,12 @@ def audio_levels(clip, levels, fast=False):
                     break
             if not sig:  # hack time
                 sig = ant[0] + 1, ant[1]
-            return ant, sig
+                final = True
+            return ant, sig, final
 
         def scalar(t):
             gft = gf(t)
-            ant, sig = get_range_levels(t)
+            ant, sig, final = get_range_levels(t)
 
             pos = (t - ant[0]) / (sig[0] - ant[0])
             factor = pos * sig[1] + (1 - pos) * ant[1]
@@ -39,7 +41,7 @@ def audio_levels(clip, levels, fast=False):
             gft = gf(t)
 
             if not ant or not sig:
-                ant, sig = get_range_levels(t[0])
+                ant, sig, final = get_range_levels(t[0])
 
             pos = (t - ant[0]) / (sig[0] - ant[0])
             factor = pos * sig[1] + (1 - pos) * ant[1]
@@ -47,13 +49,14 @@ def audio_levels(clip, levels, fast=False):
 
         def not_scalar(t):
             gft = gf(t)
-            ant, sig = get_range_levels(t[0])
-            if not t[-1] >= sig[0]:
+            ant, sig, final = get_range_levels(t[0])
+
+            if not t[-1] >= sig[0] or final:
                 return not_scalar_fast(t, ant, sig)
 
             for it in range(len(t)):
-                if t[it] >= sig[0]:
-                    ant, sig = get_range_levels(t[it])
+                if t[it] >= sig[0] and not final:
+                    ant, sig, final = get_range_levels(t[it])
 
                 pos = (t[it] - ant[0]) / (sig[0] - ant[0])
                 factor = pos * sig[1] + (1 - pos) * ant[1]


### PR DESCRIPTION
Probably the name "levels" is not the most correct

```python
from moviepy.audio.fx.audio_levels import audio_levels
from moviepy.editor import VideoFileClip


clip = VideoFileClip('example.mp4').subclip(0, 10)
clip = clip.fx(audio_levels, [(0, 1), (5, 0), (10, 1)], fast=True)
clip.write_videofile("result.mp4")
```

Example videos:
Normal:
https://youtu.be/tRsvKTv-v9Q

Fast:
https://youtu.be/1kfyBJ58sN0

Explain differences (blue is normal, green is fast):

http://imgur.com/04L4ohP

This happens because in the fast version, multiply the array of 2000 values and it can happen.

The normal version uses the "fast" part only when it detects that it does not have any point that affects.

In the last commit, the speed difference is very small, I think you could eliminate the fast option