### PR TITLE
Remove idle test and reduce media directory size

### DIFF
--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -362,15 +362,6 @@ def test_issue_470():
     subclip.write_audiofile(os.path.join(TMP_DIR, "issue_470.wav"), write_logfile=True)
 
 
-def test_issue_246():
-    def test_audio_reader():
-        video = VideoFileClip("media/video_with_failing_audio.mp4")
-        subclip = video.subclip(270)
-        subclip.write_audiofile(
-            os.path.join(TMP_DIR, "issue_246.wav"), write_logfile=True
-        )
-
-
 def test_issue_547():
     red = ColorClip((640, 480), color=(255, 0, 0)).with_duration(1)
     green = ColorClip((640, 480), color=(0, 255, 0)).with_duration(2)


### PR DESCRIPTION
The removed test is doing nothing. The resized file is used only in `tests/test_ffmpeg_reader.py::test_ffmpeg_parse_infos` to check that audio is read and the audio FPS is 44100, so 4 minutes of video are not needed. This reduces the `media/` directory size from ~21mb to ~5.8mb.

- [x] I have formatted my code using `black -t py36` 