### PR TITLE
Fixed name of optional dependency on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ Running `build_docs` has additional dependencies that require installation.
 
 .. code:: bash
 
-    $ (sudo) pip install moviepy[docs]
+    $ (sudo) pip install moviepy[doc]
 
 The documentation can be generated and viewed via:
 


### PR DESCRIPTION
The name of the extra dependency in the setup.py is doc, which is incorrectly documented in the README and will throw error " moviepy 1.0.2 does not provide the extra 'docs'"
