### PR TITLE
Fix #1338 - Replace deprecated functions

### DIFF
--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -83,13 +83,15 @@ class AudioClip(Clip):
 
         positions = np.linspace(0, total_size, nchunks + 1, endpoint=True, dtype=int)
 
+        soundarrays = []
         for i in logger.iter_bar(chunk=list(range(nchunks))):
             size = positions[i + 1] - positions[i]
             assert size <= chunksize
             timings = (1.0 / fps) * np.arange(positions[i], positions[i + 1])
-            yield self.to_soundarray(
+            soundarrays.append(self.to_soundarray(
                 timings, nbytes=nbytes, quantize=quantize, fps=fps, buffersize=chunksize
-            )
+            ))
+        return soundarrays
 
     @requires_duration
     def to_soundarray(

--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -88,9 +88,15 @@ class AudioClip(Clip):
             size = positions[i + 1] - positions[i]
             assert size <= chunksize
             timings = (1.0 / fps) * np.arange(positions[i], positions[i + 1])
-            soundarrays.append(self.to_soundarray(
-                timings, nbytes=nbytes, quantize=quantize, fps=fps, buffersize=chunksize
-            ))
+            soundarrays.append(
+                self.to_soundarray(
+                    timings,
+                    nbytes=nbytes,
+                    quantize=quantize,
+                    fps=fps,
+                    buffersize=chunksize,
+                )
+            )
         return soundarrays
 
     @requires_duration

--- a/moviepy/video/io/gif_writers.py
+++ b/moviepy/video/io/gif_writers.py
@@ -320,7 +320,7 @@ def write_gif(
             if with_mask:
                 mask = 255 * clip.mask.get_frame(t)
                 frame = np.dstack([frame, mask]).astype("uint8")
-            proc1.stdin.write(frame.tostring())
+            proc1.stdin.write(frame.tobytes())
 
     except IOError as err:
 

--- a/moviepy/video/io/gif_writers.py
+++ b/moviepy/video/io/gif_writers.py
@@ -248,7 +248,14 @@ def write_gif(
         popen_params["stdout"] = sp.DEVNULL
 
         proc1 = sp.Popen(
-            cmd1 + ["-pix_fmt", (pixel_format), "-r", "%.02f" % fps, filename,],
+            cmd1
+            + [
+                "-pix_fmt",
+                (pixel_format),
+                "-r",
+                "%.02f" % fps,
+                filename,
+            ],
             **popen_params,
         )
     else:
@@ -287,7 +294,14 @@ def write_gif(
         if opt:
 
             cmd3 = (
-                [IMAGEMAGICK_BINARY, "-", "-fuzz", "%d" % fuzz + "%", "-layers", opt,]
+                [
+                    IMAGEMAGICK_BINARY,
+                    "-",
+                    "-fuzz",
+                    "%d" % fuzz + "%",
+                    "-layers",
+                    opt,
+                ]
                 + (["-colors", "%d" % colors] if colors is not None else [])
                 + [filename]
             )

--- a/moviepy/video/io/gif_writers.py
+++ b/moviepy/video/io/gif_writers.py
@@ -248,14 +248,7 @@ def write_gif(
         popen_params["stdout"] = sp.DEVNULL
 
         proc1 = sp.Popen(
-            cmd1
-            + [
-                "-pix_fmt",
-                (pixel_format),
-                "-r",
-                "%.02f" % fps,
-                filename,
-            ],
+            cmd1 + ["-pix_fmt", (pixel_format), "-r", "%.02f" % fps, filename,],
             **popen_params,
         )
     else:
@@ -294,14 +287,7 @@ def write_gif(
         if opt:
 
             cmd3 = (
-                [
-                    IMAGEMAGICK_BINARY,
-                    "-",
-                    "-fuzz",
-                    "%d" % fuzz + "%",
-                    "-layers",
-                    opt,
-                ]
+                [IMAGEMAGICK_BINARY, "-", "-fuzz", "%d" % fuzz + "%", "-layers", opt,]
                 + (["-colors", "%d" % colors] if colors is not None else [])
                 + [filename]
             )

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -228,20 +228,7 @@ def test_margin():
     # 1 pixel black margin
     clip2 = margin(clip, margin_size=1)
     target = BitmapClip(
-        [
-            [
-                "OOOOO",
-                "ORRRO",
-                "ORRRO",
-                "OOOOO",
-            ],
-            [
-                "OOOOO",
-                "ORRBO",
-                "ORRBO",
-                "OOOOO",
-            ],
-        ],
+        [["OOOOO", "ORRRO", "ORRRO", "OOOOO",], ["OOOOO", "ORRBO", "ORRBO", "OOOOO",],],
         fps=1,
     )
     assert target == clip2
@@ -249,20 +236,7 @@ def test_margin():
     # 1 pixel green margin
     clip3 = margin(clip, margin_size=1, color=(0, 255, 0))
     target = BitmapClip(
-        [
-            [
-                "GGGGG",
-                "GRRRG",
-                "GRRRG",
-                "GGGGG",
-            ],
-            [
-                "GGGGG",
-                "GRRBG",
-                "GRRBG",
-                "GGGGG",
-            ],
-        ],
+        [["GGGGG", "GRRRG", "GRRRG", "GGGGG",], ["GGGGG", "GRRBG", "GRRBG", "GGGGG",],],
         fps=1,
     )
     assert target == clip3

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -228,7 +228,20 @@ def test_margin():
     # 1 pixel black margin
     clip2 = margin(clip, margin_size=1)
     target = BitmapClip(
-        [["OOOOO", "ORRRO", "ORRRO", "OOOOO",], ["OOOOO", "ORRBO", "ORRBO", "OOOOO",],],
+        [
+            [
+                "OOOOO",
+                "ORRRO",
+                "ORRRO",
+                "OOOOO",
+            ],
+            [
+                "OOOOO",
+                "ORRBO",
+                "ORRBO",
+                "OOOOO",
+            ],
+        ],
         fps=1,
     )
     assert target == clip2
@@ -236,7 +249,20 @@ def test_margin():
     # 1 pixel green margin
     clip3 = margin(clip, margin_size=1, color=(0, 255, 0))
     target = BitmapClip(
-        [["GGGGG", "GRRRG", "GRRRG", "GGGGG",], ["GGGGG", "GRRBG", "GRRBG", "GGGGG",],],
+        [
+            [
+                "GGGGG",
+                "GRRRG",
+                "GRRRG",
+                "GGGGG",
+            ],
+            [
+                "GGGGG",
+                "GRRBG",
+                "GRRBG",
+                "GGGGG",
+            ],
+        ],
         fps=1,
     )
     assert target == clip3


### PR DESCRIPTION
Closes #1338.

- s/frame.tostring()/frame.tobytes()
- replace generator as source for numpy stacks with a list

I'd like to contribute and this was marked as good first request and there is no activity on this issue albeit being quite simple to fix.