### PR TITLE
Fix appveyor build: remove pipenv

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,6 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   - python -m pip install --upgrade pip --user
-  - pip install pipenv
 
   # Find latest image magick version by parsing website
 
@@ -56,12 +55,10 @@ install:
 
 build_script:
   # Install all dependencies, including dev dependencies
-  - pipenv install --dev
-  # Build the compiled extension
-  #- "%CMD_IN_ENV% python c:\\projects\\moviepy\\setup.py build"
+  - pip install .[test]
 
 test_script:
-  - pipenv run pytest
+  - pytest
 
 # TODO: Support the post-test generation of binaries - Pending a version number that is supported (e.g. 0.3.0)
 #


### PR DESCRIPTION
The Appveyor build started failing 3 days ago, likely due to the new release of pipenv: https://github.com/pypa/pipenv/releases/tag/v2020.5.28. It appears to have started using Python 3.8 regardless of that environment's settings. Thankfully this causes the pillow installation to crash, or else we'd have never noticed that it wasn't being tested on Py3.6 and 3.7. Instead of working out what changed in pipenv and fixing it, I've simply removed pipenv from the appveyor installation script. I don't think that it is necessary; it is not used in travis.yml nor in our new Github Actions CI.