### PR TITLE
Bugfix for when srt file ends in white space

### DIFF
--- a/moviepy/video/tools/subtitles.py
+++ b/moviepy/video/tools/subtitles.py
@@ -156,7 +156,7 @@ def file_to_subtitles(filename):
         times = re.findall("([0-9]*:[0-9]*:[0-9]*,[0-9]*)", line)
         if times != []:
             current_times = list(map(cvsecs, times))
-        elif line.strip() == '':
+        elif line.strip() == '' and current_times != None:
             times_texts.append((current_times, current_text.strip('\n')))
             current_times, current_text = None, ""
         elif current_times is not None:


### PR DESCRIPTION
If the srt file ends in whitespace the SubtitlesClip class's constructor crashes on line 54 since the None type was inserted where the iterator on line 54 expects the none to be an iterable.

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [ ] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [ ] I have added a test to the test suite, if necessary
- [ ] I have properly documented new or changed features in the documention, or the docstrings
- [ ] I have properly documented unusual changes to the code in the comments around it
- [ ] I have made note of any breaking/backwards incompatible changes
