### PR TITLE
Move 'sintel_with_15_chapters.mp4' to 'media/' directory

### DIFF
--- a/tests/test_ffmpeg_reader.py
+++ b/tests/test_ffmpeg_reader.py
@@ -23,7 +23,7 @@ def test_ffmpeg_parse_infos():
     assert d["audio_found"]
     assert d["audio_fps"] == 48000
 
-    d = ffmpeg_parse_infos("tests/resource/sintel_with_15_chapters.mp4")
+    d = ffmpeg_parse_infos("media/sintel_with_15_chapters.mp4")
     assert d["audio_bitrate"]
     assert d["video_bitrate"]
 
@@ -37,7 +37,7 @@ def test_ffmpeg_parse_infos_duration():
 
 
 def test_ffmpeg_parse_infos_for_i926():
-    d = ffmpeg_parse_infos("tests/resource/sintel_with_15_chapters.mp4")
+    d = ffmpeg_parse_infos("media/sintel_with_15_chapters.mp4")
     assert d["audio_found"]
 
 


### PR DESCRIPTION
Just to maintain all media files in one directory, it seems confusing that file being located at `tests/resource/`.