### PR TITLE
 Fix stretched vertical video, add ability to disable autorotate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "3.6"
 
 before_install:
-  - sudo add-apt-repository -y ppa:kirillshkrogalev/ffmpeg-next
+  - sudo add-apt-repository -y ppa:mc3man/trusty-media
   - sudo apt-get -y -qq update
   - sudo apt-get install -y -qq ffmpeg
   - mkdir media

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -8,6 +8,7 @@ import os
 import subprocess as sp
 import tempfile
 import warnings
+from functools import partial
 
 import numpy as np
 from imageio import imread, imsave
@@ -882,6 +883,10 @@ class ImageClip(VideoClip):
       Set this parameter to `True` (default) if you want the alpha layer
       of the picture (if it exists) to be used as a mask.
 
+    imageio_params
+      Any additional imageio parameters to pass when reading files, as a dict.
+      ex: {'exifrotate': False}
+
     Attributes
     -----------
 
@@ -891,15 +896,18 @@ class ImageClip(VideoClip):
     """
 
     def __init__(self, img, ismask=False, transparent=True,
-                 fromalpha=False, duration=None):
+                 fromalpha=False, duration=None, imageio_params=None):
         VideoClip.__init__(self, ismask=ismask, duration=duration)
+
+        imageio_params = imageio_params or {}
+        _imread = partial(imread, **imageio_params)
 
         if PY3:
            if isinstance(img, str):
-              img = imread(img)
+              img = _imread(img)
         else:
            if isinstance(img, (str, unicode)):
-              img = imread(img)
+              img = _imread(img)
 
         if len(img.shape) == 3:  # img is (now) a RGB(a) numpy array
 

--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -51,6 +51,10 @@ class VideoFileClip(VideoClip):
       can be set to 'fps', which may be helpful if importing slow-motion videos
       that get messed up otherwise.
 
+    ffmpeg_params:
+      Any additional ffmpeg parameters to pass when reading files, as a list of
+      terms, like ['-noautorotate'].
+
 
     Attributes
     -----------
@@ -60,6 +64,9 @@ class VideoFileClip(VideoClip):
 
     fps:
       Frames per second in the original file.
+
+    rotation:
+      Rotation metadata, in degrees.
     
     
     Read docs for Clip() and VideoClip() for other, more generic, attributes.
@@ -78,7 +85,7 @@ class VideoFileClip(VideoClip):
                  audio=True, audio_buffersize = 200000,
                  target_resolution=None, resize_algorithm='bicubic',
                  audio_fps=44100, audio_nbytes=2, verbose=False,
-                 fps_source='tbr'):
+                 fps_source='tbr', ffmpeg_params=None):
 
         VideoClip.__init__(self)
 
@@ -87,7 +94,8 @@ class VideoFileClip(VideoClip):
         self.reader = FFMPEG_VideoReader(filename, pix_fmt=pix_fmt,
                                          target_resolution=target_resolution,
                                          resize_algo=resize_algorithm,
-                                         fps_source=fps_source)
+                                         fps_source=fps_source,
+                                         ffmpeg_params=ffmpeg_params)
 
         # Make some of the reader's attributes accessible from the clip
         self.duration = self.reader.duration

--- a/tests/download_media.py
+++ b/tests/download_media.py
@@ -30,7 +30,8 @@ def download():
             '/sounds/crunching.mp3', '/images/pigs_in_a_polka.gif',
             '/videos/fire2.mp4', '/videos/big_buck_bunny_0_30.webm',
             '/subtitles/subtitles1.srt', '/misc/traj.txt',
-            '/images/vacation_2017.jpg', '/images/python_logo_upside_down.png']
+            '/images/vacation_2017.jpg', '/images/python_logo_upside_down.png',
+            '/videos/ficus_vertical.mp4']
 
     # Loop through download url strings, build out path, and download the asset.
     for url in urls:

--- a/tests/download_media.py
+++ b/tests/download_media.py
@@ -31,7 +31,7 @@ def download():
             '/videos/fire2.mp4', '/videos/big_buck_bunny_0_30.webm',
             '/subtitles/subtitles1.srt', '/misc/traj.txt',
             '/images/vacation_2017.jpg', '/images/python_logo_upside_down.png',
-            '/videos/ficus_vertical.mp4']
+            '/videos/ficus_vertical.mp4', '/images/balloons_portrait.jpg']
 
     # Loop through download url strings, build out path, and download the asset.
     for url in urls:

--- a/tests/test_ImageClip.py
+++ b/tests/test_ImageClip.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Image clip tests meant to be run with pytest."""
+import sys
+
+import pytest
+from moviepy.video.VideoClip import ImageClip
+
+sys.path.append("tests")
+
+import download_media
+
+
+def test_download_media(capsys):
+    with capsys.disabled():
+       download_media.download()
+
+def test_exifrotate():
+    image_file = 'media/balloons_portrait.jpg'
+    with ImageClip(image_file, duration=1) as clip:
+        assert clip.img.meta['EXIF_MAIN']['ExifImageWidth'] == 4032
+        assert clip.img.meta['EXIF_MAIN']['ExifImageHeight'] == 3024
+        assert clip.img.meta['EXIF_MAIN']['Orientation'] == 6
+        assert clip.size == (3024, 4032)
+
+    with ImageClip(image_file, duration=1, 
+                   imageio_params={'exifrotate': False}) as clip:
+        assert clip.size == (4032, 3024)
+
+
+if __name__ == '__main__':
+   pytest.main()

