### PR TITLE
Test that the temporary audio file exists

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -240,7 +240,7 @@ class VideoClip(Clip):
 
         logger
           Either "bar" for progress bar or None or any Proglog logger.
-        
+
         verbose (deprecated, kept for compatibility)
           Formerly used for toggling messages on/off. Use logger=None now.
 
@@ -326,7 +326,8 @@ class VideoClip(Clip):
                            logger=logger)
 
         if remove_temp and make_audio:
-            os.remove(audiofile)
+            if os.path.exists(audiofile):
+                os.remove(audiofile)
         logger(message="Moviepy - video ready %s" % filename)
 
     @requires_duration


### PR DESCRIPTION
I'm using Moviepy in one of my projects and this problem about a temporary file that does not exist when calling `VideoClip.write_videofile` is popping up in our CI jobs.

This fix simply does the same thing as in `TextClip` testing that the tmp file exist before calling `os.remove`
