### PR TITLE
Replace 'tostring' by 'tobytes' in 'video.io.gif_writers::write_gif'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Lots of method and parameter names have been changed. This will be explained bet
 ### Fixed <!-- for any bug fixes -->
 - Fixed BitmapClip with fps != 1 not returning the correct frames or crashing [#1333]
 - Fixed `rotate` sometimes failing with `ValueError: axes don't match array` [#1335]
-
+- Changed deprecated `tostring` method by `tobytes` in `video.io.gif_writers::write_gif` #1429
 
 ## [v2.0.0.dev2](https://github.com/zulko/moviepy/tree/v2.0.0.dev2)
 

--- a/moviepy/video/io/gif_writers.py
+++ b/moviepy/video/io/gif_writers.py
@@ -320,7 +320,7 @@ def write_gif(
             if with_mask:
                 mask = 255 * clip.mask.get_frame(t)
                 frame = np.dstack([frame, mask]).astype("uint8")
-            proc1.stdin.write(frame.tostring())
+            proc1.stdin.write(frame.tobytes())
 
     except IOError as err:
 


### PR DESCRIPTION
The method `array.tostring` was deprecated in Python v3.2, being replaced by [`array.tobytes`](https://docs.python.org/3/library/array.html#array.array.tobytes), so I've just changed their name. This method [it's removed in Python 3.9](https://bugs.python.org/issue38916) ([Release notes](https://cpython-ericholscher.readthedocs.io/en/sphinx-hoverxref/whatsnew/3.9.html#removed)) and the change prevents next warning:

```
/.../moviepy/video/io/gif_writers.py:323: DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
```