### PR TITLE
[docker] drop the not needed download and symlink of ffmpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,5 @@ ADD . /var/src/moviepy/
 #RUN git clone https://github.com/Zulko/moviepy.git /var/src/moviepy
 RUN cd /var/src/moviepy/ && python setup.py install
 
-# install ffmpeg from imageio.
-RUN python -c "import imageio; imageio.plugins.ffmpeg.download()"
-
-#add soft link so that ffmpeg can executed (like usual) from command line
-RUN ln -s /root/.imageio/ffmpeg/ffmpeg.linux64 /usr/bin/ffmpeg
-
 # modify ImageMagick policy file so that Textclips work correctly.
 RUN cat /etc/ImageMagick-6/policy.xml | sed 's/none/read,write/g'> /etc/ImageMagick-6/policy.xml 


### PR DESCRIPTION
`libav-tools` has `ffmpeg` as a direct dependency.

https://github.com/Zulko/moviepy/blob/2ad7285bec9dee1a477250891ddc9c418a319dc1/Dockerfile#L4

Ref: https://github.com/Zulko/moviepy/issues/908#issuecomment-468182584

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [x] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [x] I have added a test to the test suite, if necessary
- [x] I have properly documented new or changed features in the documention, or the docstrings
- [x] I have properly documented unusual changes to the code in the comments around it
- [x] I have made note of any breaking/backwards incompatible changes
