### PR TITLE
WIP: Auto-detect image magick latest 6.9.X-Y version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,9 @@ install:
 
   # Find latest image magick version by parsing website
 
-  - IMAGE_MAGICK_VERSION=`python find_latest_imagemagick_version.py`
+  - python find_latest_imagemagick_version.py > temp.txt
+  - set /p IMAGE_MAGICK_VERSION=<temp.txt
+
   - echo %IMAGE_MAGICK_VERSION%
   # Download ImageMagick installer (which also installs ffmpeg.)
   # From http://ftp.fifi.org/ImageMagick/binaries/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ image: Visual Studio 2017
 
 environment:
   global:
-    IMAGE_MAGICK_VERSION: 6.9.10-35-Q16
     IMAGE_MAGICK_INSTALL_DIR: c://ImageMagick
   matrix:
     - PYTHON: "C:\\Python35-x64"
@@ -36,6 +35,10 @@ install:
   - pip install --upgrade pip --user
   - pip install pipenv
 
+  # Find latest image magick version by parsing website
+
+  - IMAGE_MAGICK_VERSION=`python find_latest_imagemagick_version.py`
+  - echo %IMAGE_MAGICK_VERSION%
   # Download ImageMagick installer (which also installs ffmpeg.)
   # From http://ftp.fifi.org/ImageMagick/binaries/
   # Might need to be updated from time to time

--- a/find_latest_imagemagick_version.py
+++ b/find_latest_imagemagick_version.py
@@ -1,0 +1,21 @@
+from urllib import request
+import re
+
+url = "https://legacy.imagemagick.org/script/index.php"
+
+'''This little script parses url above to extract latest image magick version
+(major version 6.9), to feed it into CI system. Not the best way for reproducible
+builds, but it's preferred for now over storing imagemagick installer into the
+git repository
+'''
+
+response = request.urlopen(url)
+html = response.read().decode('utf-8')
+r = re.compile("6\.9\.[0-9]+\-[0-9]+")
+version = r.findall(html)
+if len(version) == 0:
+    raise ValueError("Could not find latest legacy 6.9.X-Y ImageMagick version from {}".format(url))
+version = version[0]
+# Append Q16 build
+version += '-Q16'
+print(version)


### PR DESCRIPTION
Added auto-detection of ImageMagick latest's legacy version into CI, by parsing imagemagick's web page. This is required because old binaries are never kept around and versions iterate quickly. This will make CI more robust.

- [ ] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [ ] I have added a test to the test suite, if necessary
- [ ] I have properly documented new or changed features in the documention, or the docstrings
- [ ] I have properly documented unusual changes to the code in the comments around it
- [ ] I have made note of any breaking/backwards incompatible changes
