### PR TITLE
Fix fx.freeze frame indexing. Fix #1307.

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -902,7 +902,7 @@ class DataVideoClip(VideoClip):
         self.fps = fps
 
         def make_frame(t):
-            return self.data_to_frame(self.data[int(self.fps * t)])
+            return self.data_to_frame(self.data[min(int(self.fps * t), len(self.data) - 1)])
 
         VideoClip.__init__(
             self,
@@ -1424,7 +1424,7 @@ class BitmapClip(VideoClip):
 
         VideoClip.__init__(
             self,
-            make_frame=lambda t: frame_array[int(t * fps)],
+            make_frame=lambda t: frame_array[min(int(t * fps), self.total_frames - 1)],
             is_mask=is_mask,
             duration=duration,
         )

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -902,7 +902,9 @@ class DataVideoClip(VideoClip):
         self.fps = fps
 
         def make_frame(t):
-            return self.data_to_frame(self.data[min(int(self.fps * t), len(self.data) - 1)])
+            return self.data_to_frame(
+                self.data[min(int(self.fps * t), len(self.data) - 1)]
+            )
 
         VideoClip.__init__(
             self,

--- a/moviepy/video/fx/freeze.py
+++ b/moviepy/video/fx/freeze.py
@@ -16,7 +16,7 @@ def freeze(clip, t=0, freeze_duration=None, total_duration=None, padding_end=0):
     """
 
     if t == "end":
-        t = clip.duration - padding_end - 1
+        t = clip.duration - padding_end
 
     if freeze_duration is None:
         freeze_duration = total_duration - clip.duration

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -141,7 +141,7 @@ def test_freeze():
     target3 = BitmapClip([["R"], ["G"], ["G"], ["B"]], fps=1)
     assert clip3 == target3
 
-    clip4 = freeze(clip, t="end", total_duration=4, padding_end=1)
+    clip4 = freeze(clip, t="end", total_duration=4, padding_end=2)
     target4 = BitmapClip([["R"], ["G"], ["G"], ["B"]], fps=1)
     assert clip4 == target4
 


### PR DESCRIPTION
This fixes issue #1307 by making the `fx.freeze` use the last timestamp instead of 1 second before the last timestamp.
To prevent out-of-bounds errors, the default `make_frame` for `BitmapClip` and `DataVideoClip` have been updated to take the last frame in case the timestamp is greater than the length of the clip, as it makes the most sense for the timestamp equal to the duration of the clip to be the last frame, instead of 1 frame past the end of the clip.
The test `test_freeze` has been updated to reflect this change, as it had previously assumed a conversion of timestamps to frames that was inconsistent. Basically, it went from assuming that the second frame was from 1≤t≤2, which is illogical, to 1≤t<2, which can be consistent across the entire clip.

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 