### PR TITLE
Use integer division for the resolution of the star worms example video

### DIFF
--- a/examples/star_worms.py
+++ b/examples/star_worms.py
@@ -15,7 +15,7 @@ from skimage import transform as tf
 # RESOLUTION
 
 w = 720
-h = w * 9 / 16  # 16/9 screen
+h = w * 9 // 16  # 16/9 screen
 moviesize = w, h
 
 


### PR DESCRIPTION
Fixed the following error in the [star_worms.py](https://github.com/Zulko/moviepy/blob/master/examples/star_worms.py) example

```
  File "star_worms.py", line 58, in <lambda>
    fl = lambda gf, t: gf(t)[int(txt_speed * t) : int(txt_speed * t) + h, :]
TypeError: slice indices must be integers or None or have an __index__ method
```
