### PR TITLE
docs: fix simple typo, tranformed -> transformed

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1052,7 +1052,7 @@ class ImageClip(VideoClip):
         """Image-transformation filter.
 
         Does the same as VideoClip.image_transform, but for ImageClip the
-        tranformed clip is computed once and for all at the beginning,
+        transformed clip is computed once and for all at the beginning,
         and not for each 'frame'.
         """
         if apply_to is None:


### PR DESCRIPTION
There is a small typo in moviepy/video/VideoClip.py.

Should read `transformed` rather than `tranformed`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md