### PR TITLE
Add graphics blend modes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,7 @@ For advanced image processing, you will need one or several of the following pac
 - `Scikit Image`_ may be needed for some advanced image manipulation.
 - `OpenCV 2.4.6`_ or a more recent version (one that provides the package ``cv2``) may be needed for some advanced image manipulation.
 - `Matplotlib`_
+- `Blend Modes`_ for using the BlendedCompositeVideoClip for [blend modes](https://en.wikipedia.org/wiki/Blend_modes)
 
 Once you have installed it, ImageMagick will be automatically detected by MoviePy, (except for windows users and Ubuntu 16.04LTS users).
 
@@ -198,6 +199,7 @@ Maintainers
 .. _ImageMagick: http://www.imagemagick.org/script/index.php
 .. _`Matplotlib`: https://matplotlib.org/
 .. _`Sphinx`: http://www.sphinx-doc.org/en/master/setuptools.html
+.. _`Blend Modes`: https://github.com/flrs/blend_modes
 
 .. People
 .. _Zulko: https://github.com/Zulko

--- a/moviepy/editor.py
+++ b/moviepy/editor.py
@@ -31,6 +31,10 @@ from .video.io.ImageSequenceClip import ImageSequenceClip
 from .video.io.downloader import download_webfile
 from .video.VideoClip import VideoClip, ImageClip, ColorClip, TextClip
 from .video.compositing.CompositeVideoClip import CompositeVideoClip, clips_array
+try:
+    from .video.compositing.BlendedCompositeVideoClip import BlendedCompositeVideoClip
+except ImportError:
+    pass
 from .video.compositing.concatenate import concatenate_videoclips, concatenate # concatenate=deprecated
 
 from .audio.AudioClip import AudioClip, CompositeAudioClip, concatenate_audioclips

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -525,11 +525,15 @@ class VideoClip(Clip):
             post_array = np.hstack((post_array, x_1))
         return post_array
 
-    def blit_on(self, picture, t):
+    def blit_on(self, picture, t, blend_mode='normal', blend_opacity=1.0,
+                blend_weight=1.0):
         """
         Returns the result of the blit of the clip's frame at time `t`
         on the given `picture`, the position of the clip being given
         by the clip's ``pos`` attribute. Meant for compositing.
+
+        Blending parameters are exposed for BlendedCompositeVideoClip,
+        otherwise they are ignored.
         """
         hf, wf = framesize = picture.shape[:2]
 
@@ -578,7 +582,11 @@ class VideoClip(Clip):
 
         pos = map(int, pos)
 
-        return blit(img, picture, pos, mask=mask, ismask=self.ismask)
+        result = blit(
+            img, picture, pos, mask=mask, ismask=self.ismask, blend_mode=blend_mode,
+            blend_opacity=blend_opacity, blend_weight=blend_weight,
+        )
+        return result
 
     def add_mask(self):
         """Add a mask VideoClip to the VideoClip.

--- a/moviepy/video/compositing/BlendedCompositeVideoClip.py
+++ b/moviepy/video/compositing/BlendedCompositeVideoClip.py
@@ -1,0 +1,45 @@
+from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
+
+# Ensure that blend_modes is available, otherwise this cannot be used
+try:
+    from blend_modes import blend_modes
+except ImportError as ex:
+    msg = 'Using BlendedCompositeVideoClip requires the "blend_modes" package.'
+    raise ImportError(msg)
+
+
+class BlendedCompositeVideoClip(CompositeVideoClip):
+    def __init__(self, *args, **kwargs):
+        clips_blending = kwargs.pop('clips_blending', [])
+        CompositeVideoClip.__init__(self, *args, **kwargs)
+
+        # Sanitise and store each clip's blend kwargs
+        self.clips_blending = self._check_clips_blending(clips_blending)
+
+        # Custom definition of make_frame including blend_modes
+        def make_frame(t):
+            f = self.bg.get_frame(t)
+            for (c, blend_kwargs) in self.playing_clips(t):
+                f = c.blit_on(f, t, **blend_kwargs)
+            return f
+        self.make_frame = make_frame
+        return
+
+    def playing_clips(self, t=0):
+        playing = []
+        for index, clip in enumerate(self.clips):
+            if clip.is_playing(t):
+                playing.append((clip, self.clips_blending[index]))
+        return playing
+
+    def _check_clips_blending(self, clips_blending):
+        n_clips = len(self.clips)
+        if len(clips_blending) != n_clips:
+            clips_blending = [
+                {
+                    'blend_mode': 'normal',
+                    'blend_opacity': 1.0,
+                    'blend_weight': 1.0,
+                } for i in range(n_clips)
+            ]
+        return clips_blending

--- a/moviepy/video/tools/drawing.py
+++ b/moviepy/video/tools/drawing.py
@@ -4,14 +4,36 @@ methods that are difficult to do with the existing Python libraries.
 """
 
 import numpy as np
+try:
+    from blend_modes import blend_modes
+    blending_enabled = True
+except ImportError:
+    blending_enabled = False
 
-def blit(im1, im2, pos=None, mask=None, ismask=False):
+def blit(im1, im2, pos=None, mask=None, ismask=False, blend_mode='normal',
+         blend_opacity=1.0, blend_weight=1.0):
     """ Blit an image over another.
     
     Blits ``im1`` on ``im2`` as position ``pos=(x,y)``, using the
     ``mask`` if provided. If ``im1`` and ``im2`` are mask pictures
     (2D float arrays) then ``ismask`` must be ``True``.
+
+    By default, and if the blend_modes package is not installed, ``im1`` will
+    be follow the "normal" blend mode, see
+    https://en.wikipedia.org/wiki/Blend_modes#Normal_blend_mode
+
+    If blend_modes is installed, then any of the blend_modes can be used. There
+    are two additional parameters which can be used to fine-tune the output:
+    ``blend_opacity`` (float, [0,1]) the opacity that is passed through
+    to the blend_mode
+    ``blend_weight`` (float, [0,1]) allows for combining a blend_mode with
+    the "normal" blend mode, which is useful for layers that can end up
+    looking dark. A value of 1 corresponds to using blend_mode fully and a
+    value of 0 corresponds to using "normal" fully.
     """
+    def _blend_normal(mask, blitted, blit_region):
+        return (1.0 * mask * blitted) + ((1.0 - mask) * blit_region)
+
     if pos is None:
         pos = [0, 0]
 
@@ -41,13 +63,49 @@ def blit(im1, im2, pos=None, mask=None, ismask=False):
         if len(im1.shape) == 3:
             mask = np.dstack(3 * [mask])
         blit_region = new_im2[yp1:yp2, xp1:xp2]
-        new_im2[yp1:yp2, xp1:xp2] = (
-            1.0 * mask * blitted + (1.0 - mask) * blit_region)
+
+        # Sanity check on inputs
+        blend_mode = blend_mode.strip().lower()
+        blend_opacity = max(min(abs(blend_opacity), 1.0), 0.0)
+        blend_weight = max(min(abs(blend_weight), 1.0), 0.0)
+        if ((blend_mode == 'normal') or (not blending_enabled)):
+            new_im2[yp1:yp2, xp1:xp2] = _blend_normal(mask, blitted, blit_region)
+        else:
+            # Arrays are converted to be four-dimensional since blend_modes
+            # works with the alpha-channel for the blending
+            # For now assume all background (im2) to be visible
+            background = np.ones(
+                (blit_region.shape[0], blit_region.shape[1], 4), dtype='float'
+            )
+            background[:,:,:3] = blit_region
+
+            # Layer / im1
+            layer = np.zeros(
+                (blit_region.shape[0], blit_region.shape[1], 4), dtype='float'
+            )
+            layer[:,:,:3] = blitted
+            # Mask is duplicated across channels above, so just take the first
+            layer[:,:,3] = mask[:,:,0]
+
+            # Defer the blending calculations to blend_modes package
+            try:
+                blend_method = getattr(blend_modes, blend_mode)
+                blended = blend_method(background, layer, blend_opacity)
+            except AttributeError:
+                blended = _blend_normal(mask, blitted, blit_region)
+
+            # Combine if non-unity blend_weight
+            if blend_weight < 1.0:
+                blended *= blend_weight
+                blended[:,:,:3] += (1.0 - blend_weight) * _blend_normal(mask, blitted, blit_region)
+
+            # Update the relevant part of new_im2
+            new_im2[yp1:yp2, xp1:xp2] = blended[:,:,:3]
+
     else:
         new_im2[yp1:yp2, xp1:xp2] = blitted
 
     return new_im2.astype('uint8') if (not ismask) else new_im2
-
 
 
 def color_gradient(size,p1,p2=None,vector=None, r=None, col1=0,col2=1.0,
@@ -255,7 +313,8 @@ def color_split(size,x=None,y=None,p1=None,p2=None,vector=None,
     # if we are here, it means we didn't exit with a proper 'return'
     print( "Arguments in color_split not understood !" )
     raise
-    
+
+
 def circle(screensize, center, radius, col1=1.0, col2=0, blur=1):
     """ Draw an image with a circle.
     

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ optional_reqs = [
         "scikit-learn; python_version>='3.4'",
         "scipy>=0.19.0,<1.0; python_version!='3.3'",
         "matplotlib>=2.0.0,<3.0; python_version>='3.4'",
-        "youtube_dl"
+        "youtube_dl",
+        "blend_modes",
         ]
 
 doc_reqs = [

--- a/tests/test_compositing.py
+++ b/tests/test_compositing.py
@@ -43,3 +43,20 @@ def test_clips_array_duration():
         red.close()
         green.close()
         blue.close()
+
+def test_blended_composite_video_clip():
+    bg = VideoFileClip("media/video_for_blend_modes.mp4").set_duration(1.0)
+    text_kwargs = {"font": "Helvetica", "fontsize": 96, "color": "#bbbb11"}
+    t1 = TextClip(
+        "SOFT BLEND", **text_kwargs
+    ).set_duration(1.0).set_position(("center", "top"))
+    t2 = TextClip(
+        "HARD BLEND", **text_kwargs
+    ).set_duration(1.0).set_position(("center", "bottom"))
+    comp = BlendedCompositeVideoClip([bg, t1, t2], clips_blending=[
+        {"blend_mode": "normal"},
+        {"blend_mode": "soft_light", "blend_opacity": 0.8},
+        {"blend_mode": "hard_light", "blend_weight": 0.8},
+    ])
+    comp.write_videofile(join(TMP_DIR, "test_blended_composition.mp4"))
+    return


### PR DESCRIPTION
*Zerothly, thanks so much to @Zulko et al. for all the amazing work that's gone into MoviePy, it really is a fantastic library.

Firstly, apologies for a pull request out of the blue. I appreciate that there should be some discussion and acceptance prior to adding a feature, but this is something that we've added and are using internally so figured it would be worth pushing upstream to see if the community was interested in adopting it. Secondly, I couldn't see a contributing guide, so let me know what we've missed / how to go about this in the future.

### Motivation

Recently we ran into a situation where we wanted to reproduce blend / mix modes in a video, see e.g. https://en.wikipedia.org/wiki/Blend_modes . We came across the [blend_modes package](https://github.com/flrs/blend_modes) which seemed to have taken care of the details, but wanted to integrate it into MoviePy to take into account a varying background video.

### Overview

#### New class -- BlendedCompositeVideoClip

We didn't want to risk breaking any of the existing workflows that users might have had, so decided to isolate all of the functionality into a new clip class. This sub-classes from `video.compositing.CompositeVideoClip` but modifies the `make_frame` and `playing_clips` methods to account for the blend mode.

#### Optional dependency

As this feature requires an additional dependency then we wanted to make it optional and not force users to have to install an extra library if they didn't need it. As such, an error is only raised when trying to import the new class without blend_modes being installed.

Blend modes is MIT licensed.

#### Modifying blit_on and blit functions

In order to expose the blend_modes functionality with the minimum of impact it was necessary to change the above-mentioned method signatures. We have added in:
- blend_mode -- this corresponds to either "normal", i.e. the existing MoviePy behaviour, or to any of the blend_modes defined in the package.
- blend_opacity -- opacity of the layer, passed through to blend_modes
- blend_weight -- allows for weighting between the specified blend_mode and the "normal" mode

### Output

Forgive the gif quality, but below is a sample output using the soft_light and hard_light blending modes. This is the output of the test that we've added. Note that as far as I could tell, there was no way to actually check that the output of the tests matches what is expected, only that the files render. Is this sufficient?

![blended_composition](https://user-images.githubusercontent.com/1820761/39533447-14359802-4dfd-11e8-96bd-8d38da4481d0.gif)

The background video was taken from https://videos.pexels.com/videos/blurred-bokeh-video-855204 and is CC0 licensed. This is required for the test and is uploaded below:

[blend_modes.zip](https://github.com/Zulko/moviepy/files/1967962/blend_modes.zip)

