### PR TITLE
Change file extension for audio file and resizing parameters during…

### DIFF
--- a/examples/dancing_knights.py
+++ b/examples/dancing_knights.py
@@ -43,7 +43,7 @@ if not os.path.exists("knights.mp4"):
 
 
 audio = (
-    AudioFileClip("frontier.mp4")
+    AudioFileClip("frontier.mp4.webm")
     .subclip((4, 7), (4, 18))
     .audio_fadein(1)
     .audio_fadeout(1)
@@ -59,7 +59,7 @@ print("Analyzed the audio, found a period of %.02f seconds" % audio_period)
 clip = (
     VideoFileClip("./knights.mp4", audio=False)
     .subclip((1, 24.15), (1, 26))
-    .crop(x1=332, x2=910, y2=686)
+    .crop(x1=500, x2=1350)
 )
 
 video_period = find_video_period(clip, tmin=0.3)

--- a/examples/dancing_knights.py
+++ b/examples/dancing_knights.py
@@ -34,8 +34,8 @@ from moviepy.video.tools.cuts import find_video_period
 #     https://www.youtube.com/watch?v=lkY3Ek9VPtg => frontier.mp4
 
 if not os.path.exists("knights.mp4"):
-    os.system("youtube-dl zvCvOC2VwDc -o knights.mp4")
-    os.system("youtube-dl lkY3Ek9VPtg -o frontier.mp4")
+    os.system("youtube-dl zvCvOC2VwDc -o knights")
+    os.system("youtube-dl lkY3Ek9VPtg -o frontier")
 # ==========
 
 
@@ -43,7 +43,7 @@ if not os.path.exists("knights.mp4"):
 
 
 audio = (
-    AudioFileClip("frontier.mp4.webm")
+    AudioFileClip("frontier.webm")
     .subclip((4, 7), (4, 18))
     .audio_fadein(1)
     .audio_fadeout(1)
@@ -57,7 +57,7 @@ print("Analyzed the audio, found a period of %.02f seconds" % audio_period)
 
 
 clip = (
-    VideoFileClip("./knights.mp4", audio=False)
+    VideoFileClip("./knights.webm", audio=False)
     .subclip((1, 24.15), (1, 26))
     .crop(x1=500, x2=1350)
 )


### PR DESCRIPTION
…crop of clip

The current version of `youtube-dl` appends `webm` to the `frontier.mp4` file so that it's now `frontier.mp4.webm`, so I've updated the code in the example to reflect that (I couldn't find the parameters in `youtube-dl`'s documentation to force the `frontier.mp4` file name). Also, I changed the resizing parameters in the cropping of the video to match (as best as I could) the example posted to [YouTube](https://www.youtube.com/watch?v=Qu7HJrsEYFg).

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 