### PR TITLE
Update 'AudioClip' docstring example

### DIFF
--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -37,8 +37,8 @@ class AudioClip(Clip):
 
     >>> # Plays the note A (a sine wave of frequency 440HZ)
     >>> import numpy as np
-    >>> make_frame = lambda t: 2*[ np.sin(440 * 2 * np.pi * t) ]
-    >>> clip = AudioClip(make_frame, duration=5)
+    >>> make_frame = lambda t: np.sin(440 * 2 * np.pi * t)
+    >>> clip = AudioClip(make_frame, duration=5, fps=44100)
     >>> clip.preview()
 
     """


### PR DESCRIPTION
Current example raises `AttributeError: 'AudioClip' object has no attribute 'fps'`, and after set `fps` attribute raises `ValueError: Array depth must match number of mixer channels`.