### PR TITLE
fixed default value bug on ColorClip

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1050,7 +1050,20 @@ class ColorClip(ImageClip):
 
     def __init__(self, size, color=None, ismask=False, duration=None):
         w, h = size
-        shape = (h, w) if np.isscalar(color) else (h, w, len(color))
+
+        if ismask:
+            shape = (h, w)
+            if color is None:
+                color = 0
+            elif not np.isscalar(color):
+                raise Exception("Color has to be a scalar when mask is true")
+        else:
+            if color is None:
+                color = (0, 0, 0)
+            elif type(color) is not tuple:
+                raise Exception("Color has to be an RGB tuple")
+            shape = (h, w, len(color))
+
         super().__init__(
             np.tile(color, w * h).reshape(shape), ismask=ismask, duration=duration
         )

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1060,8 +1060,8 @@ class ColorClip(ImageClip):
         else:
             if color is None:
                 color = (0, 0, 0)
-            elif hasattr(color, "__getitem__"):
-                raise Exception("Color has to be an RGB tuple")
+            elif not hasattr(color, "__getitem__"):
+                raise Exception("Color has to contain RGB of the clip")
             shape = (h, w, len(color))
 
         super().__init__(

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1060,7 +1060,7 @@ class ColorClip(ImageClip):
         else:
             if color is None:
                 color = (0, 0, 0)
-            elif type(color) is not tuple:
+            elif hasattr(color, "__getitem__"):
                 raise Exception("Color has to be an RGB tuple")
             shape = (h, w, len(color))
 

--- a/moviepy/video/compositing/CompositeVideoClip.py
+++ b/moviepy/video/compositing/CompositeVideoClip.py
@@ -75,7 +75,7 @@ class CompositeVideoClip(VideoClip):
             self.created_bg = False
         else:
             self.clips = clips
-            self.bg = ColorClip(size, color=self.bg_color)
+            self.bg = ColorClip(size, color=self.bg_color, ismask=ismask)
             self.created_bg = True
 
         # compute duration

--- a/tests/test_VideoClip.py
+++ b/tests/test_VideoClip.py
@@ -112,6 +112,18 @@ def test_oncolor():
     location = os.path.join(TMP_DIR, "oncolor.mp4")
     on_color_clip.write_videofile(location, fps=24)
     assert os.path.isfile(location)
+
+    # test constructor with default arguements
+    clip = ColorClip(size=(100, 60), ismask=True)
+    clip = ColorClip(size=(100, 60), ismask=False)
+
+    # negative test
+    with pytest.raises(Exception):
+        clip = ColorClip(size=(100, 60), color=(255, 0, 0), ismask=True)
+
+    with pytest.raises(Exception):
+        clip = ColorClip(size=(100, 60), color=0.4, ismask=False)
+
     close_all_clips(locals())
 
 


### PR DESCRIPTION
Fixed bug in issue #1131

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have formatted my code using `black -t py36` 