### PR TITLE
Specify Coverage version explicitly.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ doc_reqs = [
     ]
 
 test_reqs = [
+        'coverage<5.0',
         'coveralls>=1.1,<2.0',
         'pytest-cov>=2.5.1,<3.0',
         'pytest>=3.0.0,<4.0',

--- a/tests/test_ImageSequenceClip.py
+++ b/tests/test_ImageSequenceClip.py
@@ -32,7 +32,7 @@ def test_2():
     images.append("media/matplotlib_demo1.png")
 
     #images are not the same size..
-    with pytest.raises(Exception, message='Expecting Exception'):
+    with pytest.raises(Exception):
          ImageSequenceClip(images, durations=durations).close()
 
 

--- a/tests/test_PR.py
+++ b/tests/test_PR.py
@@ -18,7 +18,7 @@ def test_PR_306():
     assert TextClip.list('font') != []
     assert TextClip.list('color') != []
 
-    with pytest.raises(Exception, message="Expecting Exception"):
+    with pytest.raises(Exception):
          TextClip.list('blah')
     close_all_clips(locals())
 

--- a/tests/test_compositing.py
+++ b/tests/test_compositing.py
@@ -15,8 +15,7 @@ def test_clips_array():
 
     video = clips_array([[red, green, blue]])
 
-    with pytest.raises(ValueError,
-                       message="Expecting ValueError (duration not set)"):
+    with pytest.raises(ValueError):  # duration not set
         video.resize(width=480).write_videofile(
             join(TMP_DIR, "test_clips_array.mp4"))
     close_all_clips(locals())
@@ -30,8 +29,7 @@ def test_clips_array_duration():
     blue = ColorClip((256, 200), color=(0, 0, 255))
 
     video = clips_array([[red, green, blue]]).set_duration(5)
-    with pytest.raises(AttributeError,
-                       message="Expecting ValueError (fps not set)"):
+    with pytest.raises(AttributeError):  # fps not set
         video.write_videofile(join(TMP_DIR, "test_clips_array.mp4"))
 
     # this one should work correctly

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -14,7 +14,7 @@ from moviepy.video.fx.resize import resize
 
 def test_issue_145():
     video = ColorClip((800, 600), color=(255, 0, 0)).set_duration(5)
-    with pytest.raises(Exception, message='Expecting Exception'):
+    with pytest.raises(Exception):
         concatenate_videoclips([video], method='composite')
 
 
@@ -223,10 +223,10 @@ def test_issue_407():
     assert green.h == blue.h == 480
     assert green.size == blue.size == (640, 480)
 
-    with pytest.raises(AttributeError, message="Expecting ValueError Exception"):
+    with pytest.raises(AttributeError):
         green.fps
 
-    with pytest.raises(AttributeError, message="Expecting ValueError Exception"):
+    with pytest.raises(AttributeError):
         blue.fps
 
     video = concatenate_videoclips([red, green, blue])
@@ -262,7 +262,7 @@ def test_issue_470():
     # t_end is out of bounds
     subclip = audio_clip.subclip(t_start=6, t_end=9)
 
-    with pytest.raises(IOError, message="Expecting IOError"):
+    with pytest.raises(IOError):
         subclip.write_audiofile(os.path.join(
             TMP_DIR, 'issue_470.wav'), write_logfile=True)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -19,8 +19,8 @@ def test_ext():
 
 def test_2():
     """Test for raising erre if codec not in dictionaries."""
-    message = "asking for a silly video format did not Raise a Value Error"
-    with pytest.raises(ValueError, message=message):
+
+    with pytest.raises(ValueError):  # asking for a silly video format
          tools.find_extension('flashvideo')
 
 def test_3():


### PR DESCRIPTION
The Travis builds have been broken for about 4 weeks.

I didn't fully explore the reasons, but Coverage 5.0a5 (an alpha version) was being installed, and then clashing with the Coverall which required version <5.0.

As a result, the Travis tests were not being run.

Adding a specific requirement for coverage solved the problem.

----

Also removed a deprecated parameter from pytest.raises(), which was leading to lots of deprecation warnings in the tests. [Sorry - should have been two branches, but they got mised together. The changes are trivial.]

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [N/A] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [N/A ] I have added a test to the test suite, if necessary
- [N/A] I have properly documented new or changed features in the documention, or the docstrings
- [N/A] I have properly documented unusual changes to the code in the comments around it
- [N/A] I have made note of any breaking/backwards incompatible changes
