### PR TITLE
Correctiong ffmpeg_resize parameters

### DIFF
--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -59,10 +59,11 @@ def ffmpeg_extract_audio(inputfile,output,bitrate=3000,fps=44100):
     subprocess_call(cmd)
     
 
-def ffmpeg_resize(video,output,size):
-    """ resizes ``video`` to new size ``size`` and write the result
+def ffmpeg_resize(video,output,width,height):
+    """ resizes ``video`` to new size with width ``width`` and 
+        height  ``height'' and write the result
         in file ``output``. """
-    cmd= [get_setting("FFMPEG_BINARY"), "-i", video, "-vf", "scale=%d:%d"%(res[0], res[1]),
+    cmd= [get_setting("FFMPEG_BINARY"), "-i", video, "-vf", "scale=%d:%d"%(width, height),
              output]
              
     subprocess_call(cmd)


### PR DESCRIPTION
The previous res[0] and res[1] they are not defined anywhere , and in this command in ffmpeg needs  to define the new width and the  new height. Check the url above: https://trac.ffmpeg.org/wiki/Scaling%20(resizing)%20with%20ffmpeg