### PR TITLE
bug fix in resize method for a clip with mask

### DIFF
--- a/moviepy/video/fx/resize.py
+++ b/moviepy/video/fx/resize.py
@@ -111,7 +111,7 @@ def resize(clip, newsize=None, height=None, width=None, apply_to_mask=True):
             else:
                 
                 fun = lambda gf,t: resizer(gf(t).astype('uint8'),
-                                          newsize2(t))
+                                          newsize2(t)) if len(gf(t).shape) == 3 else 1.0*resizer((gf(t)*255).astype('uint8'),newsize2(t))/255
                 
             return clip.fl(fun, keep_duration=True,
                            apply_to= (["mask"] if apply_to_mask else []))


### PR DESCRIPTION
I had previously reported an issue regarding the **bug in resize method for clips with mask** #640 .
I figured out the fix by reading fl method in Clip.py. 

Lambda function ( in original code ) on line 113 in resize.py is treating RGB image frame and mask frame in same manner. RGB image frame has it's values in range [0,255] while for a mask frame they are in range [0.0,1.0]. Applying uint8() on mask frame floors all values to 0 (and that is exactly the bug). 

I tried fixing the bug by checking the shape of frame returned by **get_frame** method. 
1. (gf(t)*255).astype('uint8')  makes it a valid opencv image (numpy uint8 image)
2. Then it is resized to newsize2.
3. Dividing the result by 255 brings the values back in range [0.0, 1.0]. 

Hope this helps!

Tejas