### PR TITLE
modified max duration error for better understanding

### DIFF
--- a/moviepy/video/io/html_tools.py
+++ b/moviepy/video/io/html_tools.py
@@ -138,9 +138,10 @@ def html_embed(clip, filetype=None, maxduration=60, rd_kwargs=None,
 
         duration = ffmpeg_parse_infos(filename)['duration']
         if duration > maxduration:
-            raise ValueError("The duration of video %s (%.1f) exceeds the 'max_duration' "%(filename, duration)+
-                             "attribute. You can increase 'max_duration', "
-                             "but note that embedding large videos may take all the memory away !")
+            raise ValueError("The duration of video %s (%.1f) exceeds the 'maxduration' "%(filename, duration)+
+                             "attribute. You can increase 'maxduration', by passing 'maxduration' parameter"
+                             "to ipython_display function."
+                             "But note that embedding large videos may take all the memory away !")
             
     with open(filename, "rb") as f:
         data= b64encode(f.read()).decode("utf-8")


### PR DESCRIPTION
When embedding video larger than the maxduration set, the error thrown suggests to set `max_duration` param but it is rather `maxduration` without underscore. Also added a line to suggest in  which function to make changes. It is minor, but it had me scratching my head for a minute.  

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [x] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [x] I have added a test to the test suite, if necessary
- [x] I have properly documented new or changed features in the documention, or the docstrings
- [x] I have properly documented unusual changes to the code in the comments around it
- [x] I have made note of any breaking/backwards incompatible changes
