### PR TITLE
Reorder FFMPEG_VideoWriter command arguments

### DIFF
--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -83,7 +83,7 @@ class FFMPEG_VideoWriter:
             '-s', '%dx%d' % (size[0], size[1]),
             '-pix_fmt', 'rgba' if withmask else 'rgb24',
             '-r', '%.02f' % fps,
-            '-i', '-', '-an',
+            '-an', '-i', '-'
         ]
         if audiofile is not None:
             cmd.extend([


### PR DESCRIPTION
stream options must be provided before the '-i' option to affect that stream.
The existing code caused '-an' (no audio) to be applied to the next stream.  This causes no audio to be generated if the next stream is the audio stream for the clip.

e.g.  On Windows:

```
import os
os.environ["IMAGEIO_FFMPEG_EXE"] = "path\to\newest\ffmpeg.exe"
from moviepy.editor import VideoFileClip
video = VideoFileClip("my_file_with_audio.mp4").subclip(0, 10)
video.write_videofile("created_clip.mp4")
```

will generate a video file with no audio.

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [x] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [ ] I have added a test to the test suite, if necessary
- [ ] I have properly documented new or changed features in the documention, or the docstrings
- [ ] I have properly documented unusual changes to the code in the comments around it
- [ ] I have made note of any breaking/backwards incompatible changes
