### PR TITLE
Update dockerfile to modify policy.xml in-place

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ ADD . /var/src/moviepy/
 RUN cd /var/src/moviepy/ && pip install .[optional]
 
 # modify ImageMagick policy file so that Textclips work correctly.
-RUN cat /etc/ImageMagick-6/policy.xml | sed 's/none/read,write/g'> /etc/ImageMagick-6/policy.xml 
+RUN sed -i 's/none/read,write/g' /etc/ImageMagick-6/policy.xml 


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 

The last line in the Dockerfile currently removes all content from the policy.xml file since the file cannot be read from and simultaneously written too. This fix edits the file in place using sed -i.

This bug can be reproduced by building the docker image and then running docker run (tagname) cat /etc/ImageMagick-6/policy.xml 