### PR TITLE
Fix for `ColorClip.rotate()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When using `VideoClip.write_videofile()` with `write_logfile=True`, errors would not be properly reported [#890]
 - `TextClip.list("color")` now returns a list of bytes, not strings [#1119]
 - `TextClip.search("colorname", "color")` does not crash with a TypeError [#1119]
+- Using `rotate()` with a `ColorClip` no longer crashes [#1139]
 
 
 ## [v1.0.2](https://github.com/zulko/moviepy/tree/v1.0.2) (2020-03-26)

--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -9,7 +9,7 @@ try:
 
     def pil_rotater(pic, angle, resample, expand):
         return np.array(
-            Image.fromarray(pic).rotate(angle, expand=expand, resample=resample)
+            Image.fromarray(np.array(pic).astype(np.uint8)).rotate(angle, expand=expand, resample=resample)
         )
 
 
@@ -78,7 +78,6 @@ def rotate(clip, angle, unit="deg", resample="bicubic", expand=True):
                 "pip install pillow"
             )
         else:
-            im = im.astype("uint8")
             return pil_rotater(im, a, resample=resample, expand=expand)
 
     return clip.fl(fl, apply_to=["mask"])

--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -9,7 +9,9 @@ try:
 
     def pil_rotater(pic, angle, resample, expand):
         return np.array(
-            Image.fromarray(np.array(pic).astype(np.uint8)).rotate(angle, expand=expand, resample=resample)
+            Image.fromarray(np.array(pic).astype(np.uint8)).rotate(
+                angle, expand=expand, resample=resample
+            )
         )
 
 

--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -8,6 +8,7 @@ try:
     PIL_FOUND = True
 
     def pil_rotater(pic, angle, resample, expand):
+        # Ensures that pic is of the correct type
         return np.array(
             Image.fromarray(np.array(pic).astype(np.uint8)).rotate(
                 angle, expand=expand, resample=resample

--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -78,6 +78,7 @@ def rotate(clip, angle, unit="deg", resample="bicubic", expand=True):
                 "pip install pillow"
             )
         else:
+            im = im.astype("uint8")
             return pil_rotater(im, a, resample=resample, expand=expand)
 
     return clip.fl(fl, apply_to=["mask"])

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -6,6 +6,7 @@ import pytest
 from moviepy.audio.fx.audio_normalize import audio_normalize
 from moviepy.audio.io.AudioFileClip import AudioFileClip
 from moviepy.utils import close_all_clips
+from moviepy.video.VideoClip import ColorClip
 from moviepy.video.fx.blackwhite import blackwhite
 
 # from moviepy.video.fx.blink import blink
@@ -216,6 +217,15 @@ def test_rotate():
     clip4 = rotate(clip, 360)  # rotate 90 degrees
     assert clip4.size == tuple(clip.size)
     clip4.write_videofile(os.path.join(TMP_DIR, "rotate4.webm"))
+
+    clip5 = rotate(clip, 50)
+    clip5.write_videofile(os.path.join(TMP_DIR, "rotate5.webm"))
+
+    # Test rotate with color clip
+    clip = ColorClip([600, 400], [150, 250, 100]).set_duration(1).set_fps(5)
+    clip = rotate(clip, 20)
+    clip.write_videofile(os.path.join(TMP_DIR, "color_rotate.webm"))
+
     close_all_clips(locals())
 
 


### PR DESCRIPTION
Fixes #1140.

Previously, attempting to use `clip.rotate(...)` when `clip` is a `ColorClip` would crash:

```
TypeError: Cannot handle this data type: (1, 1, 3), <i8

Traceback (most recent call last):
  File "/Users/tomburrows/miniconda3/envs/moviepy/lib/python3.7/site-packages/PIL/Image.py", line 2680, in fromarray
    mode, rawmode = _fromarray_typemap[typekey]
KeyError: ((1, 1, 3), '<i8')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/tom_t.py", line 64, in <module>
    c = c.rotate(lambda t: 45 + 3*t)
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/moviepy/video/fx/rotate.py", line 84, in rotate
    return clip.fl(fl, apply_to=["mask"])
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/moviepy/video/VideoClip.py", line 1000, in fl
    newclip = VideoClip.fl(self, fl, apply_to=apply_to, keep_duration=keep_duration)
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/moviepy/Clip.py", line 140, in fl
    newclip = self.set_make_frame(lambda t: fun(self.get_frame, t))
  File "</Users/tomburrows/miniconda3/envs/moviepy/lib/python3.7/site-packages/decorator.py:decorator-gen-61>", line 2, in set_make_frame
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/moviepy/decorators.py", line 14, in outplace
    f(newclip, *a, **k)
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/moviepy/video/VideoClip.py", line 721, in set_make_frame
    self.size = self.get_frame(0).shape[:2][::-1]
  File "</Users/tomburrows/miniconda3/envs/moviepy/lib/python3.7/site-packages/decorator.py:decorator-gen-11>", line 2, in get_frame
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/moviepy/decorators.py", line 87, in wrapper
    return f(*new_a, **new_kw)
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/moviepy/Clip.py", line 97, in get_frame
    return self.make_frame(t)
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/moviepy/Clip.py", line 140, in <lambda>
    newclip = self.set_make_frame(lambda t: fun(self.get_frame, t))
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/moviepy/video/fx/rotate.py", line 82, in fl
    return pil_rotater(im, a, resample=resample, expand=expand)
  File "/Users/tomburrows/Python/moviepy-dev/moviepy/moviepy/video/fx/rotate.py", line 12, in pil_rotater
    Image.fromarray(pic).rotate(angle, expand=expand, resample=resample)
  File "/Users/tomburrows/miniconda3/envs/moviepy/lib/python3.7/site-packages/PIL/Image.py", line 2682, in fromarray
    raise TypeError("Cannot handle this data type: %s, %s" % typekey)
TypeError: Cannot handle this data type: (1, 1, 3), <i8
```

Discovered on Stack Overflow: https://stackoverflow.com/questions/60940266

Explanation: when a ColorClip is created (for example `c = ColorClip([600, 400], color=[150, 200, 100])`), each pixel is stored as whatever is passed through as the `color` parameter. However, `Image.fromarray()` (from pillow) requires each pixel to be in the "uint8" format. When writing to a file, this is performed in `Clip.iter_frames()`, so this PR simply calls `.astype("uint8")` inside of `rotate()`.

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have formatted my code using `black -t py36` 