### PR TITLE
Upgrade pip by calling via python (in appveyor).

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
   # the parent CMD process).
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
-  - pip install --upgrade pip --user
+  - python -m pip install --upgrade pip --user
   - pip install pipenv
 
   # Find latest image magick version by parsing website


### PR DESCRIPTION
Currently the appveyor build is broken. See for instance https://ci.appveyor.com/project/Zulko/moviepy/builds/30261132

As recommended in the appveyor error message, we can fix by  calling `python -m pip` instead of `pip` when upgrading pip.

(The usual tasks don't seem applicable here.)
