### PR TITLE
Allow setting tempfile path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Autodetect ImageMagick executable on Windows [#1109]
 - Optionally configure paths to FFmpeg and ImageMagick binaries with environment variables or a ``.env`` file [#1109]
 - Optional `encoding` parameter in `SubtitlesClip` [#1043]
+- New `temp_audiofile_path` parameter in `VideoClip.write_videofile()` to specify where the temporary audiofile should be created
 
 ### Changed <!-- for changes in existing functionality -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If you were previously setting custom locations for FFmpeg or ImageMagick in ``config_defaults.py`` and MoviePy still cannot autodetect the binaries, you will need to switch to the new method using enviroment variables. [#1109]
 
 ### Added <!-- for new features -->
-- Support for path-like objects as an option wherever filenames are passed in as arguments
+- Support for path-like objects as an option wherever filenames are passed in as arguments [#1137]
 - Autodetect ImageMagick executable on Windows [#1109]
 - Optionally configure paths to FFmpeg and ImageMagick binaries with environment variables or a ``.env`` file [#1109]
 - Optional `encoding` parameter in `SubtitlesClip` [#1043]
-- New `temp_audiofile_path` parameter in `VideoClip.write_videofile()` to specify where the temporary audiofile should be created
+- Optional `temp_audiofile_path` parameter in `VideoClip.write_videofile()` to specify where the temporary audiofile should be created [#1144]
 
 ### Changed <!-- for changes in existing functionality -->
 

--- a/moviepy/decorators.py
+++ b/moviepy/decorators.py
@@ -76,7 +76,6 @@ def audio_video_fx(f, clip, *a, **k):
 
 def preprocess_args(fun, varnames):
     """ Applies fun to variables in varnames before launching the function """
-
     def wrapper(f, *a, **kw):
         func_code = f.__code__
 

--- a/moviepy/decorators.py
+++ b/moviepy/decorators.py
@@ -76,6 +76,7 @@ def audio_video_fx(f, clip, *a, **k):
 
 def preprocess_args(fun, varnames):
     """ Applies fun to variables in varnames before launching the function """
+
     def wrapper(f, *a, **kw):
         func_code = f.__code__
 

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -140,7 +140,7 @@ class VideoClip(Clip):
     @requires_duration
     @use_clip_fps_by_default
     @convert_masks_to_RGB
-    @convert_path_to_string("filename")
+    @convert_path_to_string(["filename", "temp_audiofile_path"])
     def write_videofile(
         self,
         filename,
@@ -155,6 +155,7 @@ class VideoClip(Clip):
         audio_bitrate=None,
         audio_bufsize=2000,
         temp_audiofile=None,
+        temp_audiofile_path="",
         rewrite_audio=True,
         remove_temp=True,
         write_logfile=False,
@@ -217,12 +218,16 @@ class VideoClip(Clip):
           If ``audio`` is the name of an audio file, this audio file
           will be incorporated as a soundtrack in the movie.
 
-        audiofps
+        audio_fps
           frame rate to use when generating the sound.
 
         temp_audiofile
           the name of the temporary audiofile to be generated and
           incorporated in the the movie, if any.
+
+        temp_audiofile_path
+          the location that the temporary audiofile is placed, as a
+          string or path-like object. Defaults to the current working directory.
 
         audio_codec
           Which audio codec should be used. Examples are 'libmp3lame'
@@ -305,7 +310,7 @@ class VideoClip(Clip):
             audiofile = temp_audiofile
         elif make_audio:
             audio_ext = find_extension(audio_codec)
-            audiofile = name + Clip._TEMP_FILES_PREFIX + "wvf_snd.%s" % audio_ext
+            audiofile = os.path.join(temp_audiofile_path, name + Clip._TEMP_FILES_PREFIX + "wvf_snd.%s" % audio_ext)
 
         # enough cpu for multiprocessing ? USELESS RIGHT NOW, WILL COME AGAIN
         # enough_cpu = (multiprocessing.cpu_count() > 1)

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -140,7 +140,7 @@ class VideoClip(Clip):
     @requires_duration
     @use_clip_fps_by_default
     @convert_masks_to_RGB
-    @convert_path_to_string(["filename", "temp_audiofile_path"])
+    @convert_path_to_string(["filename", "temp_audiofile", "temp_audiofile_path"])
     def write_videofile(
         self,
         filename,
@@ -222,8 +222,8 @@ class VideoClip(Clip):
           frame rate to use when generating the sound.
 
         temp_audiofile
-          the name of the temporary audiofile to be generated and
-          incorporated in the the movie, if any.
+          the name of the temporary audiofile, as a string or path-like object, to be created and
+          then used to write the complete video, if any.
 
         temp_audiofile_path
           the location that the temporary audiofile is placed, as a
@@ -310,7 +310,10 @@ class VideoClip(Clip):
             audiofile = temp_audiofile
         elif make_audio:
             audio_ext = find_extension(audio_codec)
-            audiofile = os.path.join(temp_audiofile_path, name + Clip._TEMP_FILES_PREFIX + "wvf_snd.%s" % audio_ext)
+            audiofile = os.path.join(
+                temp_audiofile_path,
+                name + Clip._TEMP_FILES_PREFIX + "wvf_snd.%s" % audio_ext,
+            )
 
         # enough cpu for multiprocessing ? USELESS RIGHT NOW, WILL COME AGAIN
         # enough_cpu = (multiprocessing.cpu_count() > 1)

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -23,6 +23,7 @@ from moviepy.decorators import (
     outplace,
     requires_duration,
     use_clip_fps_by_default,
+    convert_path_to_string,
 )
 from moviepy.tools import extensions_dict, find_extension, subprocess_call
 from moviepy.video.io.ffmpeg_writer import ffmpeg_write_video

--- a/tests/test_VideoClip.py
+++ b/tests/test_VideoClip.py
@@ -175,5 +175,5 @@ def test_withoutaudio():
 
 
 if __name__ == "__main__":
-    #pytest.main()
+    # pytest.main()
     test_write_videofiles_with_temp_audiofile_path()

--- a/tests/test_VideoClip.py
+++ b/tests/test_VideoClip.py
@@ -37,6 +37,18 @@ def test_errors_with_redirected_logs():
     close_all_clips(locals())
 
 
+def test_write_videofiles_with_temp_audiofile_path():
+    clip = VideoFileClip("media/big_buck_bunny_432_433.webm").subclip(0.2, 0.5)
+    location = os.path.join(TMP_DIR, "temp_audiofile_path.webm")
+    temp_location = "temp_audiofile"
+    if not os.path.exists(temp_location):
+        os.mkdir(temp_location)
+    clip.write_videofile(location, temp_audiofile_path=temp_location, remove_temp=False)
+    assert os.path.isfile(location)
+    contents_of_temp_dir = os.listdir(temp_location)
+    assert any(file.startswith("temp_audiofile_path") for file in contents_of_temp_dir)
+
+
 def test_save_frame():
     clip = VideoFileClip("media/big_buck_bunny_432_433.webm")
     location = os.path.join(TMP_DIR, "save_frame.png")
@@ -163,4 +175,5 @@ def test_withoutaudio():
 
 
 if __name__ == "__main__":
-    pytest.main()
+    #pytest.main()
+    test_write_videofiles_with_temp_audiofile_path()


### PR DESCRIPTION
Closes #892. Depends upon #1137.

A simple feature to allow the user to specify which directory the temporary audiofile should be created in.

- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 