### PR TITLE
FIX changed order of specifications -ss befor -i for ffmpeg_extract_subclip()

### DIFF
--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -33,8 +33,8 @@ def ffmpeg_extract_subclip(filename, t1, t2, targetname=None):
         targetname = "%sSUB%d_%d.%s" % (name, T1, T2, ext)
     
     cmd = [get_setting("FFMPEG_BINARY"),"-y",
-           "-i", filename,
            "-ss", "%0.2f"%t1,
+           "-i", filename,
            "-t", "%0.2f"%(t2-t1),
            "-vcodec", "copy", "-acodec", "copy", targetname]
     


### PR DESCRIPTION
Refers to #847 

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [x] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [ ] I have added a test to the test suite, if necessary
- [ ] I have properly documented new or changed features in the documention, or the docstrings
- [x] I have properly documented unusual changes to the code in the comments around it
- [x] I have made note of any breaking/backwards incompatible changes
