### PR TITLE
Update ffmpeg_tools.py

### DIFF
--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -32,9 +32,10 @@ def ffmpeg_extract_subclip(filename, t1, t2, targetname=None):
         T1, T2 = [int(1000*t) for t in [t1, t2]]
         targetname = "%sSUB%d_%d.%s" % (name, T1, T2, ext)
     
+    # See https://stackoverflow.com/a/33188399/5459467 about the arg order
     cmd = [get_setting("FFMPEG_BINARY"),"-y",
-           "-i", filename,
            "-ss", "%0.2f"%t1,
+           "-i", filename,
            "-t", "%0.2f"%(t2-t1),
            "-vcodec", "copy", "-acodec", "copy", targetname]
     


### PR DESCRIPTION
- [x] I have properly documented unusual changes to the code in the comments around it
(Other bullets do not seem relèvent to this PR)

This PR follows what was tried in 
https://github.com/Zulko/moviepy/pull/579. If prevents black frames from appearing when cutting an extract out of the key frames.

![6e78421b-086a-4db5-94b9-5389977f4040](https://user-images.githubusercontent.com/10530980/49700158-6e324d00-fbdb-11e8-848e-763ac1a2be1a.jpeg)

The fix (I tested it multiple times with various parameters) is directly inspired from  https://stackoverflow.com/a/33188399/5459467 which quotes the above doc.

I am not sure unit tests will easily allow to detect such an issue :/

Thanks a lot for the project !

fixes https://github.com/Zulko/moviepy/pull/579
fixes https://github.com/Zulko/moviepy/issues/508