### PR TITLE
Fix Clip.fx docstring

### DIFF
--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -199,20 +199,19 @@ class Clip:
         Returns the result of ``func(self, *args, **kwargs)``.
         for instance
 
-        >>> newclip = clip.fx(resize, 0.2, method='bilinear')
+        >>> newclip = clip.fx(resize, 0.2, method="bilinear")
 
         is equivalent to
 
-        >>> newclip = resize(clip, 0.2, method='bilinear')
+        >>> newclip = resize(clip, 0.2, method="bilinear")
 
         The motivation of fx is to keep the name of the effect near its
-        parameters, when the effects are chained:
+        parameters when the effects are chained:
 
         >>> from moviepy.video.fx import volumex, resize, mirrorx
-        >>> clip.fx( volumex, 0.5).fx( resize, 0.3).fx( mirrorx )
+        >>> clip.fx(volumex, 0.5).fx(resize, 0.3).fx(mirrorx)
         >>> # Is equivalent, but clearer than
-        >>> resize( volumex( mirrorx( clip ), 0.5), 0.3)
-
+        >>> mirrorx(resize(volumex(clip, 0.5), 0.3))
         """
 
         return func(self, *args, **kwargs)


### PR DESCRIPTION
As noted in #1209, the examples in the docstring of `Clip.fx` were not equivalent.