### PR TITLE
Update dependency version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,32 +76,32 @@ requires = [
     "decorator>=4.0.2,<5.0",
     "imageio>=2.5,<3.0",
     "imageio_ffmpeg>=0.2.0",
-    "numpy>=1.17.3",
+    "numpy>=1.17.3,<=1.20",
     "requests>=2.8.1,<3.0",
     "proglog<=1.0.0",
 ]
 
 optional_reqs = [
-    "python-dotenv>=0.10.0",
-    "opencv-python>=3.0,<4.0",
-    "scikit-image>=0.13.0,<1.0",
+    "python-dotenv>=0.10",
+    "opencv-python",
+    "scikit-image",
     "scikit-learn",
-    "scipy>=0.19.0,<1.5",
-    "matplotlib>=2.0.0,<3.0",
+    "scipy",
+    "matplotlib",
     "youtube_dl",
 ]
 
 doc_reqs = [
-    "pygame>=1.9.3,<2.0; python_version<'3.8'",
+    "pygame>=1.9.3",
     "numpydoc<2.0",
     "Sphinx==3.4.3",
-    "sphinx-rtd-theme<0.5",
+    "sphinx-rtd-theme==0.5.1",
 ]
 
 test_reqs = [
-    "coveralls>=3.0.0",
+    "coveralls>=3.0,<4.0",
     "pytest-cov>=2.5.1,<3.0",
-    "pytest>=3.0.0,<4.0",
+    "pytest>=3.0.0,<7.0.0",
 ]
 
 lint_reqs = [
@@ -140,6 +140,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Multimedia",
         "Topic :: Multimedia :: Sound/Audio",
         "Topic :: Multimedia :: Sound/Audio :: Analysis",

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ requires = [
 ]
 
 optional_reqs = [
+    "pygame>=1.9.3",
     "python-dotenv>=0.10",
     "opencv-python",
     "scikit-image",
@@ -92,7 +93,6 @@ optional_reqs = [
 ]
 
 doc_reqs = [
-    "pygame>=1.9.3",
     "numpydoc<2.0",
     "Sphinx==3.4.3",
     "sphinx-rtd-theme==0.5.1",


### PR DESCRIPTION
Some of these were very out of date, so I went through them and updated them to current versions. I removed the version restrictions on the optional requirements because they are used so little in moviepy, and only in niche corners of it that in my opinion there is no point spending a lot of time ensuring that each version is properly compatible. They are very likely to be compatible anyway because of how little each library is used.
Better to let users use whichever version of those libraries that they like.

Closes #1454.