### PR TITLE
cutout error fixed

### DIFF
--- a/moviepy/decorators.py
+++ b/moviepy/decorators.py
@@ -42,7 +42,7 @@ def apply_to_audio(func, clip, *args, **kwargs):
 
     new_clip = func(clip, *args, **kwargs)
     if getattr(new_clip, "audio", None):
-        new_clip.audio = func(new_clip.audio, *args, **kwargs)
+        new_clip.audio = func(clip.audio, *args, **kwargs)
     return new_clip
 
 


### PR DESCRIPTION
related to #1227

I have tested these functions that used the apply_to_audio decorator
- with_start
- with_end
- with_duration
- subclip
- cutout
- loop
- time_mirror
- time_symmetrize

I have an issue with with_start. I am not sure what with_start suppose to do as compared to with_end with_start does not start with the expected starting time also time_mirror and time_symmetry gave error the same as here #1253.

~~Also in [speedx.py](https://github.com/Zulko/moviepy/blob/4356fcd596cda574e7e4ead9178b457cd4a3280a/moviepy/video/fx/speedx.py) it imports apply_to_audio and apply_to_mask but does not use it. Is this correct?~~ *Fixed*

- [X] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [X] I have formatted my code using `black -t py36` 