### PR TITLE
Fix MacOSX tests with temporal workaround for python.app issue

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -37,6 +37,11 @@ jobs:
     #  run: conda install http://repo.continuum.io/pkgs/main/osx-64/python.app-2-py38_10.tar.bz2
     - name: Install pythonw
       run: conda install python.app
+    # https://github.com/ContinuumIO/anaconda-issues/issues/12188
+    - name: Fix python.app issue
+      run: |
+        rm -rf /usr/local/miniconda/python.app/Contents/
+        mv /usr/local/miniconda/python.app/pythonapp/Contents/ /usr/local/miniconda/python.app/Contents/
     - name: Python Version Info
       run: |
         pythonw --version


### PR DESCRIPTION
The error is documented [here](https://github.com/ContinuumIO/anaconda-issues/issues/12188), and the solution clearly explained [here](https://groups.google.com/a/continuum.io/g/anaconda/c/bvcmybCfK88/m/Bw9wHLlvBwAJ). This patch should be updated when the issue with `python.app` installation would be fixed.

Closes #1409

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
- [ ] I have formatted my code using `black -t py36` 