### PR TITLE
Fix fundamental floating point error in Clip.iter_frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `IndexError` in `vfx.freeze`, `vfx.time_mirror` and `vfx.time_symmetrize` [#1124]
 - Using `rotate()` with a `ColorClip` no longer crashes [#1139]
 - `AudioFileClip` would not generate audio identical to the original file [#1108]
+- Several issues resulting from incorrect time values due to floating point errors, for example: [#1195]
+    - Blank frames at the end of clips [#210]
+    - Sometimes getting `IndexError: list index out of range` when using `concatenate_videoclips` [#646] 
 
 
 ## [v1.0.3](https://github.com/zulko/moviepy/tree/v1.0.3) (2020-05-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `IndexError` in `vfx.freeze`, `vfx.time_mirror` and `vfx.time_symmetrize` [#1124]
 - Using `rotate()` with a `ColorClip` no longer crashes [#1139]
 - `AudioFileClip` would not generate audio identical to the original file [#1108]
-- Several issues resulting from incorrect time values due to floating point errors, for example: [#1195]
+- Several issues resulting from incorrect time values due to floating point errors [#1195], for example:
     - Blank frames at the end of clips [#210]
     - Sometimes getting `IndexError: list index out of range` when using `concatenate_videoclips` [#646] 
 

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -470,7 +470,6 @@ class Clip:
             # int is used to ensure that floating point errors are rounded
             # down to the nearest integer
             t = frame_index / fps
-            print(frame_index, t, self.duration * fps)
 
             frame = self.get_frame(t)
             if (dtype is not None) and (frame.dtype != dtype):

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -466,7 +466,12 @@ class Clip:
                      for frame in myclip.iter_frames()])
         """
         logger = proglog.default_bar_logger(logger)
-        for t in logger.iter_bar(t=np.arange(0, self.duration, 1.0 / fps)):
+        for frame_index in logger.iter_bar(t=np.arange(0, int(self.duration * fps))):
+            # int is used to ensure that floating point errors are rounded
+            # down to the nearest integer
+            t = frame_index / fps
+            print(frame_index, t, self.duration * fps)
+
             frame = self.get_frame(t)
             if (dtype is not None) and (frame.dtype != dtype):
                 frame = frame.astype(dtype)

--- a/tests/test_compositing.py
+++ b/tests/test_compositing.py
@@ -52,7 +52,7 @@ def test_concatenate_self():
 
 def test_concatenate_floating_point():
     """
-    >>>print("{0:.20f}".format(1.12))
+    >>> print("{0:.20f}".format(1.12))
     1.12000000000000010658
 
     This test uses duration=1.12 to check that it still works when the clip duration is

--- a/tests/test_compositing.py
+++ b/tests/test_compositing.py
@@ -52,12 +52,12 @@ def test_concatenate_self():
 
 def test_concatenate_floating_point():
     """
-    >>>print("{0:.20f}".format(2.24))
-    2.24000000000000021316
+    >>>print("{0:.20f}".format(1.12))
+    1.12000000000000010658
 
-    This test uses duration=2.24 to check that it still works when the clip duration is
+    This test uses duration=1.12 to check that it still works when the clip duration is
     represented as being bigger than it actually is. Fixed in #1195.
     """
-    vclip = ColorClip([1080, 1080], color=[255, 128, 64], duration=2.24).set_fps(50.0)
-    concat = concatenate_videoclips([vclip])
+    clip = ColorClip([100, 50], color=[255, 128, 64], duration=1.12).set_fps(25.0)
+    concat = concatenate_videoclips([clip])
     concat.write_videofile("concat.mp4", preset="ultrafast")

--- a/tests/test_compositing.py
+++ b/tests/test_compositing.py
@@ -38,3 +38,17 @@ def test_clips_array_duration():
     video = clips_array([[red, green, blue]]).set_duration(5)
     video.write_videofile(join(TMP_DIR, "test_clips_array.mp4"))
     close_all_clips(locals())
+
+
+def test_concatenate_self():
+    clip = BitmapClip([["AAA", "BBB"], ["CCC", "DDD"]]).set_fps(1)
+    target = BitmapClip([["AAA", "BBB"], ["CCC", "DDD"]]).set_fps(1)
+
+    concatenated = concatenate_videoclips([clip])
+
+    concatenated.write_videofile(join(TMP_DIR, "test_concatenate_self.mp4"))
+    assert concatenated == target
+
+
+if __name__ == "__main__":
+    test_concatenate_self()

--- a/tests/test_compositing.py
+++ b/tests/test_compositing.py
@@ -50,5 +50,14 @@ def test_concatenate_self():
     assert concatenated == target
 
 
-if __name__ == "__main__":
-    test_concatenate_self()
+def test_concatenate_floating_point():
+    """
+    >>>print("{0:.20f}".format(2.24))
+    2.24000000000000021316
+
+    This test uses duration=2.24 to check that it still works when the clip duration is
+    represented as being bigger than it actually is. Fixed in #1195.
+    """
+    vclip = ColorClip([1080, 1080], color=[255, 128, 64], duration=2.24).set_fps(50.0)
+    concat = concatenate_videoclips([vclip])
+    concat.write_videofile("concat.mp4", preset="ultrafast")


### PR DESCRIPTION
This PR has the same effect as #229, but with the (fixed) changes suggested in #210. 

Closes #210, #229, #632, #646, #858.

Note that this supersedes half of #634, but at a deeper level. I will edit #634 to remove this half of the fix and leave it solely for the #631 supersample fix.

I'm quite confident in this PR so I will merge in a few days if there are no objections.

Explanation taken from #210:

> ```
> clip duration = 0.56
> fps = 12.5
> ```
> When this gets written out to frames, we use (in Clip.py's iterframes):
> 
> ```
>         for t in np.arange(0, self.duration, 1.0/fps):
> ```
> 
> But numpy gives:
> 
> ```
> (Pdb) np.arange(0, .56, 1.0/12.5)
> array([ 0.  ,  0.08,  0.16,  0.24,  0.32,  0.4 ,  0.48,  0.56])
> ```
> 
> This means that a composite video clip will try to generate an 8th frame at t=0.56.  However, since the individual clips that make up the composite all have end=0.56, none of them is considered to be playing at that time.  This results in a black final frame (just the background color, with no clips composited over it).
> 
> I don't think this is really a bug in the compositor so much as a result of numerical precision issues resulting in the extra t=0.56 frame being generated.  Specifically, numpy says that arange generates a half-open interval [start, end), so in theory the arange array should end at t=0.48, but it doesn't, because the numbers 0.56 and 0.8 cannot be represented perfectly by floating point.
> 

---

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 