### PR TITLE
time_mirror fix

### DIFF
--- a/moviepy/video/fx/time_mirror.py
+++ b/moviepy/video/fx/time_mirror.py
@@ -10,4 +10,4 @@ def time_mirror(clip):
     The clip must have its ``duration`` attribute set.
     The same effect is applied to the clip's audio and mask if any.
     """
-    return clip.time_transform(lambda t: clip.duration - t - 1, keep_duration=True)
+    return clip.time_transform(lambda t: clip.duration - t, keep_duration=True)


### PR DESCRIPTION
fixes #1253

changes made:
```diff
- return clip.time_transform(lambda t: clip.duration - t - 1, keep_duration=True)
+ return clip.time_transform(lambda t: clip.duration - t, keep_duration=True)
```
This fixes the issue and reverse the video as expected but the tests related to it are failing which can be found [here](https://github.com/Zulko/moviepy/blob/master/tests/test_fx.py#L415).

I am getting ```IndexError: index 3 is out of bounds for axis 0 with size 3``` in test_time_mirror and test_time_symmetrize.

I am unable to understand what these tests are suppose to mean also I have some assignments due so I might take some more time for this.

Thank You

Error Fixed:
- [ ] IndexError in test_time_mirror
- [ ] IndexError in test_time_symmetrize

--------
- [X] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [X] I have formatted my code using `black -t py36` 