### PR TITLE
videoclip adds a mechanism to save the video alpha channel

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -268,7 +268,7 @@ class VideoClip(Clip):
         with_mask
           If video has alpha channel, and you want to keep it after processing, this parameter must be True
           You can use any FFMPEG encoding format that supports alpha channels.
-          Examples are 'png、qtrle' for '.mov'
+          Examples are 'png/qtrle' for '.mov'
           Note: 'png' encoding maybe takes long time, but the resulting video is small,
                 'qtrle' is the opposite
 
@@ -288,7 +288,6 @@ class VideoClip(Clip):
         >>> clip.write_videofile("my_new_video.mp4", codec='qtrle', with_mask=True) # is fail, FFMPEG will throw an exception: "codec not currently supported in container", because 'qtrle' not support '.mp4'
         >>> clip.write_videofile("my_new_video.mp4", codec='libx264', with_mask=True) # is bad, because 'libx264' not support alpha channel, video will lose the alpha channel
         >>> clip.close()
-
 
         """
         name, ext = os.path.splitext(os.path.basename(filename))

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -739,7 +739,7 @@ class VideoClip(Clip):
         self.size = self.get_frame(0).shape[:2][::-1]
 
     @outplace
-    def set_audio(self, audioclip, start_time=0, keep_original=True):
+    def set_audio(self, audioclip, start_time=0, keep_original=False):
         """
         Attach an AudioClip to the VideoClip.
         :param audioclip: new audioclip

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -268,7 +268,7 @@ class VideoClip(Clip):
         with_mask
           If video has alpha channel, and you want to keep it after processing, this parameter must be True
           You can use any FFMPEG encoding format that supports alpha channels.
-          Examples are 'png/qtrle' for '.mov'
+          Examples are 'png/qtrle' for '.mov', 'png' for '.mp4', 'vp8/vp9' for '.webm'
           Note: 'png' encoding maybe takes long time, but the resulting video is small,
                 'qtrle' is the opposite
 

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -268,8 +268,8 @@ class VideoClip(Clip):
         with_mask
           If video has alpha channel, and you want to keep it after processing, this parameter must be True
           You can use any FFMPEG encoding format that supports alpha channels.
-          Examples are 'png/qtrle' for '.mov', 'png' for '.mp4', 'vp8/vp9' for '.webm'
-          Note: 'png' encoding maybe takes long time, but the resulting video is small,
+          Examples are 'png/qtrle' for '.mov', 'png' for '.mp4', 'vp8/vp9' for '.webm', 'vp6a' for '.flv/.f4v'
+          Tips: 'png' encoding maybe takes long time, but the resulting video is small for '.mov' format,
                 'qtrle' is the opposite
 
         Examples

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -289,6 +289,7 @@ class VideoClip(Clip):
         >>> clip.write_videofile("my_new_video.mp4", codec='libx264', with_mask=True) # is bad, because 'libx264' not support alpha channel, video will lose the alpha channel
         >>> clip.close()
 
+
         """
         name, ext = os.path.splitext(os.path.basename(filename))
         ext = ext[1:].lower()

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -34,6 +34,10 @@ from .io.ffmpeg_writer import ffmpeg_write_video
 from .io.gif_writers import write_gif, write_gif_with_image_io, write_gif_with_tempfiles
 from .tools.drawing import blit
 
+from moviepy.audio.fx.audio_loop import audio_loop
+from moviepy.audio.fx.volumex import volumex
+from moviepy.audio.AudioClip import concatenate_audioclips, CompositeAudioClip
+
 
 class VideoClip(Clip):
     """Base class for video clips.
@@ -735,7 +739,7 @@ class VideoClip(Clip):
         self.size = self.get_frame(0).shape[:2][::-1]
 
     @outplace
-    def set_audio(self, audioclip, start_time=0, keep_original=False):
+    def set_audio(self, audioclip, start_time=0, keep_original=True):
         """
         Attach an AudioClip to the VideoClip.
         :param audioclip: new audioclip
@@ -745,12 +749,11 @@ class VideoClip(Clip):
         attribute set to ``audio``, which must be an AudioClip instance.
         """
         if start_time > 0:
-            from moviepy.editor import concatenate_audioclips
-            dummy = audioclip.audio_loop(duration=start_time).volumex(0).subclip(0, start_time)
+            dummy = audio_loop(audioclip, duration=start_time)
+            dummy = volumex(dummy, 0)
             audioclip = concatenate_audioclips([dummy, audioclip])
 
         if self.audio is not None and keep_original:
-            from moviepy.editor import CompositeAudioClip
             self.audio = CompositeAudioClip([self.audio, audioclip])
         else:
             self.audio = audioclip

--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -73,7 +73,7 @@ class FFMPEG_VideoWriter:
         audiofile=None,
         preset="medium",
         bitrate=None,
-        withmask=False,
+        with_mask=False,
         logfile=None,
         threads=None,
         ffmpeg_params=None,
@@ -99,7 +99,7 @@ class FFMPEG_VideoWriter:
             "-s",
             "%dx%d" % (size[0], size[1]),
             "-pix_fmt",
-            "rgba" if withmask else "rgb24",
+            "rgba" if with_mask else "rgb24",
             "-r",
             "%.02f" % fps,
             "-an",
@@ -217,7 +217,7 @@ def ffmpeg_write_video(
     codec="libx264",
     bitrate=None,
     preset="medium",
-    withmask=False,
+    with_mask=False,
     write_logfile=False,
     audiofile=None,
     verbose=True,
@@ -246,6 +246,7 @@ def ffmpeg_write_video(
         audiofile=audiofile,
         threads=threads,
         ffmpeg_params=ffmpeg_params,
+        with_mask=with_mask,
     ) as writer:
 
         nframes = int(clip.duration * fps)
@@ -253,7 +254,7 @@ def ffmpeg_write_video(
         for t, frame in clip.iter_frames(
             logger=logger, with_times=True, fps=fps, dtype="uint8"
         ):
-            if withmask:
+            if with_mask and clip.mask is not None:
                 mask = 255 * clip.mask.get_frame(t)
                 if mask.dtype != "uint8":
                     mask = mask.astype("uint8")


### PR DESCRIPTION
1. update video_clip.writefile function, add save video alpha channel mechanism
2. update video_clip.set_audio function, covers some frequently occurring cases

<!--
Please tick when you have done these. They don't need to all be completed before the PR is created.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have properly documented new or changed features in the documention or in the docstrings
- [ ] I formatted my code using `black -t py36` 