### PR TITLE
fix typo that introduces audio regression

### DIFF
--- a/moviepy/audio/io/readers.py
+++ b/moviepy/audio/io/readers.py
@@ -114,9 +114,9 @@ class FFMPEG_AudioReader:
         s = self.proc.stdout.read(L)
         dt = {1: 'int8',2:'int16',4:'int32'}[self.nbytes]
         if hasattr(np, 'frombuffer'):
-            result = np.frombuffer(s, dtype='uint8')
+            result = np.frombuffer(s, dtype=dt)
         else:
-            result = np.fromstring(s, dtype='uint8')
+            result = np.fromstring(s, dtype=dt)
         result = (1.0*result / 2**(8*self.nbytes-1)).\
                                  reshape((int(len(result)/self.nchannels),
                                           self.nchannels))


### PR DESCRIPTION
This should fix #891.

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [x] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [ ] I have added a test to the test suite, if necessary
- [ ] I have properly documented new or changed features in the documention, or the docstrings
- [ ] I have properly documented unusual changes to the code in the comments around it
- [ ] I have made note of any breaking/backwards incompatible changes
