### PR TITLE
Remove 'rewrite_audio' argument from 'VideoClip.write_videofile'

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -161,7 +161,6 @@ class VideoClip(Clip):
         audio_bufsize=2000,
         temp_audiofile=None,
         temp_audiofile_path="",
-        rewrite_audio=True,
         remove_temp=True,
         write_logfile=False,
         threads=None,


### PR DESCRIPTION
This argument does nothing so should be removed. Related to #1339.