### PR TITLE
add pcm_s24le codec

### DIFF
--- a/moviepy/tools.py
+++ b/moviepy/tools.py
@@ -146,7 +146,7 @@ extensions_dict = { "mp4":  {'type':'video', 'codec':['libx264','libmpeg4', 'aac
 
                     'ogg':  {'type':'audio', 'codec':['libvorbis']},
                     'mp3':  {'type':'audio', 'codec':['libmp3lame']},
-                    'wav':  {'type':'audio', 'codec':['pcm_s16le', 'pcm_s32le']},
+                    'wav':  {'type':'audio', 'codec':['pcm_s16le', 'pcm_s24le', 'pcm_s32le']},
                     'm4a':  {'type':'audio', 'codec':['libfdk_aac']}
                   }
 


### PR DESCRIPTION
As 24-bit PCM is standard in AV workflows, it would be nice to have it included, not having to transcode it once more afterwards..