### PR TITLE
Ignore utf-8 errors when decoding ffpeg output

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -279,7 +279,7 @@ def ffmpeg_parse_infos(
 
     proc = sp.Popen(cmd, **popen_params)
     (output, error) = proc.communicate()
-    infos = error.decode("utf8")
+    error.decode("utf-8", errors="ignore")
 
     proc.terminate()
     del proc


### PR DESCRIPTION
I have a MP4 file where ffmpeg yields (among other text) the following output

... location-eng    : +00.0000+000.0000/\xfe\xff\n ....

... which python can not utf-8-decode. I thought ignoring the errors would be a good idea. I can provide the file upon request. Below is the repr() of the offending "error" variable.

```
b"ffmpeg version 4.2.2-static https://johnvansickle.com/ffmpeg/  Copyright (c) 2000-2019 the FFmpeg developers\n  built with gcc 8 (Debian 8.3.0-6)\n  configuration: --enable-gpl --enable-version3 --enable-static --disable-debug --disable-ffplay --disable-indev=sndio --disable-outdev=sndio --cc=gcc --enable-fontconfig --enable-frei0r --enable-gnutls --enable-gmp --enable-libgme --enable-gray --enable-libaom --enable-libfribidi --enable-libass --enable-libvmaf --enable-libfreetype --enable-libmp3lame --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-librubberband --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libvorbis --enable-libopus --enable-libtheora --enable-libvidstab --enable-libvo-amrwbenc --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libdav1d --enable-libxvid --enable-libzvbi --enable-libzimg\n  libavutil      56. 31.100 / 56. 31.100\n  libavcodec     58. 54.100 / 58. 54.100\n  libavformat    58. 29.100 / 58. 29.100\n  libavdevice    58.  8.100 / 58.  8.100\n  libavfilter     7. 57.100 /  7. 57.100\n  libswscale      5.  5.100 /  5.  5.100\n  libswresample   3.  5.100 /  3.  5.100\n  libpostproc    55.  5.100 / 55.  5.100\nInput #0, mov,mp4,m4a,3gp,3g2,mj2, from 'videos/video-2010-11-07-10-09-07.mp4':\n  Metadata:\n    major_brand     : 3gp4\n    minor_version   : 768\n    compatible_brands: 3gp4mp413gp6\n    creation_time   : 2010-11-07T09:09:14.000000Z\n    copyright       : \n    copyright-eng   : \n    rating          : 0\n    location-eng    : +00.0000+000.0000/\xfe\xff\n    location        : +00.0000+000.0000/\xfe\xff\n  Duration: 00:00:46.59, start: 0.000000, bitrate: 1607 kb/s\n    Stream #0:0(eng): Video: mpeg4 (Simple Profile) (mp4v / 0x7634706D), yuv420p, 640x480 [SAR 1:1 DAR 4:3], 1593 kb/s, 6.29 fps, 15.08 tbr, 1k tbn, 60 tbc (default)\n    Metadata:\n      creation_time   : 2010-11-07T09:09:14.000000Z\n      handler_name    : VideoHandler\n    Stream #0:1(eng): Audio: amr_nb (samr / 0x726D6173), 8000 Hz, mono, flt, 12 kb/s (default)\n    Metadata:\n      creation_time   : 2010-11-07T09:09:14.000000Z\n      handler_name    : SoundHandler\nAt least one output file must be specified\n"
```
