### PR TITLE
Fixed error message for build docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ if "build_docs" in sys.argv:
     except ImportError:
         raise ImportError(
             "Running the documenation builds has additional"
-            " dependencies. Please run (pip install moviepy[docs])"
+            " dependencies. Please run (pip install moviepy[doc])"
         )
 
     cmdclass["build_docs"] = BuildDoc


### PR DESCRIPTION
Changed "docs" to doc since that is the correct optional dependency name