### PR TITLE
Add support for ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+      - method: pip
+        path: .
+        extra_requirements:
+           - doc

--- a/setup.py
+++ b/setup.py
@@ -88,9 +88,7 @@ optional_reqs = [
 
 doc_reqs = [
     "pygame>=1.9.3,<2.0; python_version<'3.8'",
-    "numpydoc",
-    "sphinx_rtd_theme>=0.1.10b0,<1.0",
-    "Sphinx>=1.5.2,<2.0",
+    "numpydoc<2.0",
 ]
 
 test_reqs = [

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ optional_reqs = [
 
 doc_reqs = [
     "pygame>=1.9.3,<2.0; python_version<'3.8'",
-    "numpydoc>=0.6.0,<1.0",
+    "numpydoc",
     "sphinx_rtd_theme>=0.1.10b0,<1.0",
     "Sphinx>=1.5.2,<2.0",
 ]


### PR DESCRIPTION
I've been planning documentation improvements for a while, and I'd like to switch to using readthedocs to host them. This means that any changes made to master will be instantly reflected in the documentation with no extra effort required from maintainers, and it comes with easy options for users to switch to an older snapshot of the docs. I'll also merge this change into the v1.0.x branch so that will always be available in its current form.

The URL will be moviepy.readthedocs.io, but I need @Zulko to enable the githook to allow auto-creation of the docs. Would you mind linking your account to https://readthedocs.org? Then I can add you as a maintainer to the moviepy readthedocs project and then you can link it to this GitHub repo.