### PR TITLE
Fix failing return `TextClip.list('font')` in Windows

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1188,9 +1188,11 @@ class TextClip(ImageClip):
         popen_params = {"stdout": sp.PIPE,
                         "stderr": DEVNULL,
                         "stdin": DEVNULL}
+        encoding = "UTF-8"
 
         if os.name == "nt":
             popen_params["creationflags"] = 0x08000000
+            encoding = "CP949"
 
         process = sp.Popen([get_setting("IMAGEMAGICK_BINARY"),
                             '-list', arg], **popen_params)
@@ -1198,7 +1200,7 @@ class TextClip(ImageClip):
         lines = result.splitlines()
 
         if arg == 'font':
-            return [l.decode('UTF-8')[8:] for l in lines if l.startswith(b"  Font:")]
+            return [l.decode(encoding)[8:] for l in lines if l.startswith(b"  Font:")]
         elif arg == 'color':
             return [l.split(b" ")[0] for l in lines[2:]]
         else:


### PR DESCRIPTION
Imagemagick return CP949 text in Windows. when `TextClip.list('font')` is called.
So, original code invoke error like belows.

```
Traceback (most recent call last):
  File "d:/repo/suroo/exmaple.py", line 9, in <module>
    print(TextClip.list('font'))
  File "C:\Users\kangh\AppData\Local\Programs\Python\Python37-32\lib\site-packages\moviepy-1.0.0-py3.7.egg\moviepy\video\VideoClip.py",	line 1201, in list
    return [l.decode('UTF-8')[8:] for l in lines if l.startswith(b"  Font:")]
  File "C:\Users\kangh\AppData\Local\Programs\Python\Python37-32\lib\site-packages\moviepy-1.0.0-py3.7.egg\moviepy\video\VideoClip.py", line 1201, in <listcomp>
    return [l.decode('UTF-8')[8:] for l in lines if l.startswith(b"  Font:")]
UnicodeDecodeError: 'utf-8' codec can't decode byte  0xb0 in position 10: invalid start byte
```
So, I made variable named 'encoding' and assign different value when OS is windows

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [x] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [ ] I have added a test to the test suite, if necessary
- [ ] I have properly documented new or changed features in the documention, or the docstrings
- [ ] I have properly documented unusual changes to the code in the comments around it
- [ ] I have made note of any breaking/backwards incompatible changes
- resolved: #948