### PR TITLE
Don't close the audio reader which might be linked from a shallow copy.

### DIFF
--- a/moviepy/audio/io/AudioFileClip.py
+++ b/moviepy/audio/io/AudioFileClip.py
@@ -87,8 +87,8 @@ class AudioFileClip(AudioClip):
     def close(self):
         """ Close the internal reader. """
         if self.reader:
+            self.reader.close_proc()
             self.reader = None
 
     def __del__(self):
-        self.reader.close_proc()
         self.close()

--- a/moviepy/audio/io/AudioFileClip.py
+++ b/moviepy/audio/io/AudioFileClip.py
@@ -90,4 +90,5 @@ class AudioFileClip(AudioClip):
             self.reader = None
 
     def __del__(self):
+        self.reader.close_proc()
         self.close()

--- a/moviepy/audio/io/AudioFileClip.py
+++ b/moviepy/audio/io/AudioFileClip.py
@@ -87,7 +87,6 @@ class AudioFileClip(AudioClip):
     def close(self):
         """ Close the internal reader. """
         if self.reader:
-            self.reader.close_proc()
             self.reader = None
 
     def __del__(self):

--- a/tests/test_VideoFileClip.py
+++ b/tests/test_VideoFileClip.py
@@ -46,7 +46,7 @@ def test_shallow_copy():
     """Call a function which uses @outplace
        and verify that making a shallow copy and deleting it
        does not corrupt the original clip."""
-    video_file = 'media/big_buck_bunny_432_433.webm'
+    video_file = 'media/big_buck_bunny_0_30.webm'
     video = VideoFileClip(video_file)
     video_copy = video.set_start(1)
     del(video_copy)

--- a/tests/test_VideoFileClip.py
+++ b/tests/test_VideoFileClip.py
@@ -50,7 +50,13 @@ def test_shallow_copy():
     video = VideoFileClip(video_file)
     video_copy = video.set_start(1)
     del(video_copy)
-    video.audio.make_frame(2)
+    # The clip object buffers 200000 frames, around 5 seconds ahead.
+    # When recentering the buffer, if the new buffer is more than 1000000 frames, around 25s
+    # ahead of the end of the current buffer, the reader will reinitialize and fix self.proc
+    # Thus to trigger the bug, you have to look for a frame between ~5 and ~30 seconds away.
+    # These numbers might vary for different reasons and it would be nice to have a test
+    # which was robust to changes in default buffer size, etc.
+    video.audio.make_frame(15)
 
 
 if __name__ == '__main__':

--- a/tests/test_VideoFileClip.py
+++ b/tests/test_VideoFileClip.py
@@ -49,7 +49,7 @@ def test_shallow_copy():
     video_file = 'media/big_buck_bunny_0_30.webm'
     video = VideoFileClip(video_file)
     video_copy = video.set_start(1)
-    del(video_copy)
+    del video_copy
     # The clip object buffers 200000 frames, around 5 seconds ahead.
     # When recentering the buffer, if the new buffer is more than 1000000 frames, around 25s
     # ahead of the end of the current buffer, the reader will reinitialize and fix self.proc

--- a/tests/test_VideoFileClip.py
+++ b/tests/test_VideoFileClip.py
@@ -41,6 +41,17 @@ def test_ffmpeg_resizing():
                 assert target == observed
         video.close()
 
+        
+def test_shallow_copy():
+    """Call a function which uses @outplace
+       and verify that making a shallow copy and deleting it
+       does not corrupt the original clip."""
+    video_file = 'media/big_buck_bunny_432_433.webm'
+    video = VideoFileClip(video_file)
+    video_copy = video.set_start(1)
+    del(video_copy)
+    video.audio.make_frame(2)
+
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
This fixes #1025 

A recent change closed the audio reader object when the video file reader object was closed. However the former could be shared between the clip being closed and another clip which was still needed, because of shallow copying, I think it's fine to let the garbage collector `del` the reader object when it's definitively no longer needed.

(Strikethrough - not applicable or not needed):
<!-- Please tick when you have done these. They don't need to all be completed before the PR is created -->
- [X] If this is a bugfix, I have provided code that clearly demonstrates the problem and that works when used with this PR
- [X] I have added a test to the test suite, if necessary
- [X] ~~I have properly documented new or changed features in the documention, or the docstrings~~
- [X] ~~I have properly documented unusual changes to the code in the comments around it~~
- [X] ~~I have made note of any breaking/backwards incompatible changes~~

