### PR TITLE
Updates loop.py for fix

### DIFF
--- a/moviepy/video/fx/loop.py
+++ b/moviepy/video/fx/loop.py
@@ -2,8 +2,6 @@ from moviepy.decorators import apply_to_audio, apply_to_mask, requires_duration
 
 
 @requires_duration
-@apply_to_mask
-@apply_to_audio
 def loop(clip, n=None, duration=None):
     """
     Returns a clip that plays the current clip in an infinite loop.
@@ -19,7 +17,9 @@ def loop(clip, n=None, duration=None):
       Total duration of the clip. Can be specified instead of n.
     """
     previous_duration = clip.duration
-    clip = clip.time_transform(lambda t: t % previous_duration)
+    clip = clip.time_transform(
+        lambda t: t % previous_duration, apply_to=["mask", "audio"]
+    )
     if n:
         duration = n * previous_duration
     if duration:

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -191,12 +191,23 @@ def test_loop():
     clip1 = loop(clip).with_duration(3)  # infinite looping
     clip1.write_videofile(os.path.join(TMP_DIR, "loop1.webm"))
 
-    return  # Still buggy. TODO fix
     clip2 = loop(clip, duration=10)  # loop for 10 seconds
     clip2.write_videofile(os.path.join(TMP_DIR, "loop2.webm"))
 
     clip3 = loop(clip, n=3)  # loop 3 times
     clip3.write_videofile(os.path.join(TMP_DIR, "loop3.webm"))
+
+    clip = BitmapClip([["R"], ["G"], ["B"]], fps=1)
+    clip1 = loop(clip, n=2)  # loop 2 times
+    target1 = BitmapClip([["R"], ["G"], ["B"], ["R"], ["G"], ["B"]], fps=1)
+    assert clip1 == target1
+
+    clip2 = loop(clip, duration=8)  # loop 8 seconds
+    target2 = BitmapClip(
+        [["R"], ["G"], ["B"], ["R"], ["G"], ["B"], ["R"], ["G"]], fps=1
+    )
+    assert clip2 == target2
+
     close_all_clips(objects=locals())
 
 


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
Removed decorators for the loop() and adding ```apply_to = ['mask','audio']``` fixes the loop test issue.
BitMaskClips mentioned in #1370 is added.

Checklist:
- [x]  I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in ```tests/```
- [x]  I have formatted my code using `black -t py36`
