### PR TITLE
More resilient Windows CI regarding fetching ImageMagick binaries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   # Might need to be updated from time to time
   # Versions >=7.0 have problems - executables changed names.
   # Assume 64-bit. Need to change to x86 for 32-bit.
-  - curl ftp.fifi.org/ImageMagick/binaries/ImageMagick-%IMAGE_MAGICK_VERSION%-%ARCH%-static.exe -o ImageMagick.exe
+  - curl https://imagemagick.org/download/binaries/ImageMagick-%IMAGE_MAGICK_VERSION%-%ARCH%-static.exe -o ImageMagick.exe
 
   # Install ImageMagick, telling InnoSetup to not open a window and change default install dir
   - ImageMagick.exe /SILENT /SP /DIR="%IMAGE_MAGICK_INSTALL_DIR%"


### PR DESCRIPTION
Downloads imagemagick from official website rather than third-party source, to ensure latest version is always available as binary.