### PR TITLE
Fixed typo in the slide_out transition

### DIFF
--- a/moviepy/video/compositing/transitions.py
+++ b/moviepy/video/compositing/transitions.py
@@ -43,7 +43,7 @@ def slide_in(clip, duration, side):
 
     Parameters
     ===========
-    
+
     clip
       A video clip.
 
@@ -53,10 +53,10 @@ def slide_in(clip, duration, side):
     side
       Side of the screen where the clip comes from. One of
       'top' | 'bottom' | 'left' | 'right'
-    
+
     Examples
     =========
-    
+
     >>> from moviepy.editor import *
     >>> clips = [... make a list of clips]
     >>> slided_clips = [clip.fx( transfx.slide_in, 1, 'left')
@@ -69,7 +69,7 @@ def slide_in(clip, duration, side):
                 'right' : lambda t: (max(0,w*(1-t/duration)),'center'),
                 'top' : lambda t: ('center',min(0,h*(t/duration-1))),
                 'bottom': lambda t: ('center',max(0,h*(1-t/duration)))}
-    
+
     return clip.set_pos( pos_dict[side] )
 
 
@@ -83,7 +83,7 @@ def slide_out(clip, duration, side):
 
     Parameters
     ===========
-    
+
     clip
       A video clip.
 
@@ -93,10 +93,10 @@ def slide_out(clip, duration, side):
     side
       Side of the screen where the clip goes. One of
       'top' | 'bottom' | 'left' | 'right'
-    
+
     Examples
     =========
-    
+
     >>> from moviepy.editor import *
     >>> clips = [... make a list of clips]
     >>> slided_clips = [clip.fx( transfx.slide_out, 1, 'bottom')
@@ -106,12 +106,12 @@ def slide_out(clip, duration, side):
     """
 
     w,h = clip.size
-    t_s = clip.duration - duration # start time of the effect.
+    ts = clip.duration - duration # start time of the effect.
     pos_dict = {'left' : lambda t: (min(0,w*(1-(t-ts)/duration)),'center'),
                 'right' : lambda t: (max(0,w*((t-ts)/duration-1)),'center'),
                 'top' : lambda t: ('center',min(0,h*(1-(t-ts)/duration))),
                 'bottom': lambda t: ('center',max(0,h*((t-ts)/duration-1))) }
-    
+
     return clip.set_pos( pos_dict[side] )
 
 
@@ -119,7 +119,7 @@ def slide_out(clip, duration, side):
 def make_loopable(clip, cross_duration):
     """ Makes the clip fade in progressively at its own end, this way
     it can be looped indefinitely. ``cross`` is the duration in seconds
-    of the fade-in.  """  
+    of the fade-in.  """
     d = clip.duration
     clip2 = clip.fx(crossfadein, cross_duration).\
                  set_start(d - cross_duration)


### PR DESCRIPTION
Fixed a typo in the slide_out transition, also cleaned up a little bit of whitespace in the file. I'm not sure if this actually works, but figured it was an easy fix.

Signed-off-by: Ken Cochrane <kencochrane@gmail.com>