### PR TITLE
Make TextClip work on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ before_install:
   - pip install --upgrade py pytest
   
   # modify ImageMagick policy file so that Textclips work correctly.
-  - sudo cat /etc/ImageMagick/policy.xml # | sed 's/none/read,write/g'> /etc/ImageMagick/policy.xml
+  - cat /etc/ImageMagick/policy.xml
+  - sudo cat /etc/ImageMagick/policy.xml | sudo sed 's/none/read,write/g'> /etc/ImageMagick/policy.xml
 
 install:
   - echo "No install action required. Implicitly performed by the testing."

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - echo "No install action required. Implicitly performed by the testing."
   - pip install flake8
   # modify ImageMagick policy file so that Textclips work correctly.
-  - cat /etc/ImageMagick/policy.xml | sed 's/none/read,write/g'> /etc/ImageMagick/policy.xml
+  - sudo cat /etc/ImageMagick/policy.xml | sed 's/none/read,write/g'> /etc/ImageMagick/policy.xml
 
 before_script:
   # stop the build if there are Python syntax errors or undefined names

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,8 @@ before_install:
 install:
   - echo "No install action required. Implicitly performed by the testing."
   - pip install flake8
-  - identify -list policy
   # modify ImageMagick policy file so that Textclips work correctly.
-  - cat /etc/ImageMagick-6/policy.xml | sed 's/none/read,write/g'> /etc/ImageMagick-6/policy.xml
+  - cat /etc/ImageMagick/policy.xml | sed 's/none/read,write/g'> /etc/ImageMagick/policy.xml
 
 before_script:
   # stop the build if there are Python syntax errors or undefined names

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - pip install --upgrade py pytest
   
   # modify ImageMagick policy file so that Textclips work correctly.
-  - sudo cat /etc/ImageMagick/policy.xml | sed 's/none/read,write/g'> /etc/ImageMagick/policy.xml
+  - sudo cat /etc/ImageMagick/policy.xml # | sed 's/none/read,write/g'> /etc/ImageMagick/policy.xml
 
 install:
   - echo "No install action required. Implicitly performed by the testing."

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 install:
   - echo "No install action required. Implicitly performed by the testing."
   - pip install flake8
+  - identify -list policy
   # modify ImageMagick policy file so that Textclips work correctly.
   - cat /etc/ImageMagick-6/policy.xml | sed 's/none/read,write/g'> /etc/ImageMagick-6/policy.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ before_install:
 install:
   - echo "No install action required. Implicitly performed by the testing."
   - pip install flake8
+  # modify ImageMagick policy file so that Textclips work correctly.
+  - cat /etc/ImageMagick-6/policy.xml | sed 's/none/read,write/g'> /etc/ImageMagick-6/policy.xml
 
 before_script:
   # stop the build if there are Python syntax errors or undefined names

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,13 @@ before_install:
   - pip install --upgrade setuptools
   # The default py that is installed is too old on some platforms, leading to version conflicts
   - pip install --upgrade py pytest
+  
+  # modify ImageMagick policy file so that Textclips work correctly.
+  - sudo cat /etc/ImageMagick/policy.xml | sed 's/none/read,write/g'> /etc/ImageMagick/policy.xml
 
 install:
   - echo "No install action required. Implicitly performed by the testing."
   - pip install flake8
-  # modify ImageMagick policy file so that Textclips work correctly.
-  - sudo cat /etc/ImageMagick/policy.xml | sed 's/none/read,write/g'> /etc/ImageMagick/policy.xml
 
 before_script:
   # stop the build if there are Python syntax errors or undefined names

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ before_install:
   - pip install --upgrade py pytest
   
   # modify ImageMagick policy file so that Textclips work correctly.
-  - cat /etc/ImageMagick/policy.xml
-  - sudo cat /etc/ImageMagick/policy.xml | sudo sed 's/none/read,write/g'> /etc/ImageMagick/policy.xml
+  # `| sudo tee` replaces `>` so that it can have root permissions
+  - cat /etc/ImageMagick/policy.xml | sed 's/none/read,write/g' | sudo tee /etc/ImageMagick/policy.xml
 
 install:
   - echo "No install action required. Implicitly performed by the testing."

