### PR TITLE
Add 'AudioClip.max_volume(stereo=True)' support for more than 2 channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed positioning error generating frames in `CompositeVideoClip` [\#1420](https://github.com/Zulko/moviepy/pull/1420)
 - Changed deprecated `tostring` method by `tobytes` in `video.io.gif_writers::write_gif` [\#1429](https://github.com/Zulko/moviepy/pull/1429)
 - Fixed calling `audio_normalize` on a clip with no sound causing `ZeroDivisionError` [\#1401](https://github.com/Zulko/moviepy/pull/1401)
+- `AudioClip.max_volume(stereo=True)` now can return more than 2 channels [\#1464](https://github.com/Zulko/moviepy/pull/1464)
 
 
 ## [v2.0.0.dev2](https://github.com/zulko/moviepy/tree/v2.0.0.dev2) (2020-10-05)

--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -149,17 +149,16 @@ class AudioClip(Clip):
         return snd_array
 
     def max_volume(self, stereo=False, chunksize=50000, logger=None):
+        # max volume separated by channels if ``stereo`` and not mono
+        stereo = stereo and self.nchannels > 1
 
-        stereo = stereo and (self.nchannels == 2)
-
-        maxi = np.array([0, 0]) if stereo else 0
+        # zero for each channel
+        maxi = np.zeros(self.nchannels)
         for chunk in self.iter_chunks(chunksize=chunksize, logger=logger):
-            maxi = (
-                np.maximum(maxi, abs(chunk).max(axis=0))
-                if stereo
-                else max(maxi, abs(chunk).max())
-            )
-        return maxi
+            maxi = np.maximum(maxi, abs(chunk).max(axis=0))
+
+        # if mono returns float, otherwise array of volumes by channel
+        return maxi if stereo else maxi[0]
 
     @requires_duration
     @convert_path_to_string("filename")


### PR DESCRIPTION
Next snippet of code demonstrates the bug:

```python
make_frame = lambda t: np.array([
    np.sin(t * 0),
    np.sin(440 * 2 * np.pi * t),
    np.sin(t * 0),
    np.sin(440 * 2 * np.pi * t),
]).T.copy(order="C")

clip = AudioClip(make_frame, fps=44100, duration=1)
clip.preview()
print(clip.nchannels, clip.max_volume(stereo=True))
```

The clip has 4 channels but `clip.max_volume(stereo=True)` returns maximum volume for two first. After this pull returns all of them.

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 