### PR TITLE
Add progress callback feature

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -141,7 +141,8 @@ class VideoClip(Clip):
                         rewrite_audio=True, remove_temp=True,
                         write_logfile=False, verbose=True,
                         threads=None, ffmpeg_params=None,
-                        progress_bar=True):
+                        progress_bar=True,
+                        progress_callback=None):
         """Write the clip to a videofile.
 
         Parameters
@@ -244,6 +245,10 @@ class VideoClip(Clip):
         progress_bar
           Boolean indicating whether to show the progress bar.
 
+        progress_callback
+          After writing each frame, the callback function will be invoked.
+          The function should have a signature ```func(serial_of_current_frame, total_number_of_frames)'''
+
         Examples
         ========
 
@@ -324,7 +329,8 @@ class VideoClip(Clip):
                            audiofile=audiofile,
                            verbose=verbose, threads=threads,
                            ffmpeg_params=ffmpeg_params,
-                           progress_bar=progress_bar)
+                           progress_bar=progress_bar,
+                           progress_callback=progress_callback)
 
         if remove_temp and make_audio:
             os.remove(audiofile)

--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -197,7 +197,7 @@ class FFMPEG_VideoWriter:
 def ffmpeg_write_video(clip, filename, fps, codec="libx264", bitrate=None,
                        preset="medium", withmask=False, write_logfile=False,
                        audiofile=None, verbose=True, threads=None, ffmpeg_params=None,
-                       progress_bar=True):
+                       progress_bar=True, progress_callback=None):
     """ Write the clip to a videofile. See VideoClip.write_videofile for details
     on the parameters.
     """
@@ -213,6 +213,7 @@ def ffmpeg_write_video(clip, filename, fps, codec="libx264", bitrate=None,
                                 ffmpeg_params=ffmpeg_params) as writer:
 
         nframes = int(clip.duration*fps)
+        cnt = 0
 
         for t,frame in clip.iter_frames(progress_bar=progress_bar, with_times=True,
                                         fps=fps, dtype="uint8"):
@@ -223,6 +224,9 @@ def ffmpeg_write_video(clip, filename, fps, codec="libx264", bitrate=None,
                 frame = np.dstack([frame,mask])
 
             writer.write_frame(frame)
+            cnt += 1
+            if progress_callback:
+                progress_callback(cnt, nframes)
 
     if write_logfile:
         logfile.close()


### PR DESCRIPTION
When use MoviePy as a part of service, it's necessary to know current process state. In this PR, a new parameter called ```progress_callback``` is added, which is a callback function used to pass messages.
For example, if we are building an online video converter service, we need to show percents of processed frames. Suppose we already have a function called ```update_state(percent)``` which can push state messages to frontend updating progress bar on a web page, simply add a callback function and pass it to MoviePy:
```python
def func_to_callback(current, n_frames):
  update_state(current / n_frames)

final_clip.write_videofile('result.mp4', fps=25, progress_callback=func_to_callback)
```
