### PR TITLE
Test properly 'blackwhite' FX using 'BitmapClip'

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1337,6 +1337,19 @@ class TextClip(ImageClip):
 
 
 class BitmapClip(VideoClip):
+    DEFAULT_COLOR_DICT = {
+        "R": (255, 0, 0),
+        "G": (0, 255, 0),
+        "B": (0, 0, 255),
+        "O": (0, 0, 0),
+        "W": (255, 255, 255),
+        "A": (89, 225, 62),
+        "C": (113, 157, 108),
+        "D": (215, 182, 143),
+        "E": (57, 26, 252),
+        "F": (225, 135, 33),
+    }
+
     @convert_parameter_to_seconds(["duration"])
     def __init__(
         self, bitmap_frames, *, fps=None, duration=None, color_dict=None, is_mask=False
@@ -1391,21 +1404,7 @@ class BitmapClip(VideoClip):
         """
         assert fps is not None or duration is not None
 
-        if color_dict:
-            self.color_dict = color_dict
-        else:
-            self.color_dict = {
-                "R": (255, 0, 0),
-                "G": (0, 255, 0),
-                "B": (0, 0, 255),
-                "O": (0, 0, 0),
-                "W": (255, 255, 255),
-                "A": (89, 225, 62),
-                "C": (113, 157, 108),
-                "D": (215, 182, 143),
-                "E": (57, 26, 252),
-                "F": (225, 135, 33),
-            }
+        self.color_dict = color_dict if color_dict else self.DEFAULT_COLOR_DICT
 
         frame_list = []
         for input_frame in bitmap_frames:

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -44,8 +44,10 @@ def test_accel_decel():
 
 
 def test_blackwhite():
-    # BitmapClip doesn't support colors not passed to their ``color_dict``,
-    # so we create here a color dictionary in the black/white spectrum
+    # Create black/white spectrum ``bw_color_dict`` to compare against it.
+    # Colors after ``blackwhite`` FX must be inside this dictionary
+    # Note: black/white spectrum is made of colors with same numbers
+    # [(0, 0, 0), (1, 1, 1), (2, 2, 2)...]
     bw_color_dict = {}
     for num in range(0, 256):
         bw_color_dict[chr(num + 255)] = (num, num, num)
@@ -53,43 +55,49 @@ def test_blackwhite():
     # update dictionary with default BitmapClip color_dict values
     color_dict.update(BitmapClip.DEFAULT_COLOR_DICT)
 
-    # add row with random colors
-    random_row = []
+    # add row with random colors in b/w spectrum
+    random_row = ""
     for num in range(512, 515):
+        # use unique unicode representation for each color
         char = chr(num)
-        random_row.append(char)
-        color_dict[char] = (
-            random.randint(0, 255),
-            random.randint(0, 255),
-            random.randint(0, 255),
-        )
+        random_row += char
 
+        # random colors in the b/w spectrum
+        color_dict[char] = tuple(random.randint(0, 255) for i in range(3))
+
+    # clip converted below to black/white
     clip = BitmapClip([["RGB", random_row]], color_dict=color_dict, fps=1)
 
-    # both ``preserve_luminosity`` boolean argument values
+    # for each possible ``preserve_luminosity`` boolean argument value
     for preserve_luminosity in [True, False]:
-        # default argument ``RGB=None``
+        # default argument (``RGB=None``)
         clip_bw = blackwhite(clip, preserve_luminosity=preserve_luminosity)
 
         bitmap = clip_bw.to_bitmap()
         assert bitmap
 
-        # all characters returned by ``to_bitmap`` are in the b/w spectrum
         for i, row in enumerate(bitmap[0]):
             for char in row:
+                # all characters returned by ``to_bitmap`` are in the b/w spectrum
                 assert char in bw_color_dict
-                if i == 0:  # pure "RGB" colors are converted to [85, 85, 85]
-                    assert char == row[0]  # are equal
 
-        # custom ``RGB`` argument
+                if i == 0:  # pure "RGB" colors are converted to [85, 85, 85]
+                    assert char == row[0]  # so are equal
+
+        # custom random ``RGB`` argument
         clip_bw_custom_rgb = blackwhite(
-            clip, RGB=(1, 0, 0), preserve_luminosity=preserve_luminosity
+            clip,
+            RGB=(random.randint(0, 255), 0, 0),
+            preserve_luminosity=preserve_luminosity,
         )
         bitmap = clip_bw_custom_rgb.to_bitmap()
         for i, row in enumerate(bitmap[0]):
             for i2, char in enumerate(row):
+                # all characters returned by ``to_bitmap`` are in the b/w spectrum
                 assert char in bw_color_dict
-                if i == 0 and i2 > 0:  # for "RGB" row, two latest colors are equal
+
+                # for clip "RGB" row, two latest converted colors are equal
+                if i == 0 and i2 > 0:
                     assert char == row[1] and char == row[2]
 
         # ``RGB="CRT_phosphor"`` argument
@@ -100,6 +108,7 @@ def test_blackwhite():
         assert bitmap
         for row in bitmap[0]:
             for char in row:
+                # all characters returned by ``to_bitmap`` are in the b/w spectrum
                 assert char in bw_color_dict
 
     close_all_clips(locals())


### PR DESCRIPTION
`blackwhite` FX properly tested using `BitmapClip` class. Contributes to #1355.

* Added class property `DEFAULT_COLOR_DICT` to `BitmapClip` class to avoid the repeat of default colors definition. Let me know if this is not wanted.
* Tested all posible argument combinations.

- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 