### PR TITLE
Add VideoClip.set_layer()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optionally configure paths to FFmpeg and ImageMagick binaries with environment variables or a ``.env`` file [#1109]
 - Optional `encoding` parameter in `SubtitlesClip` [#1043]
 - Optional `temp_audiofile_path` parameter in `VideoClip.write_videofile()` to specify where the temporary audiofile should be created [#1144]
-- `VideoClip.set_layer` to specify the layer of the clip for use when creating a `CompositeVideoClip` [#1176]
+- `VideoClip.set_layer()` to specify the layer of the clip for use when creating a `CompositeVideoClip` [#1176]
 
 ### Changed <!-- for changes in existing functionality -->
 - `vfx.scroll` arguments `w` and `h` have had their order swapped. The correct order is now `w, h` but it is preferable to explicitly use keyword arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optionally configure paths to FFmpeg and ImageMagick binaries with environment variables or a ``.env`` file [#1109]
 - Optional `encoding` parameter in `SubtitlesClip` [#1043]
 - Optional `temp_audiofile_path` parameter in `VideoClip.write_videofile()` to specify where the temporary audiofile should be created [#1144]
+- `VideoClip.set_layer` to specify the layer of the clip for use when creating a `CompositeVideoClip` [#1176]
 
 ### Changed <!-- for changes in existing functionality -->
 - `vfx.scroll` arguments `w` and `h` have had their order swapped. The correct order is now `w, h` but it is preferable to explicitly use keyword arguments

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1326,7 +1326,7 @@ class BitmapClip(VideoClip):
             "B": (0, 0, 255),
             "O": (0, 0, 0),  # "O" represents black
             "W": (255, 255, 255),
-            "A": (89, 225, 62),  # "A", "C", "D" and "E" represent arbitrary colors
+            "A": (89, 225, 62),  # "A", "C", "D", "E", "F" represent arbitrary colors
             "C": (113, 157, 108),
             "D": (215, 182, 143),
             "E": (57, 26, 252),
@@ -1349,6 +1349,7 @@ class BitmapClip(VideoClip):
                 "C": (113, 157, 108),
                 "D": (215, 182, 143),
                 "E": (57, 26, 252),
+                "F": (225, 135, 33),
             }
 
         frame_list = []

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -80,6 +80,11 @@ class VideoClip(Clip):
     relative_pos
       See variable ``pos``.
 
+    layer
+      Indicates which clip is rendered on top when two clips overlap in
+      a CompositeVideoClip. The highest number is rendered on top.
+      Default is 0.
+
     """
 
     def __init__(
@@ -90,6 +95,7 @@ class VideoClip(Clip):
         self.audio = None
         self.pos = lambda t: (0, 0)
         self.relative_pos = False
+        self.layer = 0
         if make_frame:
             self.make_frame = make_frame
             self.size = self.get_frame(0).shape[:2][::-1]
@@ -777,6 +783,14 @@ class VideoClip(Clip):
             self.pos = pos
         else:
             self.pos = lambda t: pos
+
+    @apply_to_mask
+    @outplace
+    def set_layer(self, layer):
+        """Set the clip's layer in compositions.
+
+        Note: Only has effect when the clip is used in a CompositeVideoClip."""
+        self.layer = layer
 
     # --------------------------------------------------------------
     # CONVERSIONS TO OTHER TYPES

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -787,7 +787,8 @@ class VideoClip(Clip):
     @apply_to_mask
     @outplace
     def set_layer(self, layer):
-        """Set the clip's layer in compositions.
+        """Set the clip's layer in compositions. Clips with a greater ``layer``
+        attribute will be displayed on top of others.
 
         Note: Only has effect when the clip is used in a CompositeVideoClip."""
         self.layer = layer

--- a/moviepy/video/compositing/CompositeVideoClip.py
+++ b/moviepy/video/compositing/CompositeVideoClip.py
@@ -22,7 +22,9 @@ class CompositeVideoClip(VideoClip):
     clips
       A list of videoclips.
 
-      If two or more clips share the same ``layer`` attribute,
+      Clips with a higher ``layer`` attribute will be dislayed
+      on top of other clips in a lower layer.
+      If two or more clips share the same ``layer``,
       then the one appearing latest in ``clips`` will be displayed
       on top (i.e. it has the higher layer).
 

--- a/moviepy/video/compositing/CompositeVideoClip.py
+++ b/moviepy/video/compositing/CompositeVideoClip.py
@@ -83,7 +83,7 @@ class CompositeVideoClip(VideoClip):
             self.created_bg = True
 
         # order self.clips by layer
-        self.clips = sorted(self.clips, key=lambda clip: clip.key)
+        self.clips = sorted(self.clips, key=lambda clip: clip.layer)
 
         # compute duration
         ends = [c.end for c in self.clips]
@@ -104,6 +104,7 @@ class CompositeVideoClip(VideoClip):
                 .set_position(c.pos)
                 .set_end(c.end)
                 .set_start(c.start, change_end=False)
+                .set_layer(c.layer)
                 for c in self.clips
             ]
 

--- a/moviepy/video/compositing/CompositeVideoClip.py
+++ b/moviepy/video/compositing/CompositeVideoClip.py
@@ -20,8 +20,12 @@ class CompositeVideoClip(VideoClip):
       The size (height x width) of the final clip.
 
     clips
-      A list of videoclips. Each clip of the list will
-      be displayed below the clips appearing after it in the list.
+      A list of videoclips.
+
+      If two or more clips share the same ``layer`` attribute,
+      then the one appearing latest in ``clips`` will be displayed
+      on top (i.e. it has the higher layer).
+
       For each clip:
        
       - The attribute ``pos`` determines where the clip is placed.
@@ -77,6 +81,9 @@ class CompositeVideoClip(VideoClip):
             self.clips = clips
             self.bg = ColorClip(size, color=self.bg_color)
             self.created_bg = True
+
+        # order self.clips by layer
+        self.clips = sorted(self.clips, key=lambda clip: clip.key)
 
         # compute duration
         ends = [c.end for c in self.clips]

--- a/tests/test_VideoClip.py
+++ b/tests/test_VideoClip.py
@@ -6,6 +6,7 @@ from numpy import pi, sin, array
 from moviepy.audio.AudioClip import AudioClip
 from moviepy.audio.io.AudioFileClip import AudioFileClip
 from moviepy.utils import close_all_clips
+from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
 from moviepy.video.fx.speedx import speedx
 from moviepy.video.io.VideoFileClip import VideoFileClip
 from moviepy.video.VideoClip import ColorClip, BitmapClip
@@ -163,6 +164,35 @@ def test_setopacity():
     close_all_clips(locals())
 
 
+def test_set_layer():
+    bottom_clip = BitmapClip([["ABC"], ["BCA"], ["CAB"]]).set_fps(1).set_layer(1)
+    top_clip = BitmapClip([["DEF"], ["EFD"]]).set_fps(1).set_layer(2)
+
+    composite_clip = CompositeVideoClip([bottom_clip, top_clip])
+    reversed_composite_clip = CompositeVideoClip([top_clip, bottom_clip])
+
+    # Make sure that the order of clips makes no difference to the composite clip
+    assert composite_clip.subclip(0, 2) == reversed_composite_clip.subclip(0, 2)
+
+    # Make sure that only the 'top' clip is kept
+    assert top_clip.subclip(0, 2) == composite_clip.subclip(0, 2)
+
+    # Make sure that it works even when there is only one clip playing at that time
+    target_clip = BitmapClip([["DEF"], ["EFD"], ["CAB"]]).set_fps(1)
+    assert composite_clip == target_clip
+
+
+def test_compositing_with_same_layers():
+    bottom_clip = BitmapClip([["ABC"], ["BCA"]]).set_fps(1)
+    top_clip = BitmapClip([["DEF"], ["EFD"]]).set_fps(1)
+
+    composite_clip = CompositeVideoClip([bottom_clip, top_clip])
+    reversed_composite_clip = CompositeVideoClip([top_clip, bottom_clip])
+
+    assert composite_clip == top_clip
+    assert reversed_composite_clip == bottom_clip
+
+
 def test_toimageclip():
     clip = VideoFileClip("media/big_buck_bunny_432_433.webm").subclip(0.2, 0.6)
     clip = clip.to_ImageClip(t=0.1, duration=0.4)
@@ -181,4 +211,4 @@ def test_withoutaudio():
 
 if __name__ == "__main__":
     # pytest.main()
-    test_write_videofiles_with_temp_audiofile_path()
+    test_set_layer()


### PR DESCRIPTION
Closes #1162. 

Allows custom ordering of clips in a CompositeVideoClip, instead of having to sort the list of clips that you create the CompositeVideoClip from.

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 