### PR TITLE
Add change_duration flag to Clip.set_fps()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added <!-- for new features -->
 - New `pix_fmt` parameter in `VideoFileClip`, `VideoClip.write_videofile()`, `VideoClip.write_gif()` that allows passing a custom `pix_fmt` parameter such as `"bgr24"` to FFmpeg [#1237]
+- New `change_duration` parameter in `Clip.set_fps()` that allows changing the video speed to match the new fps [#1329]
 
 ### Changed <!-- for changes in existing functionality -->
 - `FFMPEG_AudioReader.close_proc()` -> `FFMPEG_AudioReader.close()` for consistency with `FFMPEG_VideoReader` [#1220]

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -307,6 +307,7 @@ class Clip:
 
         if change_duration:
             from moviepy.video.fx.speedx import speedx
+
             newclip = speedx(self, fps / self.fps)
         else:
             newclip = self.copy()

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -298,11 +298,20 @@ class Clip:
         """
         self.make_frame = make_frame
 
-    @outplace
-    def set_fps(self, fps):
+    def set_fps(self, fps, change_duration=False):
         """Returns a copy of the clip with a new default fps for functions like
-        write_videofile, iterframe, etc."""
-        self.fps = fps
+        write_videofile, iterframe, etc.
+        If ``change_duration=True``, then the video speed will change to match the
+        new fps (conserving all frames 1:1). For example, if the fps is
+        halved in this mode, the duration will be doubled."""
+
+        if change_duration:
+            newclip = self.speedx(fps / self.fps)
+        else:
+            newclip = self.copy()
+
+        newclip.fps = fps
+        return newclip
 
     @outplace
     def set_ismask(self, ismask):

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -306,7 +306,8 @@ class Clip:
         halved in this mode, the duration will be doubled."""
 
         if change_duration:
-            newclip = self.speedx(fps / self.fps)
+            from moviepy.video.fx.speedx import speedx
+            newclip = speedx(self, fps / self.fps)
         else:
             newclip = self.copy()
 

--- a/tests/test_VideoClip.py
+++ b/tests/test_VideoClip.py
@@ -260,6 +260,29 @@ def test_withoutaudio():
     assert new_clip.audio is None
     close_all_clips(locals())
 
+def test_setfps_withoutchangeduration():
+    clip = VideoFileClip("media/big_buck_bunny_432_433.webm").subclip(0, 1)
+    # The sum is unique for each frame, so we can use it as a frame-ID 
+    # to check which frames are being preserved
+    clip_sums = [f.sum() for f in clip.iter_frames()]
+
+    clip2 = clip.set_fps(48)
+    clip2_sums = [f.sum() for f in clip2.iter_frames()]
+    assert clip2_sums[::2] == clip_sums
+    assert clip2.duration == clip.duration
+    close_all_clips(locals())
+
+def test_setfps_withchangeduration():
+    clip = VideoFileClip("media/big_buck_bunny_432_433.webm").subclip(0, 1)
+    # The sum is unique for each frame, so we can use it as a frame-ID 
+    # to check which frames are being preserved
+    clip_sums = [f.sum() for f in clip.iter_frames()]
+
+    clip2 = clip.set_fps(48, change_duration=True)
+    clip2_sums = [f.sum() for f in clip2.iter_frames()]
+    assert clip2_sums == clip_sums
+    assert clip2.duration == clip.duration / 2
+    close_all_clips(locals())
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_VideoClip.py
+++ b/tests/test_VideoClip.py
@@ -260,9 +260,10 @@ def test_withoutaudio():
     assert new_clip.audio is None
     close_all_clips(locals())
 
+
 def test_setfps_withoutchangeduration():
     clip = VideoFileClip("media/big_buck_bunny_432_433.webm").subclip(0, 1)
-    # The sum is unique for each frame, so we can use it as a frame-ID 
+    # The sum is unique for each frame, so we can use it as a frame-ID
     # to check which frames are being preserved
     clip_sums = [f.sum() for f in clip.iter_frames()]
 
@@ -272,9 +273,10 @@ def test_setfps_withoutchangeduration():
     assert clip2.duration == clip.duration
     close_all_clips(locals())
 
+
 def test_setfps_withchangeduration():
     clip = VideoFileClip("media/big_buck_bunny_432_433.webm").subclip(0, 1)
-    # The sum is unique for each frame, so we can use it as a frame-ID 
+    # The sum is unique for each frame, so we can use it as a frame-ID
     # to check which frames are being preserved
     clip_sums = [f.sum() for f in clip.iter_frames()]
 
@@ -283,6 +285,7 @@ def test_setfps_withchangeduration():
     assert clip2_sums == clip_sums
     assert clip2.duration == clip.duration / 2
     close_all_clips(locals())
+
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
This pull fixes #1069 by adding a new `change_duration=False` flag to `Clip.set_fps`. When False, original behaviour is conserved, When true, the speed and duration of the video are both changed when the fps is changed (so that all frames are preserved 1:1).

I have yet to write tests but on some test videos the behaviour is as expected.

- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 