--- a/tests/test_ImageSequenceClip.py
+++ b/tests/test_ImageSequenceClip.py
@@ -41,6 +41,19 @@ def test_2():
     with pytest.raises(Exception, message='Expecting Exception'):
          ImageSequenceClip(images, durations=durations).close()
 
+def test_exifrotate():
+    image_file = 'media/balloons_portrait.jpg'
+    with ImageSequenceClip([image_file], fps=1) as clip:
+        frame = clip.get_frame(0)
+        assert frame.meta['EXIF_MAIN']['ExifImageWidth'] == 4032
+        assert frame.meta['EXIF_MAIN']['ExifImageHeight'] == 3024
+        assert frame.meta['EXIF_MAIN']['Orientation'] == 6
+        assert clip.size == (3024, 4032)
+
+    with ImageSequenceClip([image_file], fps=1,
+                           imageio_params={'exifrotate': False}) as clip:
+        assert clip.size == (4032, 3024)
+
 
 if __name__ == '__main__':
    pytest.main()

--- a/tests/test_VideoFileClip.py
+++ b/tests/test_VideoFileClip.py
@@ -56,6 +56,19 @@ def test_ffmpeg_resizing():
         frame = video.get_frame(0)
         assert frame.shape[1] == target_resolution[1]
 
+def test_ffmpeg_resizing_with_autorotate():
+    # This test requires ffmpeg >=2.7
+    video_file = 'media/ficus_vertical.mp4'
+    target_resolution=(720, None)
+    with VideoFileClip(video_file, target_resolution=target_resolution) as video:
+        frame = video.get_frame(0)
+        assert frame.shape[0:2] == (720, 405)
+
+    with VideoFileClip(video_file, target_resolution=target_resolution,
+                       ffmpeg_params=['-noautorotate']) as video:
+        frame = video.get_frame(0)
+        assert frame.shape[0:2] == (720, 1280)
+
 
 if __name__ == '__main__':
    pytest.main()

--- a/tests/test_ffmpeg_reader.py
+++ b/tests/test_ffmpeg_reader.py
@@ -3,11 +3,11 @@
 import sys
 
 import pytest
-from moviepy.video.io.ffmpeg_reader import ffmpeg_parse_infos
-
-import download_media
+from moviepy.video.io.ffmpeg_reader import ffmpeg_parse_infos, FFMPEG_VideoReader
 
 sys.path.append("tests")
+
+import download_media
 
 
 def test_download_media(capsys):
@@ -21,6 +21,20 @@ def test_ffmpeg_parse_infos():
     d=ffmpeg_parse_infos("media/pigs_in_a_polka.gif")
     assert d['video_size'] == [314, 273]
     assert d['duration'] == 3.0
+
+def test_autorotate():
+    # This test requires ffmpeg >=2.7
+    video_file = 'media/ficus_vertical.mp4'
+    reader = FFMPEG_VideoReader(video_file)
+    assert reader.infos['video_size'] == [1920, 1080]
+    assert reader.infos['video_rotation'] == 90
+    assert reader.size == [1080, 1920]
+    reader.close()
+
+    reader = FFMPEG_VideoReader(video_file, ffmpeg_params=['-noautorotate'])
+    assert reader.size == [1920, 1080]
+    assert reader.rotation == 90
+    reader.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes stretched video from issue #682, and adds the ability to disable autorotate for VideoFileClip, ImageClip, and ImageSequenceClip.

VideoFileClip now has an ffmpeg_params argument, and setting it to `['-noautorotate']` will disable autorotation. ImageClip and ImageSequenceClip now have an imageio_params argument. Use `{'exifrotate': False}` to disable autorotation.

I've updated the version of ffmpeg used on Travis from 2.4.3 to 3.3.3 by changing the apt repo. The [new one](https://launchpad.net/~mc3man/+archive/ubuntu/trusty-media) comes from http://ffmpeg.org/download.html. I did this because the tests for autorotate require ffmpeg >=2.7. If it's better to keep the older version, I could skip the tests instead.

Thanks to @taddyhuo for laying the groundwork for this in #529. And thanks to @bobatsar for his work in #577, which started me on this path. Also, thanks to the moviepy maintainers for the excellent project organization. :)

EDIT: I pushed new commits since I opened this PR.