### PR TITLE
Update README badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,16 +4,16 @@ MoviePy
 .. image:: https://badge.fury.io/py/moviepy.svg
     :target: PyPI_
     :alt: MoviePy page on the Python Package Index
-.. image:: https://badges.gitter.im/movie-py/gitter.png
+.. image:: https://img.shields.io/gitter/room/movie-py/gitter?color=46BC99&logo=gitter
     :target: Gitter_
     :alt: Discuss MoviePy on Gitter
-.. image:: https://travis-ci.org/Zulko/moviepy.svg?branch=master
-    :target: https://travis-ci.org/Zulko/moviepy
-    :alt: Build status on travis-ci
+.. image:: https://img.shields.io/github/workflow/status/Zulko/moviepy/Run%20Test%20Suite?logo=github
+    :target: https://github.com/Zulko/moviepy/actions?query=workflow%3A%22Run+Test+Suite%22
+    :alt: Build status on gh-actions
 .. image:: https://ci.appveyor.com/api/projects/status/github/zulko/moviepy?svg=true
     :target: https://ci.appveyor.com/project/Zulko/moviepy
     :alt: Build status on appveyor
-.. image:: https://coveralls.io/repos/github/Zulko/moviepy/badge.svg?branch=master
+.. image:: https://img.shields.io/coveralls/github/Zulko/moviepy/master?logo=coveralls
     :target: https://coveralls.io/github/Zulko/moviepy?branch=master
     :alt: Code coverage from coveralls.io
 


### PR DESCRIPTION
- Deprecate TravisCI badge replacing it by GH Actions "Run Test Suite" workflow badge
- Improve Gitter badge using SVG version.
- Add icons to all badges except PyPI version.

See it renderized [here](https://github.com/mondeja/moviepy/tree/update-readme-badges#moviepy).