### PR TITLE
Allow get_frame to return None to end clip when needed

### DIFF
--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -487,6 +487,7 @@ class Clip:
             t = frame_index / fps
 
             frame = self.get_frame(t)
+            if frame is None: return
             if (dtype is not None) and (frame.dtype != dtype):
                 frame = frame.astype(dtype)
             if with_times:

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -487,7 +487,8 @@ class Clip:
             t = frame_index / fps
 
             frame = self.get_frame(t)
-            if frame is None: return
+            if frame is None:
+                return
             if (dtype is not None) and (frame.dtype != dtype):
                 frame = frame.astype(dtype)
             if with_times:


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 