### PR TITLE
Update Scipy version in optional dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ optional_reqs = [
     "opencv-python>=3.0,<4.0",
     "scikit-image>=0.13.0,<1.0",
     "scikit-learn",
-    "scipy>=0.19.0,<1.5",
+    "scipy>=0.19.0,<=1.6.0",
     "matplotlib>=2.0.0,<3.0",
     "youtube_dl",
 ]

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ optional_reqs = [
     "opencv-python>=3.0,<4.0",
     "scikit-image>=0.13.0,<1.0",
     "scikit-learn",
-    "scipy>=0.19.0,<=1.6.0",
+    "scipy>=0.19.0,<1.7.0",
     "matplotlib>=2.0.0,<3.0",
     "youtube_dl",
 ]


### PR DESCRIPTION
This change increases the installation speed of Scipy in Python 3.9, since it is not built from the `.tar.gz` source. I've tested the two imports of Scipy with v1.6.0 and both work:

- `import scipy.ndimage as ndi`
- `from scipy.ndimage.filters import sobel`