### PR TITLE
Fixed typo in docstring for VideoClip class

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -30,7 +30,7 @@ from .tools.drawing import blit
 class VideoClip(Clip):
     """Base class for video clips.
 
-    See ``VideofileClip``, ``ImageClip`` etc. for more user-friendly
+    See ``VideoFileClip``, ``ImageClip`` etc. for more user-friendly
     classes.
 
 


### PR DESCRIPTION
Changed VideofileClip to VideoFileClip in docstring

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [ ] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [ ] I have added a test to the test suite, if necessary
- [x] I have properly documented new or changed features in the documention, or the docstrings
- [ ] I have properly documented unusual changes to the code in the comments around it
- [ ] I have made note of any breaking/backwards incompatible changes
