### PR TITLE
Switch Black GitHub action to the official working version

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -7,12 +7,11 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2    
-      - name: Black
-        uses: lgeiger/black-action@v1.0.1    
-        with:
-          args: "--check --diff --target-version py36 $GITHUB_WORKSPACE"
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable
+        #with:
+        #  args: "--check --diff --target-version py36 $GITHUB_WORKSPACE"
   flake8:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: psf/black@stable
-        #with:
-        #  args: "--check --diff --target-version py36 $GITHUB_WORKSPACE"
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Black
+        uses: psf/black@stable  # already includes args "--check --diff"
   flake8:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
For the last couple of days, our `black` GitHub action has been failing (https://github.com/Zulko/moviepy/runs/1222088083). This PR changes the action to one from the official black repo (https://github.com/psf/black/blob/master/Dockerfile). Note that it does not allow customisation of arguments, so without specifying Python 3.6 it defaults to "per-file auto-detection". I've tested this and no matter what version of Python 3 I specify, nothing changes in black's output. We'll continue to recommend that contributors use `-t py36`, so in the unlikely event that the GH action lets something incompatible with Python 3.6 through, someone else should catch it very quickly.

Issue reported to the original action: https://github.com/lgeiger/black-action/issues/12
Feature request to official action: https://github.com/psf/black/issues/1751