### PR TITLE
New version of imageio with imageio_ffmpeg for python 3.4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 language: python
 cache: pip
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 language: python
 cache: pip
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,16 +16,10 @@ environment:
 
   matrix:
   
-     # MoviePy supports Python 2.7 and 3.4 onwards.
+     # MoviePy supports Python 3.4 onwards.
      # Strategy:
      #    Test the latest known patch in each version
      #    Test the oldest and the newest 32 bit release. 64-bit otherwise.
-  
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.13"
-      PYTHON_ARCH: "64"
-      MINICONDA: C:\Miniconda
-      CONDA_INSTALL: "numpy"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.5"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,12 +39,6 @@ environment:
       MINICONDA: C:\Miniconda36-x64
       CONDA_INSTALL: "numpy"
 
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.13"
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda
-      CONDA_INSTALL: "numpy"
-
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.6.2"
       PYTHON_ARCH: "32"

--- a/moviepy/editor.py
+++ b/moviepy/editor.py
@@ -22,8 +22,6 @@ import os
 # Downloads ffmpeg if it isn't already installed
 import imageio
 # Checks to see if the user has set a place for their own version of ffmpeg
-if os.getenv('FFMPEG_BINARY', 'ffmpeg-imageio') == 'ffmpeg-imageio':
-    imageio.plugins.ffmpeg.download()
 
 # Clips
 from .video.io.VideoFileClip import VideoFileClip

--- a/moviepy/editor.py
+++ b/moviepy/editor.py
@@ -25,7 +25,7 @@ import imageio
 # Checks to see if the user has set a place for their own version of ffmpeg
 
 if os.getenv('FFMPEG_BINARY', 'ffmpeg-imageio') == 'ffmpeg-imageio':
-    if sys.version_info[0] < (3, 4):
+    if sys.version_info < (3, 4):
         #uses an old version of imageio with ffmpeg.download.
         imageio.plugins.ffmpeg.download()
 

--- a/moviepy/editor.py
+++ b/moviepy/editor.py
@@ -18,10 +18,16 @@ clip.preview().
 # file, but this would make the loading of moviepy slower.
 
 import os
+import sys
 
 # Downloads ffmpeg if it isn't already installed
 import imageio
 # Checks to see if the user has set a place for their own version of ffmpeg
+
+if os.getenv('FFMPEG_BINARY', 'ffmpeg-imageio') == 'ffmpeg-imageio':
+    if sys.version_info[0] < (3, 4):
+        #uses an old version of imageio with ffmpeg.download.
+        imageio.plugins.ffmpeg.download()
 
 # Clips
 from .video.io.VideoFileClip import VideoFileClip

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ exec(open('moviepy/version.py').read()) # loads __version__
 requires = [
     'decorator>=4.0.2,<5.0',
     'imageio>=2.5,<3.0',
-    'imageio_ffmpeg>=0.2.0',
+    'imageio>=2.0,<2.5; python_version<3.4',
+    'imageio_ffmpeg>=0.2.0; python_version>='3.4'',
     'tqdm>=4.11.2,<5.0',
     'numpy',
     'requests>=2.8.1,<3.0',

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,8 @@ exec(open('moviepy/version.py').read()) # loads __version__
 requires = [
     'decorator>=4.0.2,<5.0',
     'imageio>=2.5,<3.0',
-    'imageio>=2.0,<2.5; python_version<3.4',
-    'imageio_ffmpeg>=0.2.0; python_version>='3.4'',
+    "imageio>=2.0,<2.5; python_version<'3.4'",
+    "imageio_ffmpeg>=0.2.0; python_version>='3.4'",
     'tqdm>=4.11.2,<5.0',
     'numpy',
     'requests>=2.8.1,<3.0',

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ exec(open('moviepy/version.py').read()) # loads __version__
 # Define the requirements for specific execution needs.
 requires = [
     'decorator>=4.0.2,<5.0',
-    'imageio>=2.1.2,<3.0',
+    'imageio>=2.5,<3.0',
+    'imageio_ffmpeg>=0.2.0',
     'tqdm>=4.11.2,<5.0',
     'numpy',
     'requests>=2.8.1,<3.0',


### PR DESCRIPTION
Many changes and done very quickly by lack of time. Python 2.7 versions should still work at least in the short term but imageio may deprecate its previous versions soon (i.e. there may be a risk that the ffmpeg binaries for previous versions just disappear) 
