### PR TITLE
WSL fix for terminate process in audio

### DIFF
--- a/moviepy/audio/io/readers.py
+++ b/moviepy/audio/io/readers.py
@@ -144,7 +144,10 @@ class FFMPEG_AudioReader:
 
     def close_proc(self):
         if hasattr(self, 'proc') and self.proc is not None:
-            self.proc.terminate()
+            try:
+                self.proc.terminate()
+            except ProcessLookupError:
+                pass  # process already terminated
             for std in [ self.proc.stdout,
                          self.proc.stderr]:
                 std.close()


### PR DESCRIPTION
added @ryanfox's fix (https://github.com/Zulko/moviepy/pull/861) to the audio:

> Prevents proc.terminate() from throwing an exception when the process has already terminated.

It's the final fix for #765 I believe.

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [x] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [ ] I have added a test to the test suite, if necessary
- [x] I have properly documented new or changed features in the documention, or the docstrings
- [ ] I have properly documented unusual changes to the code in the comments around it
- [ ] I have made note of any breaking/backwards incompatible changes
