### PR TITLE
Fix out of bounds error

### DIFF
--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -67,15 +67,14 @@ class AudioClip(Clip):
         
         totalsize = int(fps*self.duration)
 
-        if (totalsize % chunksize == 0):
-            nchunks = totalsize // chunksize
-        else:
-            nchunks = totalsize // chunksize + 1
+        nchunks = totalsize // chunksize + 1
 
-        pospos = list(range(0, totalsize,  chunksize))+[totalsize]
+        pospos = np.linspace(0, totalsize, nchunks + 1, endpoint=True, dtype=int)
 
         def generator():
             for i in range(nchunks):
+                size = pospos[i+1] - pospos[i]
+                assert(size <= chunksize)
                 tt = (1.0/fps)*np.arange(pospos[i],pospos[i+1])
                 yield self.to_soundarray(tt, nbytes= nbytes, quantize=quantize, fps=fps,
                                          buffersize=chunksize)

--- a/moviepy/audio/io/readers.py
+++ b/moviepy/audio/io/readers.py
@@ -185,6 +185,8 @@ class FFMPEG_AudioReader:
             try:
                 result = np.zeros((len(tt),self.nchannels))
                 indices = frames - self.buffer_startframe
+                if len(self.buffer) < self.buffersize // 2:
+                    indices = indices - (self.buffersize // 2 - len(self.buffer) + 1)
                 result[in_time] = self.buffer[indices]
                 return result
 


### PR DESCRIPTION
Closes #19, #246, #269, #281.

`iter_chunks` now uses `np.linspace` to generate indices. In addition
to fixing the out of bounds error, this also ensures each chunk
generates a uniform number of indices.