### PR TITLE
Add coreader function to VideoFileClip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Important Announcements
 
 ### Added <!-- for new features -->
+- `VideoFileClip.coreader()` that creates a new clip created from the same source file as the original (to complement the existing `AudioFileClip.coreader()`) [#1332]
 
 ### Changed <!-- for changes in existing functionality -->
 

--- a/moviepy/video/fx/freeze.py
+++ b/moviepy/video/fx/freeze.py
@@ -16,7 +16,7 @@ def freeze(clip, t=0, freeze_duration=None, total_duration=None, padding_end=0):
     """
 
     if t == "end":
-        t = clip.duration - padding_end - 1
+        t = clip.duration - padding_end - 0.00001
 
     if freeze_duration is None:
         freeze_duration = total_duration - clip.duration

--- a/moviepy/video/fx/freeze.py
+++ b/moviepy/video/fx/freeze.py
@@ -16,7 +16,7 @@ def freeze(clip, t=0, freeze_duration=None, total_duration=None, padding_end=0):
     """
 
     if t == "end":
-        t = clip.duration - padding_end - 0.00001
+        t = clip.duration - padding_end - 1
 
     if freeze_duration is None:
         freeze_duration = total_duration - clip.duration

--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -145,6 +145,12 @@ class VideoFileClip(VideoClip):
                 nbytes=audio_nbytes,
             )
 
+    def coreader(self):
+        """Returns a copy of the VideoFileClip, i.e. a new entrance point
+        to the video file. Use copy when you have different clips
+        watching the video file at different times."""
+        return VideoFileClip(self.filename, audio_buffersize=self.audio.buffersize)
+
     def close(self):
         """ Close the internal reader. """
         if self.reader:


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
Tested on code snippet from issue #915. Without this fix, snippet raises an AttributeError because VideoFileClip has no attribute coreader. This fix should close #915.

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have formatted my code using `black -t py36` 