### PR TITLE
Fix minor inconsistencies

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -137,9 +137,6 @@ class VideoClip(Clip):
             if attr in ("mask", "audio"):
                 value = _copy.copy(value)
             setattr(new_clip, attr, value)
-
-        new_clip.audio = _copy.copy(self.audio)
-        new_clip.mask = _copy.copy(self.mask)
         return new_clip
 
     copy = __copy__

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -14,7 +14,7 @@ except ImportError:
     matplotlib = None
 
 
-@pytest.mark.skipif(not matplotlib, reason="no mpl")
+@pytest.mark.skipif(not matplotlib, reason="no matplotlib")
 def test_matplotlib_simple_example():
     import matplotlib.pyplot as plt
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -14,6 +14,11 @@ from moviepy.utils import close_all_clips
 
 from tests.test_helper import TMP_DIR
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 
 def test_issue_145():
     video = ColorClip((800, 600), color=(255, 0, 0)).with_duration(5)
@@ -261,6 +266,7 @@ def test_issue_359():
         video.write_gif(filename=os.path.join(TMP_DIR, "issue_359.gif"), tempfiles=True)
 
 
+@pytest.mark.skipif(not matplotlib, reason="no matplotlib")
 def test_issue_368():
     import numpy as np
     import matplotlib.pyplot as plt


### PR DESCRIPTION
Skip test execution if matplotlib not installed and remove redundant statements in `Videoclip.__copy__` introduced by #1442.