### PR TITLE
Get ffmpeg to use all audio streams

### DIFF
--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -36,7 +36,7 @@ def ffmpeg_extract_subclip(filename, t1, t2, targetname=None):
            "-ss", "%0.2f"%t1,
            "-i", filename,
            "-t", "%0.2f"%(t2-t1),
-           "-vcodec", "copy", "-acodec", "copy", targetname]
+           "-map", "0", "-vcodec", "copy", "-acodec", "copy", targetname]
     
     subprocess_call(cmd)
 


### PR DESCRIPTION
For some formats ffmpeg picks just one audio stream without "-map 0" instead of all.

<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [ ] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [ ] I have added a test to the test suite, if necessary
- [ ] I have properly documented new or changed features in the documention, or the docstrings
- [ ] I have properly documented unusual changes to the code in the comments around it
- [ ] I have made note of any breaking/backwards incompatible changes
