### PR TITLE
Help tests run on Windows - don't assume temp dir or fonts.

### DIFF
--- a/tests/test_PR.py
+++ b/tests/test_PR.py
@@ -9,8 +9,11 @@ from moviepy.video.io.VideoFileClip import VideoFileClip
 from moviepy.video.tools.interpolators import Trajectory
 from moviepy.video.VideoClip import ColorClip, ImageClip, TextClip
 
+
 sys.path.append("tests")
-from test_helper import TMP_DIR, TRAVIS
+from test_helper import TMP_DIR, TRAVIS, FONT
+
+
 
 def test_download_media(capsys):
     """Test downloading."""
@@ -34,11 +37,11 @@ def test_PR_339():
        return
 
     # In caption mode.
-    TextClip(txt='foo', color='white', font="Liberation-Mono", size=(640, 480),
+    TextClip(txt='foo', color='white', font=FONT, size=(640, 480),
              method='caption', align='center', fontsize=25)
 
     # In label mode.
-    TextClip(txt='foo', font="Liberation-Mono", method='label')
+    TextClip(txt='foo', font=FONT, method='label')
 
 def test_PR_373():
     result = Trajectory.load_list("media/traj.txt")

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -2,7 +2,17 @@
 """Define general test helper attributes and utilities."""
 import os
 import sys
+import tempfile
 
-TRAVIS=os.getenv("TRAVIS_PYTHON_VERSION") is not None
+TRAVIS = os.getenv("TRAVIS_PYTHON_VERSION") is not None
 PYTHON_VERSION = "%s.%s" % (sys.version_info.major, sys.version_info.minor)
-TMP_DIR="/tmp"
+TMP_DIR = tempfile.tempdir
+
+# Arbitrary font used in caption testing.
+if sys.platform in ("win32", "cygwin"):
+    FONT = "Arial"
+    # Even if Windows users install the Liberation fonts, it is called LiberationMono on Windows, so
+    # it doesn't help.
+else:
+    FONT = "Liberation-Mono" # This is available in the fonts-liberation package on Linux.
+

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -10,7 +10,7 @@ from moviepy.video.VideoClip import ColorClip, TextClip
 from moviepy.video.io.VideoFileClip import VideoFileClip
 
 import download_media
-from test_helper import TMP_DIR, TRAVIS
+from test_helper import TMP_DIR, TRAVIS, FONT
 
 sys.path.append("tests")
 
@@ -35,7 +35,7 @@ def test_subtitles():
     if TRAVIS:
        return
 
-    generator = lambda txt: TextClip(txt, font='Liberation-Mono',
+    generator = lambda txt: TextClip(txt, font=FONT,
                                      size=(800,600), fontsize=24,
                                      method='caption', align='South',
                                      color='white')


### PR DESCRIPTION
This is a re-attempt at PR #597.

* Python already has a feature for finding the temp dir. Changed
test helper to take advantage of it.

* Still outstanding: Several hard-coded references to /tmp appear in
the tests.

* Liberation-Mono is not commonly installed on Windows, and even when
it is, the font has a different name. Provide a fall-back for Windows
fonts. (Considered the use of a 3rd party tool to help select, but
seemed overkill.)
