### PR TITLE
Remove 'preview' and 'show' functions from 'moviepy.editor'

### DIFF
--- a/moviepy/editor.py
+++ b/moviepy/editor.py
@@ -64,3 +64,5 @@ except ImportError:
 AudioClip.preview = preview
 
 __all__ = ["ipython_display", "sliders"]
+
+del preview, show


### PR DESCRIPTION
Closes #1249

In the linked issue #1249, the user has tried to preview a video clip using the ``preview`` function exposed by the editor, that was `moviepy.audio.io.preview::preview` because is imported latest in `editor` module. This adds confusion to the use of the editor, so ~~I have decided to unify the two `preview` functions into one that is capable of executing the correct preview function regardless of the type of the clip passed as first argument.~~ EDIT: Removed `preview` function from suggestion instead.

I've not added tests because I can't see any test module regarding the editor's API, so let me know if I'm missing something.

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 