### PR TITLE
Move directory of test to temporal location and close clips

### DIFF
--- a/tests/test_VideoClip.py
+++ b/tests/test_VideoClip.py
@@ -62,13 +62,14 @@ def test_write_frame_errors_with_redirected_logs():
 def test_write_videofiles_with_temp_audiofile_path():
     clip = VideoFileClip("media/big_buck_bunny_432_433.webm").subclip(0.2, 0.5)
     location = os.path.join(TMP_DIR, "temp_audiofile_path.webm")
-    temp_location = "temp_audiofile"
+    temp_location = os.path.join(TMP_DIR, "temp_audiofile")
     if not os.path.exists(temp_location):
         os.mkdir(temp_location)
     clip.write_videofile(location, temp_audiofile_path=temp_location, remove_temp=False)
     assert os.path.isfile(location)
     contents_of_temp_dir = os.listdir(temp_location)
     assert any(file.startswith("temp_audiofile_path") for file in contents_of_temp_dir)
+    close_all_clips(locals())
 
 
 def test_save_frame():


### PR DESCRIPTION
- [x] I have formatted my code using `black -t py36` 

- Used temporal directory to save the directory `temp_audiofile` of the test `test_VideoClip.py::test_write_videofiles_with_temp_audiofile_path` to prevent that a directory `temp_audiofile` would be created in the root of the project.
- Closed the video clip explicitly using `utils.close_all_clips`.