### PR TITLE
Use max fps for CompositeVideoClip

### DIFF
--- a/moviepy/video/compositing/CompositeVideoClip.py
+++ b/moviepy/video/compositing/CompositeVideoClip.py
@@ -40,8 +40,7 @@ class CompositeVideoClip(VideoClip):
       have the same size as the final clip. If it has no transparency, the final
       clip will have no mask. 
     
-    If all clips with a fps attribute have the same fps, it becomes the fps of
-    the result.
+    The clip with the highest FPS will be the FPS of the composite clip.
 
     """
 
@@ -60,10 +59,11 @@ class CompositeVideoClip(VideoClip):
         if bg_color is None:
             bg_color = 0.0 if ismask else (0, 0, 0)
 
-        
-        fps_list = list(set([c.fps for c in clips if hasattr(c,'fps')]))
-        if len(fps_list)==1:
-            self.fps= fps_list[0]
+        fpss = [c.fps for c in clips if hasattr(c, 'fps') and c.fps is not None]
+        if len(fpss) == 0:
+            self.fps = None
+        else:
+            self.fps = max(fpss)
 
         VideoClip.__init__(self)
         

--- a/tests/test_PR.py
+++ b/tests/test_PR.py
@@ -8,6 +8,7 @@ from moviepy.video.fx.scroll import scroll
 from moviepy.video.io.VideoFileClip import VideoFileClip
 from moviepy.video.tools.interpolators import Trajectory
 from moviepy.video.VideoClip import ColorClip, ImageClip, TextClip
+from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
 
 sys.path.append("tests")
 from test_helper import TMP_DIR, TRAVIS
@@ -110,6 +111,19 @@ def test_PR_528():
 def test_PR_529():
     video_clip = VideoFileClip("media/fire2.mp4")
     assert video_clip.rotation == 180
+
+
+def test_PR_610():
+    """
+    Test that the max fps of the video clips is used for the composite video clip
+    """
+    clip1 = ColorClip((640, 480), color=(255, 0, 0)).set_duration(1)
+    clip2 = ColorClip((640, 480), color=(0, 255, 0)).set_duration(1)
+    clip1.fps = 24
+    clip2.fps = 25
+    composite = CompositeVideoClip([clip1, clip2])
+
+    assert composite.fps == 25
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As of commit c0f6925, concatenate_videoclips uses the max fps of the
video clips.

This commit adds the same functionality for CompositeVideoClip.