### PR TITLE
Correct CompositeVideoClip docstring (swap width, height ordering)

### DIFF
--- a/moviepy/video/compositing/CompositeVideoClip.py
+++ b/moviepy/video/compositing/CompositeVideoClip.py
@@ -17,7 +17,7 @@ class CompositeVideoClip(VideoClip):
     ----------
 
     size
-      The size (height x width) of the final clip.
+      The size (width, height) of the final clip.
 
     clips
       A list of videoclips.


### PR DESCRIPTION
Simple fix to correct the description of `CompositeVideoClip`'s size parameter.