### PR TITLE
Fixed ffmpeg clipped video results in few seconds of black / white screen on start.

### DIFF
--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -33,10 +33,10 @@ def ffmpeg_extract_subclip(filename, t1, t2, targetname=None):
         targetname = name+ "%sSUB%d_%d.%s"(name, T1, T2, ext)
     
     cmd = [get_setting("FFMPEG_BINARY"),"-y",
-      "-i", filename,
       "-ss", "%0.2f"%t1,
       "-t", "%0.2f"%(t2-t1),
-      "-vcodec", "copy", "-acodec", "copy", targetname]
+      "-i", filename,
+      "-vcodec", "copy", "-acodec", "copy", "-avoid_negative_ts", "make_zero", targetname]
     
     subprocess_call(cmd)
 


### PR DESCRIPTION
I tested clip a mp4 format video and the subclip will show white screen in 1~3 seconds on start. This will make some video player can't play the video then crash. The reason is most videos use codecs which perform temporal compression, so a specified cutpoint may rely on frames before (and after) that cutpoint to be correctly decoded. If using FFmpeg to clip the video with copy mode (argument vcodec and acodec), you should include all frames before and after the trimmed segment, which make decoder decode the segment correctly. [ref. [Mulvya](https://video.stackexchange.com/a/18285)]
So in the argument we should add "-avoid_negative_ts make_zero", I tested on the normal version and ffmpeg.osx (download by imageio.plugins.ffmpeg.download()) shows the same result, with the "-avoid_negative_ts make_zero" the video will produced correctly.
