### PR TITLE
defunct ffmpeg processes removed after clip.close()

### DIFF
--- a/moviepy/audio/io/readers.py
+++ b/moviepy/audio/io/readers.py
@@ -148,6 +148,7 @@ class FFMPEG_AudioReader:
             for std in [ self.proc.stdout,
                          self.proc.stderr]:
                 std.close()
+            self.proc.wait()
             self.proc = None
 
     def get_frame(self, tt):


### PR DESCRIPTION
Defunct ffmpeg processes which were previously being left behind (even after doing clip.close() ) were associated with the audio of the file.

I had mentioned this issue at #745 

After comparing code in [ffmpeg_reader.py](https://github.com/Zulko/moviepy/blob/master/moviepy/video/io/ffmpeg_reader.py) and [readers.py](https://github.com/Zulko/moviepy/blob/master/moviepy/audio/io/readers.py), I noticed `self.proc.wait()` was missing in `close_proc` method in [readers.py](https://github.com/Zulko/moviepy/blob/master/moviepy/audio/io/readers.py)

So, I Added `self.proc.wait()` in `close_proc` method and that helped me get rid of defunct ffmpeg processes.



I'm not sure if someone else has already done it before.

Thanks!


