### PR TITLE
Pass tuple to 'np.vstack' and 'np.hstack' in 'AudioClip.to_soundarray'

### DIFF
--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -119,8 +119,10 @@ class AudioClip(Clip):
         if tt is None:
             if self.duration > max_duration:
                 return stacker(
-                    self.iter_chunks(
-                        fps=fps, quantize=quantize, nbytes=2, chunksize=buffersize
+                    tuple(
+                        self.iter_chunks(
+                            fps=fps, quantize=quantize, nbytes=2, chunksize=buffersize
+                        )
                     )
                 )
             else:


### PR DESCRIPTION
Remove a warning raised by Numpy because [hstack](https://numpy.org/doc/stable/reference/generated/numpy.hstack.html) and [vstack](https://numpy.org/doc/stable/reference/generated/numpy.vstack.html) don't accept generators as argument now. Cast to a tuple the result from `AudioClip.iter_chunks` in `AudioClip.to_soundarray`.

Closes #1338, closes #1365.