### PR TITLE
deprecation warnings #1338

### DIFF
--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -83,13 +83,21 @@ class AudioClip(Clip):
 
         positions = np.linspace(0, total_size, nchunks + 1, endpoint=True, dtype=int)
 
+        sound_arrays = []
         for i in logger.iter_bar(chunk=list(range(nchunks))):
             size = positions[i + 1] - positions[i]
             assert size <= chunksize
             timings = (1.0 / fps) * np.arange(positions[i], positions[i + 1])
-            yield self.to_soundarray(
-                timings, nbytes=nbytes, quantize=quantize, fps=fps, buffersize=chunksize
+            sound_arrays.append(
+                self.to_soundarray(
+                    timings,
+                    nbytes=nbytes,
+                    quantize=quantize,
+                    fps=fps,
+                    buffersize=chunksize,
+                )
             )
+        return sound_arrays
 
     @requires_duration
     def to_soundarray(

--- a/moviepy/video/io/gif_writers.py
+++ b/moviepy/video/io/gif_writers.py
@@ -320,7 +320,7 @@ def write_gif(
             if with_mask:
                 mask = 255 * clip.mask.get_frame(t)
                 frame = np.dstack([frame, mask]).astype("uint8")
-            proc1.stdin.write(frame.tostring())
+            proc1.stdin.write(frame.tobytes())
 
     except IOError as err:
 


### PR DESCRIPTION
I have replaced deprecation warnings and applied `black -t py36 .` to formate code. Closes #1338.