### PR TITLE
Added ffmpeg download when importing moviepy.editor

### DIFF
--- a/moviepy/editor.py
+++ b/moviepy/editor.py
@@ -17,6 +17,8 @@ clip.preview().
 # Note that these imports could have been performed in the __init__.py
 # file, but this would make the loading of moviepy slower.
 
+import os
+
 # Downloads ffmpeg if it isn't already installed
 import imageio
 # Checks to see if the user has set a place for their own version of ffmpeg

--- a/moviepy/editor.py
+++ b/moviepy/editor.py
@@ -17,8 +17,11 @@ clip.preview().
 # Note that these imports could have been performed in the __init__.py
 # file, but this would make the loading of moviepy slower.
 
-# Clips
+# Downloads ffmpeg if it isn't already installed
+import imageio
+imageio.plugins.ffmpeg.download()
 
+# Clips
 from .video.io.VideoFileClip import VideoFileClip
 from .video.io.ImageSequenceClip import ImageSequenceClip
 from .video.io.downloader import download_webfile

--- a/moviepy/editor.py
+++ b/moviepy/editor.py
@@ -19,7 +19,9 @@ clip.preview().
 
 # Downloads ffmpeg if it isn't already installed
 import imageio
-imageio.plugins.ffmpeg.download()
+# Checks to see if the user has set a place for their own version of ffmpeg
+if os.getenv('FFMPEG_BINARY', 'ffmpeg-imageio') == 'ffmpeg-imageio':
+    imagio.plugins.ffmpeg.downlad()
 
 # Clips
 from .video.io.VideoFileClip import VideoFileClip

--- a/moviepy/editor.py
+++ b/moviepy/editor.py
@@ -23,7 +23,7 @@ import os
 import imageio
 # Checks to see if the user has set a place for their own version of ffmpeg
 if os.getenv('FFMPEG_BINARY', 'ffmpeg-imageio') == 'ffmpeg-imageio':
-    imagio.plugins.ffmpeg.downlad()
+    imageio.plugins.ffmpeg.download()
 
 # Clips
 from .video.io.VideoFileClip import VideoFileClip


### PR DESCRIPTION
See discussion in #493. Calling `imagio.plugins.ffmpeg.downlad()` doesn't install ffmpeg if it is already installed somewhere on the system.