### PR TITLE
Docs fixes: added code back into logo example and fixed a couple of typos

### DIFF
--- a/docs/examples/logo.rst
+++ b/docs/examples/logo.rst
@@ -6,3 +6,8 @@ MoviePy logo with a moving shadow
         <div style="position: relative; padding-bottom: 56.25%; padding-top: 30px; margin-bottom:30px; height: 0; overflow: hidden; margin-left: 5%;"><iframe type="text/html" src="https://www.youtube.com/embed/TG86KzL18NA" frameborder="0" style="position: absolute; top: 0; bottom: 10; width: 90%; height: 100%;" allowfullscreen></iframe></div>
 
 Here the logo is a picture, while the shadow is actually a black rectangle taking the whole screen, overlaid over the logo, but with a moving mask composed of a bi-gradient, such that only one (moving) part of the rectangle is visible.
+
+
+And here is the code:
+
+.. literalinclude:: ../../examples/logo.py

--- a/docs/getting_started/videoclips.rst
+++ b/docs/getting_started/videoclips.rst
@@ -30,7 +30,7 @@ In this section we see how to create clips, (for instance from video or audio fi
 Categories of video clips
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Video clips are the building blocks of longer videos. Technically, they are clips with a ``clip.get_frame(t)`` method which outputs a HxWx3 numpy array representing the frame of the clip at time *t*. There are two main categories: animated clips (made with ``VideoFileClip`` and ``VideoClip``) and unanimated clips which show the same picture for an a-priori infinite duration (``ImageClip``, ``TextClip``,``ColorClip``). There are also special video clips call masks, which belong to the categories above but output greyscale frames indicating which parts of another clip are visible or not. A video clip can carry around an audio clip (``clip.audio``) which is its *soundtrack*, and a mask clip.
+Video clips are the building blocks of longer videos. Technically, they are clips with a ``clip.get_frame(t)`` method which outputs a HxWx3 numpy array representing the frame of the clip at time *t*. There are two main categories: animated clips (made with ``VideoFileClip`` and ``VideoClip``) and unanimated clips which show the same picture for an a-priori infinite duration (``ImageClip``, ``TextClip``, ``ColorClip``). There are also special video clips call masks, which belong to the categories above but output greyscale frames indicating which parts of another clip are visible or not. A video clip can carry around an audio clip (``clip.audio``) which is its *soundtrack*, and a mask clip.
 
 VideoClip
 """"""""""
@@ -54,7 +54,7 @@ VideoClip
    :width: 128 px
    :align: center
 
-Note that clips make with a `make_frame` do not have an explicit frame rate, so you must provide a frame rate (``fps``, frames er second) for ``write_gif`` and ``write_videofile``, and more generally for any methods that requires iterating through the frames.
+Note that clips made with a `make_frame` do not have an explicit frame rate, so you must provide a frame rate (``fps``, frames er second) for ``write_gif`` and ``write_videofile``, and more generally for any methods that requires iterating through the frames.
 
 VideoFileClip
 """""""""""""""


### PR DESCRIPTION
I fixed a few things in the docs that I noticed were wrong.
- added the code back into the logo example
- there was a formatting error for ``ColorClip`` that was causing the quotes to appear
- there was a typo make->made

It is important to note that the logo example code doesn't actually work, I was going to fix it, but I don't know how. Maybe that was why it wasn't shown on the logo example page?

Signed-off-by: Ken Cochrane <kencochrane@gmail.com>