### PR TITLE
Progress bar optional for GIF creation

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -394,7 +394,7 @@ class VideoClip(Clip):
     @convert_masks_to_RGB
     def write_gif(self, filename, fps=None, program='imageio',
                   opt='nq', fuzz=1, verbose=True,
-                  loop=0, dispose=False, colors=None, tempfiles=False):
+                  loop=0, dispose=False, colors=None, tempfiles=False, progress_bar=True):
         """ Write the VideoClip to a GIF file.
 
         Converts a VideoClip into an animated GIF using ImageMagick
@@ -430,6 +430,9 @@ class VideoClip(Clip):
           Useful on computers with little RAM. Can only be used with
           ImageMagick' or 'ffmpeg'.
 
+        progress_bar
+          If True, displays a progress bar
+
 
         Notes
         -----
@@ -447,7 +450,8 @@ class VideoClip(Clip):
 
         if program == 'imageio':
             write_gif_with_image_io(self, filename, fps=fps, opt=opt, loop=loop,
-                                    verbose=verbose, colors=colors)
+                                    verbose=verbose, colors=colors,
+                                    progress_bar=progress_bar)
         elif tempfiles:
             # convert imageio opt variable to something that can be used with
             # ImageMagick
@@ -459,11 +463,13 @@ class VideoClip(Clip):
             write_gif_with_tempfiles(self, filename, fps=fps,
                                      program=program, opt=opt1, fuzz=fuzz,
                                      verbose=verbose, loop=loop,
-                                     dispose=dispose, colors=colors)
+                                     dispose=dispose, colors=colors,
+                                     progress_bar=progress_bar)
         else:
             write_gif(self, filename, fps=fps, program=program,
                       opt=opt, fuzz=fuzz, verbose=verbose, loop=loop,
-                      dispose=dispose, colors=colors)
+                      dispose=dispose, colors=colors,
+                      progress_bar=progress_bar)
 
     # -----------------------------------------------------------------
     # F I L T E R I N G

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -314,7 +314,8 @@ class VideoClip(Clip):
                                        audio_nbytes, audio_bufsize,
                                        audio_codec, bitrate=audio_bitrate,
                                        write_logfile=write_logfile,
-                                       verbose=verbose, progress_bar=progress_bar)
+                                       verbose=verbose,
+                                       progress_bar=progress_bar)
 
         ffmpeg_write_video(self, filename, fps, codec,
                            bitrate=bitrate,
@@ -394,7 +395,8 @@ class VideoClip(Clip):
     @convert_masks_to_RGB
     def write_gif(self, filename, fps=None, program='imageio',
                   opt='nq', fuzz=1, verbose=True,
-                  loop=0, dispose=False, colors=None, tempfiles=False, progress_bar=True):
+                  loop=0, dispose=False, colors=None, tempfiles=False,
+                  progress_bar=True):
         """ Write the VideoClip to a GIF file.
 
         Converts a VideoClip into an animated GIF using ImageMagick

--- a/moviepy/video/io/gif_writers.py
+++ b/moviepy/video/io/gif_writers.py
@@ -19,7 +19,7 @@ except ImportError:
 @use_clip_fps_by_default
 def write_gif_with_tempfiles(clip, filename, fps=None, program= 'ImageMagick',
        opt="OptimizeTransparency", fuzz=1, verbose=True,
-       loop=0, dispose=True, colors=None):
+       loop=0, dispose=True, colors=None, progress_bar=True):
     """ Write the VideoClip to a GIF file.
 
 
@@ -40,8 +40,13 @@ def write_gif_with_tempfiles(clip, filename, fps=None, program= 'ImageMagick',
 
     verbose_print(verbose, "[MoviePy] Generating GIF frames...\n")
 
-    total = int(clip.duration*fps)+1
-    for i, t in tqdm(enumerate(tt), total=total):
+    if progress_bar:
+        total = int(clip.duration*fps)+1
+        iterator = tqdm(enumerate(tt), total=total)
+    else:
+        iterator = enumerate(tt)
+
+    for i, t in iterator:
 
         name = "%s_GIFTEMP%04d.png"%(fileName, i+1)
         tempfiles.append(name)
@@ -96,7 +101,7 @@ def write_gif_with_tempfiles(clip, filename, fps=None, program= 'ImageMagick',
 @use_clip_fps_by_default
 def write_gif(clip, filename, fps=None, program= 'ImageMagick',
            opt="OptimizeTransparency", fuzz=1, verbose=True, withmask=True,
-           loop=0, dispose=True, colors=None):
+           loop=0, dispose=True, colors=None, progress_bar=True):
     """ Write the VideoClip to a GIF file, without temporary files.
 
     Converts a VideoClip into an animated GIF using ImageMagick
@@ -220,7 +225,7 @@ def write_gif(clip, filename, fps=None, program= 'ImageMagick',
 
     try:
 
-        for t,frame in clip.iter_frames(fps=fps, progress_bar=True,
+        for t,frame in clip.iter_frames(fps=fps, progress_bar=progress_bar,
                                         with_times=True,  dtype="uint8"):
             if withmask:
                 mask = 255 * clip.mask.get_frame(t)
@@ -251,7 +256,7 @@ def write_gif(clip, filename, fps=None, program= 'ImageMagick',
 
 
 def write_gif_with_image_io(clip, filename, fps=None, opt=0, loop=0,
-                            colors=None, verbose=True):
+                            colors=None, verbose=True, progress_bar=True):
     """
     Writes the gif with the Python library ImageIO (calls FreeImage).
 
@@ -282,7 +287,7 @@ def write_gif_with_image_io(clip, filename, fps=None, opt=0, loop=0,
         )
 
     verbose_print(verbose, "\n[MoviePy] Building file %s with imageio\n" % filename)
-    
-    for frame in clip.iter_frames(fps=fps, progress_bar=True, dtype='uint8'):
+
+    for frame in clip.iter_frames(fps=fps, progress_bar=progress_bar, dtype='uint8'):
 
         writer.append_data(frame)


### PR DESCRIPTION
This is a non-API-breaking change which makes the display of a progress bar optional when making gifs.

Moviepy has been used to create gifs for tensorboard to visualise deep learning, with [this package](https://github.com/lanpa/tensorboard-pytorch). However, the terminal is usually used to keep track of training progress - the unwanted display of progress bars interrupts this display, hence this pull request to allow for them to be hidden.