### PR TITLE
prevent terminating already-terminated process on WSL

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -256,7 +256,10 @@ def ffmpeg_parse_infos(filename, print_infos=False, check_duration=True,
     proc = sp.Popen(cmd, **popen_params)
 
     proc.stdout.readline()
-    proc.terminate()
+    try:
+        proc.terminate()
+    except ProcessLookupError:
+        pass  # process already terminated
     infos = proc.stderr.read().decode('utf8')
     del proc
 


### PR DESCRIPTION
Prevents `proc.terminate()` from throwing an exception when the process has already terminated.

Potential fix for #765

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [ ] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [ ] I have added a test to the test suite, if necessary
- [ ] I have properly documented new or changed features in the documention, or the docstrings
- [+ ] I have properly documented unusual changes to the code in the comments around it
- [ ] I have made note of any breaking/backwards incompatible changes
