### PR TITLE
Removed Hz from audio_fps match in ffmpeg_parse_infos

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -385,7 +385,7 @@ def ffmpeg_parse_infos(filename, print_infos=False, check_duration=True,
         line = lines_audio[0]
         try:
             match = re.search(" [0-9]* Hz", line)
-            hz_string = line[match.start()+1:match.end()-3]
+            hz_string = line[match.start()+1:match.end()-3]  # Removes the 'hz' from the end
             result['audio_fps'] = int(hz_string)
         except:
             result['audio_fps'] = 'unknown'

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -385,7 +385,7 @@ def ffmpeg_parse_infos(filename, print_infos=False, check_duration=True,
         line = lines_audio[0]
         try:
             match = re.search(" [0-9]* Hz", line)
-            result['audio_fps'] = int(line[match.start()+1:match.end()])
+            result['audio_fps'] = int(line[match.start()+1:match.end()-3])
         except:
             result['audio_fps'] = 'unknown'
 

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -385,7 +385,8 @@ def ffmpeg_parse_infos(filename, print_infos=False, check_duration=True,
         line = lines_audio[0]
         try:
             match = re.search(" [0-9]* Hz", line)
-            result['audio_fps'] = int(line[match.start()+1:match.end()-3])
+            hz_string = line[match.start()+1:match.end()-3]
+            result['audio_fps'] = int(hz_string)
         except:
             result['audio_fps'] = 'unknown'
 

--- a/tests/test_ffmpeg_reader.py
+++ b/tests/test_ffmpeg_reader.py
@@ -21,6 +21,15 @@ def test_ffmpeg_parse_infos():
     d=ffmpeg_parse_infos("media/pigs_in_a_polka.gif")
     assert d['video_size'] == [314, 273]
     assert d['duration'] == 3.0
+    assert not d['audio_found']
+
+    d=ffmpeg_parse_infos("media/video_with_failing_audio.mp4")
+    assert d['audio_found']
+    assert d['audio_fps'] == 44100
+
+    d=ffmpeg_parse_infos("media/crunching.mp3")
+    assert d['audio_found']
+    assert d['audio_fps'] == 48000
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Cuts the ' Hz' off of the regex match when trying to find the fps info of an audio stream.

Previously, this was always setting `result['audio_fps']` to `'unknown'` because the casting to an integer would fail. 