### PR TITLE
Improve 'resizer' function discovering in 'moviepy.video.fx.resize'

### DIFF
--- a/moviepy/video/fx/resize.py
+++ b/moviepy/video/fx/resize.py
@@ -60,7 +60,7 @@ def _get_scipy_resizer():
             return (
                 None,
                 [
-                    "scipy.misc.imresize not found (was deprecated in scipy v1.3.0,"
+                    "scipy.misc.imresize not found (was removed in scipy v1.3.0,"
                     f" you are using v{__scipy_version__}, install 'Pillow')"
                 ],
             )

--- a/moviepy/video/fx/resize.py
+++ b/moviepy/video/fx/resize.py
@@ -1,10 +1,8 @@
-resize_possible = True
-
-try:
-    # TRY USING OpenCV AS RESIZER
-    # raise ImportError #debugging
-    import cv2
-    import numpy as np
+def _get_cv2_resizer():
+    try:
+        import cv2
+    except ImportError:
+        return (None, ["OpenCV not found (install 'opencv-python')"])
 
     def resizer(pic, new_size):
         lx, ly = int(new_size[0]), int(new_size[1])
@@ -16,43 +14,105 @@ try:
             interpolation = cv2.INTER_AREA
         return cv2.resize(+pic.astype("uint8"), (lx, ly), interpolation=interpolation)
 
-    resizer.origin = "cv2"
+    return (resizer, [])
 
-except ImportError:
 
+def _get_PIL_resizer():
     try:
-        # TRY USING PIL/PILLOW AS RESIZER
         from PIL import Image
-        import numpy as np
-
-        def resizer(pic, new_size):
-            new_size = list(map(int, new_size))[::-1]
-            # shape = pic.shape
-            # if len(shape) == 3:
-            #     newshape = (new_size[0], new_size[1], shape[2])
-            # else:
-            #     newshape = (new_size[0], new_size[1])
-
-            pil_img = Image.fromarray(pic)
-            resized_pil = pil_img.resize(new_size[::-1], Image.ANTIALIAS)
-            # arr = np.fromstring(resized_pil.tostring(), dtype='uint8')
-            # arr.reshape(newshape)
-            return np.array(resized_pil)
-
-        resizer.origin = "PIL"
-
     except ImportError:
-        # TRY USING SCIPY AS RESIZER
+        return (None, ["PIL not found (install 'Pillow')"])
+
+    import numpy as np
+
+    def resizer(pic, new_size):
+        new_size = list(map(int, new_size))[::-1]
+        # shape = pic.shape
+        # if len(shape) == 3:
+        #     newshape = (new_size[0], new_size[1], shape[2])
+        # else:
+        #     newshape = (new_size[0], new_size[1])
+
+        pil_img = Image.fromarray(pic)
+        resized_pil = pil_img.resize(new_size[::-1], Image.ANTIALIAS)
+        # arr = np.fromstring(resized_pil.tostring(), dtype="uint8")
+        # arr.reshape(newshape)
+        return np.array(resized_pil)
+
+    return (resizer, [])
+
+
+def _get_scipy_resizer():
+    try:
+        from scipy.misc import imresize
+    except ImportError:
         try:
-            from scipy.misc import imresize
-
-            def resizer(pic, new_size):
-                return imresize(pic, map(int, new_size[::-1]))
-
-            resizer.origin = "Scipy"
-
+            from scipy import __version__ as __scipy_version__
         except ImportError:
-            resize_possible = False
+            return (None, ["Scipy not found (install 'scipy' or 'Pillow')"])
+
+        scipy_version_info = tuple(
+            int(num) for num in __scipy_version__.split(".") if num.isdigit()
+        )
+
+        # ``scipy.misc.imresize`` was removed in v1.3.0
+        if scipy_version_info >= (1, 3, 0):
+            return (
+                None,
+                [
+                    "scipy.misc.imresize not found (was deprecated in scipy v1.3.0,"
+                    f" you are using v{__scipy_version__}, install 'Pillow')"
+                ],
+            )
+
+        # unknown reason
+        return (None, "scipy.misc.imresize not found")
+
+    def resizer(pic, new_size):
+        return imresize(pic, map(int, new_size[::-1]))
+
+    return (resizer, [])
+
+
+def _get_resizer():
+    """Tries to define a ``resizer`` function using next libraries, in the given
+    order:
+
+    - cv2
+    - PIL
+    - scipy
+
+    Returns a dictionary with following attributes:
+
+    - ``resizer``: Function used to resize images in ``resize`` FX function.
+    - ``origin``: Library used to resize.
+    - ``error_msgs``: If any of the libraries is available, shows the user why
+    this feature is not available and how to fix it in several error messages
+    which are formatted in the error displayed, if resizing is not possible.
+    """
+    error_messages = []
+
+    resizer_getters = {
+        "cv2": _get_cv2_resizer,
+        "PIL": _get_PIL_resizer,
+        "scipy": _get_scipy_resizer,
+    }
+    for origin, resizer_getter in resizer_getters.items():
+        resizer, _error_messages = resizer_getter()
+        if resizer is not None:
+            return {"resizer": resizer, "origin": origin, "error_msgs": []}
+        else:
+            error_messages.extend(_error_messages)
+
+    return {"resizer": None, "origin": None, "error_msgs": reversed(error_messages)}
+
+
+resizer = None
+_resizer_data = _get_resizer()
+if _resizer_data["resizer"] is not None:
+    resizer = _resizer_data["resizer"]
+    resizer.origin = _resizer_data["origin"]
+    del _resizer_data["error_msgs"]
 
 
 def resize(clip, new_size=None, height=None, width=None, apply_to_mask=True):
@@ -174,10 +234,15 @@ def resize(clip, new_size=None, height=None, width=None, apply_to_mask=True):
     return new_clip
 
 
-if not resize_possible:
+if resizer is None:
+    del resizer
+
     doc = resize.__doc__
 
     def resize(clip, new_size=None, height=None, width=None):
-        raise ImportError("fx resize needs OpenCV or Scipy or PIL")
+        fix_tips = "- " + "\n- ".join(_resizer_data["error_msgs"])
+        raise ImportError(f"fx resize needs OpenCV or Scipy or PIL\n{fix_tips}")
 
     resize.__doc__ = doc
+
+del _resizer_data["origin"], _resizer_data["resizer"]


### PR DESCRIPTION
- Improve `resizer` function autodiscovering in `video.fx.resize`. If any resizer can't be found, shows why and how to solve the problem, like (example without install PIL nor OpenCV, using Scipy v1.4.1):

```
ImportError: fx resize needs OpenCV or Scipy or PIL
- scipy.misc.imresize not found (was removed in scipy v1.3.0, you are using v1.4.1, install 'Pillow')
- PIL not found (install 'Pillow')
- OpenCV not found (install 'opencv-python')
```

- Scipy v1.3.0 was removed the function [`scipy.misc.imresize`](https://docs.scipy.org/doc/scipy-1.2.0/reference/generated/scipy.misc.imresize.html) and, since moviepy supports that version, this lacking is checked and shown to the user if needed.

- [x] I have formatted my code using `black -t py36` 