--- a/tests/test_PR.py
+++ b/tests/test_PR.py
@@ -12,7 +12,7 @@ from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
 
 
 sys.path.append("tests")
-from test_helper import TMP_DIR, TRAVIS, FONT
+from test_helper import TMP_DIR, FONT
 
 
 
@@ -23,10 +23,7 @@ def test_download_media(capsys):
        download_media.download()
 
 def test_PR_306():
-    if TRAVIS:
-       return
 
-    #put this back in once we get ImageMagick working on travis-ci
     assert TextClip.list('font') != []
     assert TextClip.list('color') != []
 
@@ -34,9 +31,6 @@ def test_PR_306():
          TextClip.list('blah')
 
 def test_PR_339():
-    if TRAVIS:
-       return
-
     # In caption mode.
     TextClip(txt='foo', color='white', font=FONT, size=(640, 480),
              method='caption', align='center', fontsize=25).close()

--- a/tests/test_TextClip.py
+++ b/tests/test_TextClip.py
@@ -5,15 +5,10 @@ from moviepy.video.fx.blink import blink
 from moviepy.video.VideoClip import TextClip
 
 sys.path.append("tests")
-from test_helper import TMP_DIR, TRAVIS
+from test_helper import TMP_DIR
 
 def test_duration():
-    #TextClip returns the following error under Travis (issue with Imagemagick)
-    #convert.im6: not authorized `@/tmp/tmpWL7I3M.txt' @ error/property.c/InterpretImageProperties/3057.
-    #convert.im6: no images defined `PNG32:/tmp/tmpRZVqGQ.png' @ error/convert.c/ConvertImageCommand/3044.
-    if TRAVIS:
-       return
-    
+
     clip = TextClip('hello world', size=(1280,720), color='white')
     clip = clip.set_duration(5) #  Changed due to #598.
     assert clip.duration == 5
@@ -26,17 +21,12 @@ def test_duration():
 
 # Moved from tests.py. Maybe we can remove these?
 def test_if_textclip_crashes_in_caption_mode():
-    if TRAVIS:
-       return
-    
     TextClip(txt='foo', color='white', size=(640, 480), method='caption',
              align='center', fontsize=25).close()
 
 def test_if_textclip_crashes_in_label_mode():
-    if TRAVIS:
-       return
-    
     TextClip(txt='foo', method='label').close()
 
+
 if __name__ == '__main__':
-   pytest.main()
+    pytest.main()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -10,7 +10,7 @@ from moviepy.video.VideoClip import ColorClip, TextClip
 from moviepy.video.io.VideoFileClip import VideoFileClip
 
 import download_media
-from test_helper import TMP_DIR, TRAVIS, FONT
+from test_helper import TMP_DIR, FONT
 
 sys.path.append("tests")
 
@@ -29,11 +29,6 @@ def test_subtitles():
     blue = ColorClip((800, 600), color=(0,0,255)).set_duration(10)
     myvideo = concatenate_videoclips([red,green,blue])
     assert myvideo.duration == 30
-
-    #travis does not like TextClip.. so return for now..
-    #but allow regular users to still run the test below
-    if TRAVIS:
-       return
 
     generator = lambda txt: TextClip(txt, font=FONT,
                                      size=(800,600), fontsize=24,

--- a/tests/test_videotools.py
+++ b/tests/test_videotools.py
@@ -6,13 +6,10 @@ import os
 from moviepy.video.tools.credits import credits1
 
 sys.path.append("tests")
-from test_helper import TMP_DIR, TRAVIS
+from test_helper import TMP_DIR
 
 
 def test_credits():
-    if TRAVIS:
-        # Same issue with ImageMagick on Travis as in `test_TextClip.py`
-        return
     credit_file = "# This is a comment\n" \
                   "# The next line says : leave 4 blank lines\n" \
                   ".blank 2\n" \


### PR DESCRIPTION
I found a line in our Dockerfile that fixes the problem that ImageMagick has with TextClips.  This PR intends to run that command on Travis as well, so that all the tests using TextClips can be run.

The first commit just pushes the changes to the tests, to confirm that it still fails on Travis.