### PR TITLE
Use temporal directory to write a video in test and close clips

### DIFF
--- a/tests/test_compositing.py
+++ b/tests/test_compositing.py
@@ -60,4 +60,5 @@ def test_concatenate_floating_point():
     """
     clip = ColorClip([100, 50], color=[255, 128, 64], duration=1.12).with_fps(25.0)
     concat = concatenate_videoclips([clip])
-    concat.write_videofile("concat.mp4", preset="ultrafast")
+    concat.write_videofile(join(TMP_DIR, "concat.mp4"), preset="ultrafast")
+    close_all_clips(locals())


### PR DESCRIPTION
- [x] I have formatted my code using `black -t py36`

- Prevent the creation of the file `concat.mp4` in the root of the project using temporal directory.
- Close clips used by the test.