### PR TITLE
Fix not importing everything from editor.py

### DIFF
--- a/moviepy/editor.py
+++ b/moviepy/editor.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
 
     def sliders(*args, **kwargs):
-        """NOT AVAILABLE: sliders requires matplotlib installed."""
+        """NOT AVAILABLE: sliders requires matplotlib installed"""
         raise ImportError("sliders requires matplotlib installed")
 
 

--- a/moviepy/editor.py
+++ b/moviepy/editor.py
@@ -11,15 +11,16 @@ MoviePy that you will use for live editing by simply typing:
 
 import os
 
-from . import *
-from .video.io.html_tools import ipython_display
+import moviepy  # So that we can access moviepy.__all__ later
+from moviepy import *
+from moviepy.video.io.html_tools import ipython_display
 
 try:
     from .video.io.sliders import sliders
 except ImportError:
 
     def sliders(*args, **kwargs):
-        """NOT AVAILABLE : sliders requires matplotlib installed."""
+        """NOT AVAILABLE: sliders requires matplotlib installed."""
         raise ImportError("sliders requires matplotlib installed")
 
 
@@ -63,6 +64,6 @@ except ImportError:
 
 AudioClip.preview = preview
 
-__all__ = ["ipython_display", "sliders"]
+__all__ = moviepy.__all__ + ["ipython_display", "sliders"]
 
 del preview, show


### PR DESCRIPTION
The idea of #1340 was that you could do `from moviepy import *` and get everything that you generally need, or do `from moviepy.editor import *` and get all of that _plus_ extra stuff like `.preview()`. This way the change would be fully backwards compatible from when everyone imported from `moviepy.editor`. When we added `__all__` to editor.py in https://github.com/Zulko/moviepy/pull/1340/commits/0f80a888a69978abb01bbad9a61235c095b851d6 this broke because it meant that you could only import from editor.py's `__all__`.

This PR remedies the issue so that you can do the following again:

```
from moviepy.editor import *
clip = VideoFileClip("example.mp4")
```
