### PR TITLE
Fix TextClip.list("color") returning an incorrect list of byte objects, not strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed <!-- for any bug fixes -->
 - When using `VideoClip.write_videofile()` with `write_logfile=True`, errors would not be properly reported [#890]
+- `TextClip.list("color")` now returns a list of bytes, not strings [#1119]
+- `TextClip.search("colorname", "color")` does not crash with a TypeError [#1119]
 
 
 ## [v1.0.2](https://github.com/zulko/moviepy/tree/v1.0.2) (2020-03-26)

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1269,8 +1269,8 @@ class TextClip(ImageClip):
 
     @staticmethod
     def list(arg):
-        """Returns the list of all valid entries for the argument of
-        ``TextClip`` given (can be ``font``, ``color``, etc...) """
+        """Returns a list of all valid entries for the ``font`` or ``color`` argument of
+        ``TextClip``"""
 
         popen_params = {"stdout": sp.PIPE, "stderr": sp.DEVNULL, "stdin": sp.DEVNULL}
 
@@ -1280,15 +1280,15 @@ class TextClip(ImageClip):
         process = sp.Popen(
             [get_setting("IMAGEMAGICK_BINARY"), "-list", arg], **popen_params
         )
-        result = process.communicate()[0]
+        result = process.communicate()[0].decode()
         lines = result.splitlines()
 
         if arg == "font":
-            return [l.decode("UTF-8")[8:] for l in lines if l.startswith(b"  Font:")]
+            return [l[8:] for l in lines if l.startswith("  Font:")]
         elif arg == "color":
-            return [l.split(b" ")[0] for l in lines[2:]]
+            return [l.split(" ")[0] for l in lines[5:]]
         else:
-            raise Exception("Moviepy:Error! Argument must equal " "'font' or 'color'")
+            raise Exception("Moviepy Error: Argument must equal 'font' or 'color'")
 
     @staticmethod
     def search(string, arg):
@@ -1296,7 +1296,7 @@ class TextClip(ImageClip):
            argument ``arg`` of ``TextClip``, for instance
 
            >>> # Find all the available fonts which contain "Courier"
-           >>> print ( TextClip.search('Courier', 'font') )
+           >>> print(TextClip.search('Courier', 'font'))
 
         """
         string = string.lower()

--- a/tests/test_TextClip.py
+++ b/tests/test_TextClip.py
@@ -9,8 +9,22 @@ from moviepy.video.VideoClip import TextClip
 from .test_helper import FONT
 
 
-def test_fontlist():
-    TextClip.list("font")
+def test_list():
+    fonts = TextClip.list("font")
+    assert isinstance(fonts, list)
+    assert isinstance(fonts[0], str)
+
+    colors = TextClip.list("color")
+    assert isinstance(colors, list)
+    assert isinstance(colors[0], str)
+    assert "blue" in colors
+
+
+def test_search():
+    blues = TextClip.search("blue", "color")
+    assert isinstance(blues, list)
+    assert isinstance(blues[0], str)
+    assert "blue" in blues
 
 
 def test_duration():
@@ -43,4 +57,6 @@ def test_if_textclip_crashes_in_label_mode():
 
 
 if __name__ == "__main__":
-    pytest.main()
+    # pytest.main()
+    test_list()
+    test_search()

--- a/tests/test_TextClip.py
+++ b/tests/test_TextClip.py
@@ -57,6 +57,4 @@ def test_if_textclip_crashes_in_label_mode():
 
 
 if __name__ == "__main__":
-    # pytest.main()
-    test_list()
-    test_search()
+    pytest.main()


### PR DESCRIPTION
Before:

    >>> TextClip.list("color")
    [b'', b'Name', b'-------------------------------------------------------------------------------', b'AliceBlue', b'AntiqueWhite', b'AntiqueWhite1', b'AntiqueWhite2', b'AntiqueWhite3', b'AntiqueWhite4', b'aqua', b'aquamarine', b'aquamarine1', b'aquamarine2', b'aquamarine3', b'aquamarine4', b'azure', b'azure1', b'azure2', b'azure3', b'azure4', b'beige', b'bisque', b'bisque1', b'bisque2', b'bisque3', b'bisque4', b'black', b'BlanchedAlmond', b'blue', b'blue1', b'blue2', b'blue3', b'blue4', b'BlueViolet', b'brown', b'brown1', b'brown2', b'brown3', b'brown4', b'burlywood', b'burlywood1', b'burlywood2', b'burlywood3', b'burlywood4', b'CadetBlue', b'CadetBlue1', b'CadetBlue2', b'CadetBlue3', b'CadetBlue4', b'chartreuse', b'chartreuse1', b'chartreuse2', b'chartreuse3', b'chartreuse4', b'chocolate', b'chocolate1', b'chocolate2', b'chocolate3', b'chocolate4', b'coral', b'coral1', b'coral2', b'coral3', b'coral4', b'CornflowerBlue', b'cornsilk', b'cornsilk1', b'cornsilk2', b'cornsilk3', b'cornsilk4', b'crimson', b'cyan', b'cyan1', b'cyan2', b'cyan3', b'cyan4', b'DarkBlue', b'DarkCyan', b'DarkGoldenrod', b'DarkGoldenrod1', b'DarkGoldenrod2', b'DarkGoldenrod3', b'DarkGoldenrod4', b'DarkGray', b'DarkGreen', b'DarkGrey', b'DarkKhaki', b'DarkMagenta', b'DarkOliveGreen', b'DarkOliveGreen1', b'DarkOliveGreen2', b'DarkOliveGreen3', b'DarkOliveGreen4', b'DarkOrange', b'DarkOrange1', b'DarkOrange2', b'DarkOrange3', b'DarkOrange4', b'DarkOrchid', b'DarkOrchid1', b'DarkOrchid2', b'DarkOrchid3', b'DarkOrchid4', b'DarkRed', b'DarkSalmon', b'DarkSeaGreen', b'DarkSeaGreen1', b'DarkSeaGreen2', b'DarkSeaGreen3', b'DarkSeaGreen4', b'DarkSlateBlue', b'DarkSlateGray', b'DarkSlateGray1', b'DarkSlateGray2', b'DarkSlateGray3', b'DarkSlateGray4', b'DarkSlateGrey', b'DarkTurquoise', b'DarkViolet', b'DeepPink', b'DeepPink1', b'DeepPink2', b'DeepPink3', b'DeepPink4', b'DeepSkyBlue', b'DeepSkyBlue1', b'DeepSkyBlue2', b'DeepSkyBlue3', b'DeepSkyBlue4', b'DimGray', b'DimGrey', b'DodgerBlue', b'DodgerBlue1', b'DodgerBlue2', b'DodgerBlue3', b'DodgerBlue4', b'firebrick', b'firebrick1', b'firebrick2', b'firebrick3', b'firebrick4', b'FloralWhite', b'ForestGreen', b'fractal', b'freeze', b'fuchsia', b'gainsboro', b'GhostWhite', b'gold', b'gold1', b'gold2', b'gold3', b'gold4', b'goldenrod', b'goldenrod1', b'goldenrod2', b'goldenrod3', b'goldenrod4', b'gray', b'gray', b'gray0', b'gray1', b'gray10', b'gray100', b'gray100', b'gray11', b'gray12', b'gray13', b'gray14', b'gray15', b'gray16', b'gray17', b'gray18', b'gray19', b'gray2', b'gray20', b'gray21', b'gray22', b'gray23', b'gray24', b'gray25', b'gray26', b'gray27', b'gray28', b'gray29', b'gray3', b'gray30', b'gray31', b'gray32', b'gray33', b'gray34', b'gray35', b'gray36', b'gray37', b'gray38', b'gray39', b'gray4', b'gray40', b'gray41', b'gray42', b'gray43', b'gray44', b'gray45', b'gray46', b'gray47', b'gray48', b'gray49', b'gray5', b'gray50', b'gray51', b'gray52', b'gray53', b'gray54', b'gray55', b'gray56', b'gray57', b'gray58', b'gray59', b'gray6', b'gray60', b'gray61', b'gray62', b'gray63', b'gray64', b'gray65', b'gray66', b'gray67', b'gray68', b'gray69', b'gray7', b'gray70', b'gray71', b'gray72', b'gray73', b'gray74', b'gray75', b'gray76', b'gray77', b'gray78', b'gray79', b'gray8', b'gray80', b'gray81', b'gray82', b'gray83', b'gray84', b'gray85', b'gray86', b'gray87', b'gray88', b'gray89', b'gray9', b'gray90', b'gray91', b'gray92', b'gray93', b'gray94', b'gray95', b'gray96', b'gray97', b'gray98', b'gray99', b'green', b'green', b'green1', b'green2', b'green3', b'green4', b'GreenYellow', b'grey', b'grey0', b'grey1', b'grey10', b'grey100', b'grey11', b'grey12', b'grey13', b'grey14', b'grey15', b'grey16', b'grey17', b'grey18', b'grey19', b'grey2', b'grey20', b'grey21', b'grey22', b'grey23', b'grey24', b'grey25', b'grey26', b'grey27', b'grey28', b'grey29', b'grey3', b'grey30', b'grey31', b'grey32', b'grey33', b'grey34', b'grey35', b'grey36', b'grey37', b'grey38', b'grey39', b'grey4', b'grey40', b'grey41', b'grey42', b'grey43', b'grey44', b'grey45', b'grey46', b'grey47', b'grey48', b'grey49', b'grey5', b'grey50', b'grey51', b'grey52', b'grey53', b'grey54', b'grey55', b'grey56', b'grey57', b'grey58', b'grey59', b'grey6', b'grey60', b'grey61', b'grey62', b'grey63', b'grey64', b'grey65', b'grey66', b'grey67', b'grey68', b'grey69', b'grey7', b'grey70', b'grey71', b'grey72', b'grey73', b'grey74', b'grey75', b'grey76', b'grey77', b'grey78', b'grey79', b'grey8', b'grey80', b'grey81', b'grey82', b'grey83', b'grey84', b'grey85', b'grey86', b'grey87', b'grey88', b'grey89', b'grey9', b'grey90', b'grey91', b'grey92', b'grey93', b'grey94', b'grey95', b'grey96', b'grey97', b'grey98', b'grey99', b'honeydew', b'honeydew1', b'honeydew2', b'honeydew3', b'honeydew4', b'HotPink', b'HotPink1', b'HotPink2', b'HotPink3', b'HotPink4', b'IndianRed', b'IndianRed1', b'IndianRed2', b'IndianRed3', b'IndianRed4', b'indigo', b'ivory', b'ivory1', b'ivory2', b'ivory3', b'ivory4', b'khaki', b'khaki1', b'khaki2', b'khaki3', b'khaki4', b'lavender', b'LavenderBlush', b'LavenderBlush1', b'LavenderBlush2', b'LavenderBlush3', b'LavenderBlush4', b'LawnGreen', b'LemonChiffon', b'LemonChiffon1', b'LemonChiffon2', b'LemonChiffon3', b'LemonChiffon4', b'LightBlue', b'LightBlue1', b'LightBlue2', b'LightBlue3', b'LightBlue4', b'LightCoral', b'LightCyan', b'LightCyan1', b'LightCyan2', b'LightCyan3', b'LightCyan4', b'LightGoldenrod', b'LightGoldenrod1', b'LightGoldenrod2', b'LightGoldenrod3', b'LightGoldenrod4', b'LightGoldenrodYellow', b'LightGray', b'LightGreen', b'LightGrey', b'LightPink', b'LightPink1', b'LightPink2', b'LightPink3', b'LightPink4', b'LightSalmon', b'LightSalmon1', b'LightSalmon2', b'LightSalmon3', b'LightSalmon4', b'LightSeaGreen', b'LightSkyBlue', b'LightSkyBlue1', b'LightSkyBlue2', b'LightSkyBlue3', b'LightSkyBlue4', b'LightSlateBlue', b'LightSlateGray', b'LightSlateGrey', b'LightSteelBlue', b'LightSteelBlue1', b'LightSteelBlue2', b'LightSteelBlue3', b'LightSteelBlue4', b'LightYellow', b'LightYellow1', b'LightYellow2', b'LightYellow3', b'LightYellow4', b'lime', b'LimeGreen', b'linen', b'magenta', b'magenta1', b'magenta2', b'magenta3', b'magenta4', b'maroon', b'maroon', b'maroon1', b'maroon2', b'maroon3', b'maroon4', b'matte', b'MediumAquamarine', b'MediumBlue', b'MediumForestGreen', b'MediumGoldenRod', b'MediumOrchid', b'MediumOrchid1', b'MediumOrchid2', b'MediumOrchid3', b'MediumOrchid4', b'MediumPurple', b'MediumPurple1', b'MediumPurple2', b'MediumPurple3', b'MediumPurple4', b'MediumSeaGreen', b'MediumSlateBlue', b'MediumSpringGreen', b'MediumTurquoise', b'MediumVioletRed', b'MidnightBlue', b'MintCream', b'MistyRose', b'MistyRose1', b'MistyRose2', b'MistyRose3', b'MistyRose4', b'moccasin', b'NavajoWhite', b'NavajoWhite1', b'NavajoWhite2', b'NavajoWhite3', b'NavajoWhite4', b'navy', b'NavyBlue', b'none', b'OldLace', b'olive', b'OliveDrab', b'OliveDrab1', b'OliveDrab2', b'OliveDrab3', b'OliveDrab4', b'opaque', b'orange', b'orange1', b'orange2', b'orange3', b'orange4', b'OrangeRed', b'OrangeRed1', b'OrangeRed2', b'OrangeRed3', b'OrangeRed4', b'orchid', b'orchid1', b'orchid2', b'orchid3', b'orchid4', b'PaleGoldenrod', b'PaleGreen', b'PaleGreen1', b'PaleGreen2', b'PaleGreen3', b'PaleGreen4', b'PaleTurquoise', b'PaleTurquoise1', b'PaleTurquoise2', b'PaleTurquoise3', b'PaleTurquoise4', b'PaleVioletRed', b'PaleVioletRed1', b'PaleVioletRed2', b'PaleVioletRed3', b'PaleVioletRed4', b'PapayaWhip', b'PeachPuff', b'PeachPuff1', b'PeachPuff2', b'PeachPuff3', b'PeachPuff4', b'peru', b'pink', b'pink1', b'pink2', b'pink3', b'pink4', b'plum', b'plum1', b'plum2', b'plum3', b'plum4', b'PowderBlue', b'purple', b'purple', b'purple1', b'purple2', b'purple3', b'purple4', b'red', b'red1', b'red2', b'red3', b'red4', b'RosyBrown', b'RosyBrown1', b'RosyBrown2', b'RosyBrown3', b'RosyBrown4', b'RoyalBlue', b'RoyalBlue1', b'RoyalBlue2', b'RoyalBlue3', b'RoyalBlue4', b'SaddleBrown', b'salmon', b'salmon1', b'salmon2', b'salmon3', b'salmon4', b'SandyBrown', b'SeaGreen', b'SeaGreen1', b'SeaGreen2', b'SeaGreen3', b'SeaGreen4', b'seashell', b'seashell1', b'seashell2', b'seashell3', b'seashell4', b'sienna', b'sienna1', b'sienna2', b'sienna3', b'sienna4', b'silver', b'SkyBlue', b'SkyBlue1', b'SkyBlue2', b'SkyBlue3', b'SkyBlue4', b'SlateBlue', b'SlateBlue1', b'SlateBlue2', b'SlateBlue3', b'SlateBlue4', b'SlateGray', b'SlateGray1', b'SlateGray2', b'SlateGray3', b'SlateGray4', b'SlateGrey', b'snow', b'snow1', b'snow2', b'snow3', b'snow4', b'SpringGreen', b'SpringGreen1', b'SpringGreen2', b'SpringGreen3', b'SpringGreen4', b'SteelBlue', b'SteelBlue1', b'SteelBlue2', b'SteelBlue3', b'SteelBlue4', b'tan', b'tan1', b'tan2', b'tan3', b'tan4', b'teal', b'thistle', b'thistle1', b'thistle2', b'thistle3', b'thistle4', b'tomato', b'tomato1', b'tomato2', b'tomato3', b'tomato4', b'transparent', b'turquoise', b'turquoise1', b'turquoise2', b'turquoise3', b'turquoise4', b'violet', b'VioletRed', b'VioletRed1', b'VioletRed2', b'VioletRed3', b'VioletRed4', b'wheat', b'wheat1', b'wheat2', b'wheat3', b'wheat4', b'white', b'WhiteSmoke', b'yellow', b'yellow1', b'yellow2', b'yellow3', b'yellow4', b'YellowGreen']

After:

    >>> TextClip.list("color")
    ['AliceBlue', 'AntiqueWhite', 'AntiqueWhite1', 'AntiqueWhite2', 'AntiqueWhite3', 'AntiqueWhite4', 'aqua', 'aquamarine', 'aquamarine1', 'aquamarine2', 'aquamarine3', 'aquamarine4', 'azure', 'azure1', 'azure2', 'azure3', 'azure4', 'beige', 'bisque', 'bisque1', 'bisque2', 'bisque3', 'bisque4', 'black', 'BlanchedAlmond', 'blue', 'blue1', 'blue2', 'blue3', 'blue4', 'BlueViolet', 'brown', 'brown1', 'brown2', 'brown3', 'brown4', 'burlywood', 'burlywood1', 'burlywood2', 'burlywood3', 'burlywood4', 'CadetBlue', 'CadetBlue1', 'CadetBlue2', 'CadetBlue3', 'CadetBlue4', 'chartreuse', 'chartreuse1', 'chartreuse2', 'chartreuse3', 'chartreuse4', 'chocolate', 'chocolate1', 'chocolate2', 'chocolate3', 'chocolate4', 'coral', 'coral1', 'coral2', 'coral3', 'coral4', 'CornflowerBlue', 'cornsilk', 'cornsilk1', 'cornsilk2', 'cornsilk3', 'cornsilk4', 'crimson', 'cyan', 'cyan1', 'cyan2', 'cyan3', 'cyan4', 'DarkBlue', 'DarkCyan', 'DarkGoldenrod', 'DarkGoldenrod1', 'DarkGoldenrod2', 'DarkGoldenrod3', 'DarkGoldenrod4', 'DarkGray', 'DarkGreen', 'DarkGrey', 'DarkKhaki', 'DarkMagenta', 'DarkOliveGreen', 'DarkOliveGreen1', 'DarkOliveGreen2', 'DarkOliveGreen3', 'DarkOliveGreen4', 'DarkOrange', 'DarkOrange1', 'DarkOrange2', 'DarkOrange3', 'DarkOrange4', 'DarkOrchid', 'DarkOrchid1', 'DarkOrchid2', 'DarkOrchid3', 'DarkOrchid4', 'DarkRed', 'DarkSalmon', 'DarkSeaGreen', 'DarkSeaGreen1', 'DarkSeaGreen2', 'DarkSeaGreen3', 'DarkSeaGreen4', 'DarkSlateBlue', 'DarkSlateGray', 'DarkSlateGray1', 'DarkSlateGray2', 'DarkSlateGray3', 'DarkSlateGray4', 'DarkSlateGrey', 'DarkTurquoise', 'DarkViolet', 'DeepPink', 'DeepPink1', 'DeepPink2', 'DeepPink3', 'DeepPink4', 'DeepSkyBlue', 'DeepSkyBlue1', 'DeepSkyBlue2', 'DeepSkyBlue3', 'DeepSkyBlue4', 'DimGray', 'DimGrey', 'DodgerBlue', 'DodgerBlue1', 'DodgerBlue2', 'DodgerBlue3', 'DodgerBlue4', 'firebrick', 'firebrick1', 'firebrick2', 'firebrick3', 'firebrick4', 'FloralWhite', 'ForestGreen', 'fractal', 'freeze', 'fuchsia', 'gainsboro', 'GhostWhite', 'gold', 'gold1', 'gold2', 'gold3', 'gold4', 'goldenrod', 'goldenrod1', 'goldenrod2', 'goldenrod3', 'goldenrod4', 'gray', 'gray', 'gray0', 'gray1', 'gray10', 'gray100', 'gray100', 'gray11', 'gray12', 'gray13', 'gray14', 'gray15', 'gray16', 'gray17', 'gray18', 'gray19', 'gray2', 'gray20', 'gray21', 'gray22', 'gray23', 'gray24', 'gray25', 'gray26', 'gray27', 'gray28', 'gray29', 'gray3', 'gray30', 'gray31', 'gray32', 'gray33', 'gray34', 'gray35', 'gray36', 'gray37', 'gray38', 'gray39', 'gray4', 'gray40', 'gray41', 'gray42', 'gray43', 'gray44', 'gray45', 'gray46', 'gray47', 'gray48', 'gray49', 'gray5', 'gray50', 'gray51', 'gray52', 'gray53', 'gray54', 'gray55', 'gray56', 'gray57', 'gray58', 'gray59', 'gray6', 'gray60', 'gray61', 'gray62', 'gray63', 'gray64', 'gray65', 'gray66', 'gray67', 'gray68', 'gray69', 'gray7', 'gray70', 'gray71', 'gray72', 'gray73', 'gray74', 'gray75', 'gray76', 'gray77', 'gray78', 'gray79', 'gray8', 'gray80', 'gray81', 'gray82', 'gray83', 'gray84', 'gray85', 'gray86', 'gray87', 'gray88', 'gray89', 'gray9', 'gray90', 'gray91', 'gray92', 'gray93', 'gray94', 'gray95', 'gray96', 'gray97', 'gray98', 'gray99', 'green', 'green', 'green1', 'green2', 'green3', 'green4', 'GreenYellow', 'grey', 'grey0', 'grey1', 'grey10', 'grey100', 'grey11', 'grey12', 'grey13', 'grey14', 'grey15', 'grey16', 'grey17', 'grey18', 'grey19', 'grey2', 'grey20', 'grey21', 'grey22', 'grey23', 'grey24', 'grey25', 'grey26', 'grey27', 'grey28', 'grey29', 'grey3', 'grey30', 'grey31', 'grey32', 'grey33', 'grey34', 'grey35', 'grey36', 'grey37', 'grey38', 'grey39', 'grey4', 'grey40', 'grey41', 'grey42', 'grey43', 'grey44', 'grey45', 'grey46', 'grey47', 'grey48', 'grey49', 'grey5', 'grey50', 'grey51', 'grey52', 'grey53', 'grey54', 'grey55', 'grey56', 'grey57', 'grey58', 'grey59', 'grey6', 'grey60', 'grey61', 'grey62', 'grey63', 'grey64', 'grey65', 'grey66', 'grey67', 'grey68', 'grey69', 'grey7', 'grey70', 'grey71', 'grey72', 'grey73', 'grey74', 'grey75', 'grey76', 'grey77', 'grey78', 'grey79', 'grey8', 'grey80', 'grey81', 'grey82', 'grey83', 'grey84', 'grey85', 'grey86', 'grey87', 'grey88', 'grey89', 'grey9', 'grey90', 'grey91', 'grey92', 'grey93', 'grey94', 'grey95', 'grey96', 'grey97', 'grey98', 'grey99', 'honeydew', 'honeydew1', 'honeydew2', 'honeydew3', 'honeydew4', 'HotPink', 'HotPink1', 'HotPink2', 'HotPink3', 'HotPink4', 'IndianRed', 'IndianRed1', 'IndianRed2', 'IndianRed3', 'IndianRed4', 'indigo', 'ivory', 'ivory1', 'ivory2', 'ivory3', 'ivory4', 'khaki', 'khaki1', 'khaki2', 'khaki3', 'khaki4', 'lavender', 'LavenderBlush', 'LavenderBlush1', 'LavenderBlush2', 'LavenderBlush3', 'LavenderBlush4', 'LawnGreen', 'LemonChiffon', 'LemonChiffon1', 'LemonChiffon2', 'LemonChiffon3', 'LemonChiffon4', 'LightBlue', 'LightBlue1', 'LightBlue2', 'LightBlue3', 'LightBlue4', 'LightCoral', 'LightCyan', 'LightCyan1', 'LightCyan2', 'LightCyan3', 'LightCyan4', 'LightGoldenrod', 'LightGoldenrod1', 'LightGoldenrod2', 'LightGoldenrod3', 'LightGoldenrod4', 'LightGoldenrodYellow', 'LightGray', 'LightGreen', 'LightGrey', 'LightPink', 'LightPink1', 'LightPink2', 'LightPink3', 'LightPink4', 'LightSalmon', 'LightSalmon1', 'LightSalmon2', 'LightSalmon3', 'LightSalmon4', 'LightSeaGreen', 'LightSkyBlue', 'LightSkyBlue1', 'LightSkyBlue2', 'LightSkyBlue3', 'LightSkyBlue4', 'LightSlateBlue', 'LightSlateGray', 'LightSlateGrey', 'LightSteelBlue', 'LightSteelBlue1', 'LightSteelBlue2', 'LightSteelBlue3', 'LightSteelBlue4', 'LightYellow', 'LightYellow1', 'LightYellow2', 'LightYellow3', 'LightYellow4', 'lime', 'LimeGreen', 'linen', 'magenta', 'magenta1', 'magenta2', 'magenta3', 'magenta4', 'maroon', 'maroon', 'maroon1', 'maroon2', 'maroon3', 'maroon4', 'matte', 'MediumAquamarine', 'MediumBlue', 'MediumForestGreen', 'MediumGoldenRod', 'MediumOrchid', 'MediumOrchid1', 'MediumOrchid2', 'MediumOrchid3', 'MediumOrchid4', 'MediumPurple', 'MediumPurple1', 'MediumPurple2', 'MediumPurple3', 'MediumPurple4', 'MediumSeaGreen', 'MediumSlateBlue', 'MediumSpringGreen', 'MediumTurquoise', 'MediumVioletRed', 'MidnightBlue', 'MintCream', 'MistyRose', 'MistyRose1', 'MistyRose2', 'MistyRose3', 'MistyRose4', 'moccasin', 'NavajoWhite', 'NavajoWhite1', 'NavajoWhite2', 'NavajoWhite3', 'NavajoWhite4', 'navy', 'NavyBlue', 'none', 'OldLace', 'olive', 'OliveDrab', 'OliveDrab1', 'OliveDrab2', 'OliveDrab3', 'OliveDrab4', 'opaque', 'orange', 'orange1', 'orange2', 'orange3', 'orange4', 'OrangeRed', 'OrangeRed1', 'OrangeRed2', 'OrangeRed3', 'OrangeRed4', 'orchid', 'orchid1', 'orchid2', 'orchid3', 'orchid4', 'PaleGoldenrod', 'PaleGreen', 'PaleGreen1', 'PaleGreen2', 'PaleGreen3', 'PaleGreen4', 'PaleTurquoise', 'PaleTurquoise1', 'PaleTurquoise2', 'PaleTurquoise3', 'PaleTurquoise4', 'PaleVioletRed', 'PaleVioletRed1', 'PaleVioletRed2', 'PaleVioletRed3', 'PaleVioletRed4', 'PapayaWhip', 'PeachPuff', 'PeachPuff1', 'PeachPuff2', 'PeachPuff3', 'PeachPuff4', 'peru', 'pink', 'pink1', 'pink2', 'pink3', 'pink4', 'plum', 'plum1', 'plum2', 'plum3', 'plum4', 'PowderBlue', 'purple', 'purple', 'purple1', 'purple2', 'purple3', 'purple4', 'red', 'red1', 'red2', 'red3', 'red4', 'RosyBrown', 'RosyBrown1', 'RosyBrown2', 'RosyBrown3', 'RosyBrown4', 'RoyalBlue', 'RoyalBlue1', 'RoyalBlue2', 'RoyalBlue3', 'RoyalBlue4', 'SaddleBrown', 'salmon', 'salmon1', 'salmon2', 'salmon3', 'salmon4', 'SandyBrown', 'SeaGreen', 'SeaGreen1', 'SeaGreen2', 'SeaGreen3', 'SeaGreen4', 'seashell', 'seashell1', 'seashell2', 'seashell3', 'seashell4', 'sienna', 'sienna1', 'sienna2', 'sienna3', 'sienna4', 'silver', 'SkyBlue', 'SkyBlue1', 'SkyBlue2', 'SkyBlue3', 'SkyBlue4', 'SlateBlue', 'SlateBlue1', 'SlateBlue2', 'SlateBlue3', 'SlateBlue4', 'SlateGray', 'SlateGray1', 'SlateGray2', 'SlateGray3', 'SlateGray4', 'SlateGrey', 'snow', 'snow1', 'snow2', 'snow3', 'snow4', 'SpringGreen', 'SpringGreen1', 'SpringGreen2', 'SpringGreen3', 'SpringGreen4', 'SteelBlue', 'SteelBlue1', 'SteelBlue2', 'SteelBlue3', 'SteelBlue4', 'tan', 'tan1', 'tan2', 'tan3', 'tan4', 'teal', 'thistle', 'thistle1', 'thistle2', 'thistle3', 'thistle4', 'tomato', 'tomato1', 'tomato2', 'tomato3', 'tomato4', 'transparent', 'turquoise', 'turquoise1', 'turquoise2', 'turquoise3', 'turquoise4', 'violet', 'VioletRed', 'VioletRed1', 'VioletRed2', 'VioletRed3', 'VioletRed4', 'wheat', 'wheat1', 'wheat2', 'wheat3', 'wheat4', 'white', 'WhiteSmoke', 'yellow', 'yellow1', 'yellow2', 'yellow3', 'yellow4', 'YellowGreen']

So you can see that as well as not decoding the output when `arg="color"`, it didn't remove enough lines at the start, so I've increased the slice index from 2 to 5 to fix this.

I've also added some tests.

This also fixes `TextClip.search("***", "color")`, which expects a list of strings, not bytes and previously failed with the following error:

```
Traceback (most recent call last):
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/tests/test_TextClip.py", line 65, in <module>
    test_search()
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/tests/test_TextClip.py", line 27, in test_search
    blues = TextClip.search("blue", "color")
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/moviepy/video/VideoClip.py", line 1304, in search
    return [name for name in names_list if string in name.lower()]
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/moviepy/video/VideoClip.py", line 1304, in <listcomp>
    return [name for name in names_list if string in name.lower()]
TypeError: a bytes-like object is required, not 'str'
```

- [x] <!--Only relevant if this is a bug fix-->I have provided code that clearly demonstrates the bug and only works correctly when used with this PR
- [x] I have added suitable tests to the test suite in `tests/`
- [x] I formatted my code using `black -t py36` 