### PR TITLE
Hide pygame support prompt

### DIFF
--- a/moviepy/editor.py
+++ b/moviepy/editor.py
@@ -29,6 +29,9 @@ if os.getenv('FFMPEG_BINARY', 'ffmpeg-imageio') == 'ffmpeg-imageio':
         #uses an old version of imageio with ffmpeg.download.
         imageio.plugins.ffmpeg.download()
 
+# Hide the welcome message from pygame: https://github.com/pygame/pygame/issues/542
+os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "1"
+
 # Clips
 from .video.io.VideoFileClip import VideoFileClip
 from .video.io.ImageSequenceClip import ImageSequenceClip


### PR DESCRIPTION
This PR prevents PyGame from printing a support message to stdout every time it is imported. Importing any of the following without first importing moviepy.editor will still display the prompt:
moviepy.video.io.preview
moviepy.audio.io.preview
moviepy.video.tools.tracking

The one-liner could also be added to the above files.
This PR is an alternative to #988 that doesn't require another dependency.

See https://github.com/pygame/pygame/issues/542 for details and discussion about the prompt.