### PR TITLE
Fixed duration in meta data when generating subclips.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed <!-- for now removed features -->
 
 ### Fixed <!-- for any bug fixes -->
+- Fixed `ffmpeg_tools.ffmpeg_extract_subclip` creating clips with incorrect duration metadata [#1317]
 - `OSError: MoviePy error: failed to read the first frame of video file...` would occasionally occur for no reason [#1220]
 - Warnings are no longer being supressed by MoviePy [#1191]
 - Fixed `UnicodeDecodeError` crash when file metadata contained non-UTF8 characters [#959]

--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -57,6 +57,7 @@ def ffmpeg_extract_subclip(filename, t1, t2, targetname=None):
         "copy",
         "-acodec",
         "copy",
+        "-copyts",
         targetname,
     ]
     subprocess_call(cmd)


### PR DESCRIPTION
Fixes issue #1316 
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 