### PR TITLE
Use input seeking in ffmpeg_extract_subclip, not output seeking

### DIFF
--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -33,8 +33,8 @@ def ffmpeg_extract_subclip(filename, t1, t2, targetname=None):
         targetname = name+ "%sSUB%d_%d.%s"(name, T1, T2, ext)
     
     cmd = [get_setting("FFMPEG_BINARY"),"-y",
-      "-i", filename,
       "-ss", "%0.2f"%t1,
+      "-i", filename,
       "-t", "%0.2f"%(t2-t1),
       "-vcodec", "copy", "-acodec", "copy", targetname]
     


### PR DESCRIPTION
`ffmpeg_extract_subclip` should not decode the frames preceding the start of the desired subclip, as this is slow. Input seeking makes more sense here than output seeking. See [seeking (ffmpeg wiki)](https://trac.ffmpeg.org/wiki/Seeking).