### PR TITLE
Convert named lambda functions into defined functions

### DIFF
--- a/examples/logo.py
+++ b/examples/logo.py
@@ -19,7 +19,7 @@ logo = ImageClip("../../videos/logo_descr.png").\
 screen = logo.on_color(moviesize, color = (0,0,0), pos='center')
 
 shade = ColorClip(moviesize,col=(0,0,0))
-mask_frame = lambda t : f(t,moviesize,duration)
+def mask_frame(t): return f(t,moviesize,duration)
 shade.mask = VideoClip(ismask=True, get_frame = mask_frame)
                     
 cc = CompositeVideoClip([im.set_pos(2*["center"]),shade],

--- a/examples/moving_letters.py
+++ b/examples/moving_letters.py
@@ -14,32 +14,36 @@ cvc = CompositeVideoClip( [txtClip.set_pos('center')],
 
 
 # helper function
-rotMatrix = lambda a: np.array( [[np.cos(a),np.sin(a)], 
-                                 [-np.sin(a),np.cos(a)]] )
+def rotMatrix(a): np.array( [[np.cos(a),np.sin(a)],
+                            [-np.sin(a),np.cos(a)]] )
 
 def vortex(screenpos,i,nletters):
-    d = lambda t : 1.0/(0.3+t**8) #damping
+    def d(t): return 1.0/(0.3+t**8) #damping
     a = i*np.pi/ nletters # angle of the movement
     v = rotMatrix(a).dot([-1,0])
     if i%2 : v[1] = -v[1]
-    return lambda t: screenpos+400*d(t)*rotMatrix(0.5*d(t)*a).dot(v)
+    def closure(t): return screenpos+400*d(t)*rotMatrix(0.5*d(t)*a).dot(v)
+    return closure
     
 def cascade(screenpos,i,nletters):
     v = np.array([0,-1])
-    d = lambda t : 1 if t<0 else abs(np.sinc(t)/(1+t**4))
-    return lambda t: screenpos+v*400*d(t-0.15*i)
+    def d(t): return 1 if t<0 else abs(np.sinc(t)/(1+t**4))
+    def closure(t): return screenpos+v*400*d(t-0.15*i)
+    return closure
 
 def arrive(screenpos,i,nletters):
     v = np.array([-1,0])
-    d = lambda t : max(0, 3-3*t)
-    return lambda t: screenpos-400*v*d(t-0.2*i)
+    def d(t): return max(0, 3-3*t)
+    def closure(t): return screenpos-400*v*d(t-0.2*i)
+    return closure
     
 def vortexout(screenpos,i,nletters):
-    d = lambda t : max(0,t) #damping
+    def d(t): return max(0,t) #damping
     a = i*np.pi/ nletters # angle of the movement
     v = rotMatrix(a).dot([-1,0])
     if i%2 : v[1] = -v[1]
-    return lambda t: screenpos+400*d(t-0.1*i)*rotMatrix(-0.2*d(t)*a).dot(v)
+    def closure(t): return screenpos+400*d(t-0.1*i)*rotMatrix(-0.2*d(t)*a).dot(v)
+    return closure
 
 
 

--- a/examples/star_worms.py
+++ b/examples/star_worms.py
@@ -54,7 +54,7 @@ clip_txt = TextClip(txt,color='white', align='West',fontsize=25,
 # SCROLL THE TEXT IMAGE BY CROPPING A MOVING AREA
 
 txt_speed = 27
-fl = lambda gf,t : gf(t)[int(txt_speed*t):int(txt_speed*t)+h,:]
+def fl(gf, t): return gf(t)[int(txt_speed*t):int(txt_speed*t)+h,:]
 moving_txt= clip_txt.fl(fl, apply_to=['mask'])
 
 
@@ -63,7 +63,7 @@ moving_txt= clip_txt.fl(fl, apply_to=['mask'])
 grad = color_gradient(moving_txt.size,p1=(0,2*h/3),
                 p2=(0,h/4),col1=0.0,col2=1.0)
 gradmask = ImageClip(grad,ismask=True)
-fl = lambda pic : np.minimum(pic,gradmask.img)
+def fl(pic): return np.minimum(pic,gradmask.img)
 moving_txt.mask = moving_txt.mask.fl_image(fl)
 
 
@@ -79,8 +79,8 @@ def trapzWarp(pic,cx,cy,ismask=False):
     im = tf.warp(pic, tform.inverse, output_shape=(Y,X))
     return im if ismask else (im*255).astype('uint8')
 
-fl_im = lambda pic : trapzWarp(pic,0.2,0.3)
-fl_mask = lambda pic : trapzWarp(pic,0.2,0.3, ismask=True)
+def fl_im(pic): return trapzWarp(pic,0.2,0.3)
+def fl_mask(pic): return trapzWarp(pic,0.2,0.3, ismask=True)
 warped_txt= moving_txt.fl_image(fl_im)
 warped_txt.mask = warped_txt.mask.fl_image(fl_mask)
 

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -127,7 +127,7 @@ class Clip:
         content scrolls from the top to the bottom of the frames of
         ``clip``.
 
-        >>> fl = lambda gf,t : gf(t)[int(t):int(t)+50, :]
+        >>> def fl(gf, t): return gf(t)[int(t):int(t)+50, :]
         >>> newclip = clip.fl(fl, apply_to='mask')
 
         """
@@ -435,7 +435,7 @@ class Clip:
         if they exist.
         """
 
-        fl = lambda t: t + (t >= ta)*(tb - ta)
+        def fl(t): return t + (t >= ta)*(tb - ta)
         newclip = self.fl_time(fl)
 
         if self.duration is not None:

--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -36,7 +36,7 @@ class AudioClip(Clip):
     
     >>> # Plays the note A (a sine wave of frequency 404HZ)
     >>> import numpy as np
-    >>> make_frame = lambda t : 2*[ np.sin(404 * 2 * np.pi * t) ]
+    >>> def make_frame(t): return 2*[ np.sin(404 * 2 * np.pi * t) ]
     >>> clip = AudioClip(make_frame, duration=5)
     >>> clip.preview()
                      

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -588,7 +588,7 @@ class VideoClip(Clip):
             mask = ColorClip(self.size, 1.0, ismask=True)
             return self.set_mask(mask.set_duration(self.duration))
         else:
-            make_frame = lambda t: np.ones(self.get_frame(t).shape[:2], dtype=float)
+            def make_frame(t): return np.ones(self.get_frame(t).shape[:2], dtype=float)
             mask = VideoClip(ismask=True, make_frame=make_frame)
             return self.set_mask(mask.set_duration(self.duration))
 
@@ -744,7 +744,7 @@ class VideoClip(Clip):
     def to_RGB(self):
         """Return a non-mask video clip made from the mask video clip."""
         if self.ismask:
-            f = lambda pic: np.dstack(3 * [255 * pic]).astype('uint8')
+            def f(pic): return np.dstack(3 * [255 * pic]).astype('uint8')
             newclip = self.fl_image(f)
             newclip.ismask = False
             return newclip
@@ -798,7 +798,7 @@ class DataVideoClip(VideoClip):
         self.data = data
         self.data_to_frame = data_to_frame
         self.fps=fps
-        make_frame = lambda t: self.data_to_frame( self.data[int(self.fps*t)])
+        def make_frame(t): return self.data_to_frame( self.data[int(self.fps*t)])
         VideoClip.__init__(self, make_frame, ismask=ismask,
                duration=1.0*len(data)/fps, has_constant_size=has_constant_size)
 

--- a/moviepy/video/fx/accel_decel.py
+++ b/moviepy/video/fx/accel_decel.py
@@ -12,8 +12,8 @@ def f_accel_decel(t, old_d, new_d, abruptness=1, soonness=1.0):
     
     a = 1.0+abruptness
     def _f(t):
-        f1 = lambda t: (0.5)**(1-a)*(t**a)
-        f2 = lambda t: (1-f1(1-t))
+        def f1(t): return (0.5)**(1-a)*(t**a)
+        def f2(t): return (1-f1(1-t))
         return (t<.5)*f1(t) + (t>=.5)*f2(t) 
     
     return old_d*_f((t/new_d)**soonness)
@@ -38,7 +38,7 @@ def accel_decel(clip, new_duration=None, abruptness=1.0, soonness=1.0):
     if new_duration is None:
         new_duration = clip.duration
     
-    fl = lambda t : f_accel_decel(t, clip.duration, new_duration,
+    def fl(t): return f_accel_decel(t, clip.duration, new_duration,
                                    abruptness, soonness)
 
     return clip.fl_time(fl).set_duration(new_duration)

--- a/moviepy/video/fx/even_size.py
+++ b/moviepy/video/fx/even_size.py
@@ -14,11 +14,11 @@ def even_size(clip):
         return clip
     
     if (w%2 != 0) and (h%2!=0):
-        fl_image = lambda a : a[:-1,:-1,:]
+        def fl_image(a): return a[:-1,:-1,:]
     elif (w%2 != 0):
-        fl_image = lambda a : a[:,:-1,:]
+        def fl_image(a): return a[:,:-1,:]
     else:
-        fl_image = lambda a : a[:-1,:,:]
+        def fl_image(a): return a[:-1,:,:]
 
     return clip.fl_image(fl_image)
 

--- a/moviepy/video/fx/mask_color.py
+++ b/moviepy/video/fx/mask_color.py
@@ -16,9 +16,9 @@ def mask_color(clip, color=None, thr=0, s=1):
         color = [0,0,0]
 
     # code a little sloppy, it just works.
-    hill = lambda x: (1.0*(x!=0) if (thr==0) else (x**s/ (thr**s+x**s)))
+    def hill(x): return (1.0*(x!=0) if (thr==0) else (x**s/ (thr**s+x**s)))
     color = np.array(color)
-    flim = lambda im: hill(np.sqrt(((im-color)**2).sum(axis=2)))
+    def flim(im): return hill(np.sqrt(((im-color)**2).sum(axis=2)))
     mask = clip.fl_image(flim)
     mask.ismask= True
     newclip = clip.set_mask(mask)

--- a/moviepy/video/fx/resize.py
+++ b/moviepy/video/fx/resize.py
@@ -45,7 +45,7 @@ except ImportError:
         # TRY USING SCIPY AS RESIZER
         try:
             from scipy.misc import imresize
-            resizer = lambda pic, newsize : imresize(pic,
+            def resizer(pic, newsize): return imresize(pic,
                                             map(int, newsize[::-1]))
             resizer.origin = "Scipy"
                                                
@@ -102,15 +102,15 @@ def resize(clip, newsize=None, height=None, width=None, apply_to_mask=True):
                 
         if hasattr(newsize, "__call__"):
             
-            newsize2 = lambda t : trans_newsize(newsize(t))
+            def newsize2(t): return trans_newsize(newsize(t))
             
             if clip.ismask:
                 
-                fun = lambda gf,t: (1.0*resizer((255 * gf(t)).astype('uint8'),
+                def fun(gf, t): return (1.0*resizer((255 * gf(t)).astype('uint8'),
                                                  newsize2(t))/255)
             else:
                 
-                fun = lambda gf,t: resizer(gf(t).astype('uint8'),
+                def fun(gf, t): return resizer(gf(t).astype('uint8'),
                                           newsize2(t))
                 
             return clip.fl(fun, keep_duration=True,
@@ -124,7 +124,7 @@ def resize(clip, newsize=None, height=None, width=None, apply_to_mask=True):
     elif height is not None:
         
         if hasattr(height, "__call__"):
-            fun = lambda t : 1.0*int(height(t))/h
+            def fun(t): return 1.0*int(height(t))/h
             return resize(clip, fun)
 
 
@@ -135,7 +135,7 @@ def resize(clip, newsize=None, height=None, width=None, apply_to_mask=True):
     elif width is not None:
 
         if hasattr(width, "__call__"):
-            fun = lambda t : 1.0*width(t)/w
+            def fun(t): return 1.0*width(t)/w
             return resize(clip, fun)
         
         newsize = [width, h * width / w]
@@ -144,10 +144,10 @@ def resize(clip, newsize=None, height=None, width=None, apply_to_mask=True):
     # From here, the resizing is constant (not a function of time), size=newsize
 
     if clip.ismask:
-        fl = lambda pic: 1.0*resizer((255 * pic).astype('uint8'), newsize)/255.0
+        def fl(pic): return 1.0*resizer((255 * pic).astype('uint8'), newsize)/255.0
             
     else:
-        fl = lambda pic: resizer(pic.astype('uint8'), newsize)
+        def fl(pic): return resizer(pic.astype('uint8'), newsize)
 
     newclip = clip.fl_image(fl)
 

--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -43,7 +43,7 @@ def rotate(clip, angle, unit='deg', resample="bicubic", expand=True):
     if not hasattr(angle, '__call__'):
         # if angle is a constant, convert to a constant function
         a = +angle
-        angle = lambda t: a
+        def angle(t): return a
 
     transpo = [1,0] if clip.ismask else [1,0,2]
 

--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -102,7 +102,7 @@ class VideoFileClip(VideoClip):
         if has_mask:
 
             self.make_frame = lambda t: self.reader.get_frame(t)[:,:,:3]
-            mask_mf =  lambda t: self.reader.get_frame(t)[:,:,3]/255.0
+            def mask_mf(t): return self.reader.get_frame(t)[:,:,3]/255.0
             self.mask = (VideoClip(ismask = True, make_frame = mask_mf)
                        .set_duration(self.duration))
             self.mask.fps = self.fps

--- a/moviepy/video/tools/cuts.py
+++ b/moviepy/video/tools/cuts.py
@@ -10,7 +10,7 @@ def find_video_period(clip,fps=None,tmin=.3):
     """ Finds the period of a video based on frames correlation """
     
 
-    frame = lambda t: clip.get_frame(t).flatten()
+    def frame(t): return clip.get_frame(t).flatten()
     tt = np.arange(tmin,clip.duration,1.0/ fps)[1:]
     ref = frame(0)
     corrs = [ np.corrcoef(ref, frame(t))[0,1] for t in tt]
@@ -137,7 +137,7 @@ class FramesMatches(list):
         """ 
         
         N_pixels = clip.w * clip.h * 3
-        dot_product = lambda F1, F2: (F1*F2).sum()/N_pixels
+        def dot_product(F1, F2): return (F1*F2).sum()/N_pixels
         F = {} # will store the frames and their mutual distances
         
         def distance(t1, t2):

--- a/moviepy/video/tools/subtitles.py
+++ b/moviepy/video/tools/subtitles.py
@@ -25,7 +25,7 @@ class SubtitlesClip(VideoClip):
     
     >>> from moviepy.video.tools.subtitles import SubtitlesClip
     >>> from moviepy.video.io.VideoFileClip import VideoFileClip
-    >>> generator = lambda txt: TextClip(txt, font='Georgia-Regular', fontsize=24, color='white')
+    >>> def generator(txt): return TextClip(txt, font='Georgia-Regular', fontsize=24, color='white')
     >>> sub = SubtitlesClip("subtitles.srt", generator)
     >>> myvideo = VideoFileClip("myvideo.avi")
     >>> final = CompositeVideoClip([clip, subtitles])
@@ -45,7 +45,7 @@ class SubtitlesClip(VideoClip):
         self.textclips = dict()
 
         if make_textclip is None:
-            make_textclip = lambda txt: TextClip(txt, font='Georgia-Bold',
+            def make_textclip(txt): return TextClip(txt, font='Georgia-Bold',
                                         fontsize=24, color='white',
                                         stroke_color='black', stroke_width=0.5)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -35,7 +35,7 @@ def test_subtitles():
     if TRAVIS:
        return
 
-    generator = lambda txt: TextClip(txt, font=FONT,
+    def generator(txt): return TextClip(txt, font=FONT,
                                      size=(800,600), fontsize=24,
                                      method='caption', align='South',
                                      color='white')


### PR DESCRIPTION
http://pep8.org/ says:

> Always use a def statement instead of an assignment statement that binds a lambda expression directly to an identifier.
> 
> Yes:
> 
> `def f(x): return 2*x`
> 
> No:
> 
> `f = lambda x: 2*x`
> 
> The first form means that the name of the resulting function object is specifically `f` instead of the generic `<lambda>`. This is more useful for tracebacks and string representations in general. The use of the assignment statement eliminates the sole benefit a lambda expression can offer over an explicit def statement (i.e. that it can be embedded inside a larger expression)