### PR TITLE
Fix 90 degrees rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed <!-- for any bug fixes -->
 - Fixed BitmapClip with fps != 1 not returning the correct frames or crashing [#1333]
+- Fixed `rotate` sometimes failing with `ValueError: axes don't match array` [#1335]
 
 
 ## [v2.0.0.dev2](https://github.com/zulko/moviepy/tree/v2.0.0.dev2)

--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -61,8 +61,6 @@ def rotate(clip, angle, unit="deg", resample="bicubic", expand=True):
         def angle(t):
             return a
 
-    transpo = [1, 0] if clip.ismask else [1, 0, 2]
-
     def fl(gf, t):
 
         a = angle(t)
@@ -70,6 +68,8 @@ def rotate(clip, angle, unit="deg", resample="bicubic", expand=True):
 
         if unit == "rad":
             a = 360.0 * a / (2 * np.pi)
+
+        transpo = [1, 0] if len(im.shape) == 2 else [1, 0, 2]
 
         a %= 360
         if (a == 0) and expand:


### PR DESCRIPTION
Resolves #781 #990 #1042 #1126 #1278 

Rotating clips by either 90 or 270 degrees throws an exception because axes don't match when transposing. The clips seem to contain a frame (particularly the second frame of the clip) that has two dimensions instead of three. These changes should fix this issue by checking the shape for each frame and setting the appropriate value for transposing.

```python
# Code that demonstrates the bug
import moviepy.editor as mp
text_video = mp.TextClip("test", color="blue", fontsize=72)
text_video = text_video.rotate(90).set_duration(2)
text_video.write_videofile("test.mp4", fps=24)
```

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 