### PR TITLE
Fix incorrect behaviour from BitmapClip when fps != 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed <!-- for now removed features -->
 
 ### Fixed <!-- for any bug fixes -->
+- Fixed BitmapClip with fps != 1 not returning the correct frames or crashing [#1333]
 
 
 ## [v2.0.0.dev2](https://github.com/zulko/moviepy/tree/v2.0.0.dev2)

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1411,7 +1411,7 @@ class BitmapClip(VideoClip):
 
         VideoClip.__init__(
             self,
-            make_frame=lambda t: frame_array[int(t)],
+            make_frame=lambda t: frame_array[int(t * fps)],
             ismask=ismask,
             duration=duration,
         )

--- a/tests/test_BitmapClip.py
+++ b/tests/test_BitmapClip.py
@@ -45,5 +45,15 @@ def test_setting_duration():
     assert clip.duration == 6
 
 
+def test_to_bitmap():
+    bitmap = [["R"], ["R"], ["B"], ["B"], ["G"], ["G"]]
+    clip1 = BitmapClip(bitmap, fps=0.345)
+    clip2 = BitmapClip(bitmap, fps=1)
+    clip3 = BitmapClip(bitmap, fps=3.12345)
+    assert bitmap == clip1.to_bitmap()
+    assert bitmap == clip2.to_bitmap()
+    assert bitmap == clip3.to_bitmap()
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Closes #1326.
Added tests 1 and 3 fail without this PR. Test 1 (fps < 1) would crash and test 3 (fps > 1) would return the wrong results.

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have formatted my code using `black -t py36` 