### PR TITLE
Change docs and comments to reflect default fps_source changing from 'tbr' to 'fps'

### DIFF
--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -47,9 +47,9 @@ class VideoFileClip(VideoClip):
       https://ffmpeg.org/ffmpeg-scaler.html
 
     fps_source:
-      The fps value to collect from the metadata. Set by default to 'tbr', but
-      can be set to 'fps', which may be helpful if importing slow-motion videos
-      that get messed up otherwise.
+      The fps value to collect from the metadata. Set by default to 'fps', but
+      can be set to 'tbr', which may be helpful if you are finding that it is reading
+      the incorrect fps from the file.
 
     pix_fmt
       Optional: Pixel format for the video to read. If is not specified

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -372,8 +372,8 @@ def ffmpeg_parse_infos(
 
         # Get the frame rate. Sometimes it's 'tbr', sometimes 'fps', sometimes
         # tbc, and sometimes tbc/2...
-        # Current policy: Trust tbr first, then fps unless fps_source is
-        # specified as 'fps' in which case try fps then tbr
+        # Current policy: Trust fps first, then tbr unless fps_source is
+        # specified as 'tbr' in which case try tbr then fps
 
         # If result is near from x*1000/1001 where x is 23,24,25,50,
         # replace by x*1000/1001 (very common case for the fps).


### PR DESCRIPTION
I forgot to update the docstrings and comments to reflect the change made to the default value of `fps_source` in #1222.