### PR TITLE
Prevent exception when filename is given.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `IndexError` in `vfx.freeze`, `vfx.time_mirror` and `vfx.time_symmetrize` [#1124]
 - Using `rotate()` with a `ColorClip` no longer crashes [#1139]
 - `AudioFileClip` would not generate audio identical to the original file [#1108]
+- Fixed `TypeError` when using `filename` instead of `txt` parameter in `TextClip` [#1201]
 
 
 ## [v1.0.3](https://github.com/zulko/moviepy/tree/v1.0.3) (2020-05-07)

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1262,9 +1262,9 @@ class TextClip(ImageClip):
         self.stroke_color = stroke_color
 
         if remove_temp:
-            if os.path.exists(tempfilename):
+            if tempfilename is not None and os.path.exists(tempfilename):
                 os.remove(tempfilename)
-            if os.path.exists(temptxt):
+            if temptxt is not None and os.path.exists(temptxt):
                 os.remove(temptxt)
 
     @staticmethod


### PR DESCRIPTION
just a short fix, I have issue about textclip, so I fixed it for me, and make the fix available here. Perhaps, it is a logic error. I did not check that. but at least you know that there is something strange around this code when passing a filename argument.

My textCilp construction is: 
`txtclip = TextClip(filename="/home/user/path/to/where/i/want/{}".format(text),font="Inria-Sans",fontsize=150, color="white")`