### PR TITLE
Speed up 'AudioClip.to_soundarray'

### DIFF
--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -115,13 +115,13 @@ class AudioClip(Clip):
           2 for 16bit, 4 for 32bit sound.
 
         """
-        if fps is None:
-            fps = self.fps
-
-        stacker = np.vstack if self.nchannels == 2 else np.hstack
-        max_duration = 1.0 * buffersize / fps
         if tt is None:
+            if fps is None:
+                fps = self.fps
+
+            max_duration = 1 * buffersize / fps
             if self.duration > max_duration:
+                stacker = np.vstack if self.nchannels == 2 else np.hstack
                 return stacker(
                     tuple(
                         self.iter_chunks(


### PR DESCRIPTION
This simple change improves the performance of `AudioClip.to_soundarray`. Variables `fps`, `max_duration` and `stacker` are not used if `tt is not None`, so can be moved inside the block. This function is executed multiple times from `AudioClip.iter_chunks` iterator, so performance increasements here are worth.

- [x] I have formatted my code using `black -t py36` 