### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7-stretch
 
 # Install numpy using system package manager
 RUN apt-get -y update && apt-get -y install libav-tools imagemagick libopencv-dev python-opencv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.7-stretch
+FROM python:3
 
 # Install numpy using system package manager
-RUN apt-get -y update && apt-get -y install libav-tools imagemagick libopencv-dev python-opencv
+RUN apt-get -y update && apt-get -y install ffmpeg imagemagick libopencv-dev python-opencv
 
 # Install some special fonts we use in testing, etc..
 RUN apt-get -y install fonts-liberation


### PR DESCRIPTION
The Dockerfile was broken. The error stated that the package `libav-tools` was unavailable. 
To fix this I have fixed the Python version to `python:3.7-stretch` since `python:3.7-buster` does not contain `libav-tools`. See also the [Debian package index](https://packages.debian.org/search?keywords=libav-tools).
