### PR TITLE
Add 'center', 'translate' and 'bg_color' arguments to 'rotate' FX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `copy.copy(clip)` and `copy.deepcopy(clip)` with same behaviour as `clip.copy()` [\#1442](https://github.com/Zulko/moviepy/pull/1442)
 - `audio.fx.multiply_stereo_volume` to control volume by audio channels [\#1424](https://github.com/Zulko/moviepy/pull/1424)
 - Support for retrieve clip frames number using `clip.n_frames` [\#1471](https://github.com/Zulko/moviepy/pull/1471)
+- `center`, `translate` and `bg_color` arguments to `video.fx.rotate` [\#1474](https://github.com/Zulko/moviepy/pull/1474)
 
 ### Changed <!-- for changes in existing functionality -->
 - Lots of method and parameter names have been changed. This will be explained better in the documentation soon. See https://github.com/Zulko/moviepy/pull/1170 for more information. [\#1170](https://github.com/Zulko/moviepy/pull/1170)

--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -41,40 +41,39 @@ def rotate(
 ):
     """
     Rotates the specified clip by ``angle`` degrees (or radians) anticlockwise
-    If the angle is not a multiple of 90 (degrees), the package ``pillow`` must
-    be installed, and there will be black borders. You can make them
-    transparent with:
+    If the angle is not a multiple of 90 (degrees) or ``center``, ``translate``,
+    and ``bg_color`` are not ``None``, the package ``pillow`` must be installed,
+    and there will be black borders. You can make them transparent with:
 
     >>> new_clip = clip.add_mask().rotate(72)
 
     Parameters
     ===========
 
-    clip
+    clip : VideoClip
       A video clip.
 
-    angle
+    angle : float
       Either a value or a function angle(t) representing the angle of rotation.
 
-    unit
-      Unit of parameter `angle` (either `deg` for degrees or `rad` for radians).
-      Default: `deg`
+    unit : str, optional
+      Unit of parameter `angle` (either "deg" for degrees or "rad" for radians).
 
-    resample
+    resample : str, optional
       An optional resampling filter. One of "nearest", "bilinear", or "bicubic".
 
-    expand
+    expand : bool, optional
       If true, expands the output image to make it large enough to hold the
       entire rotated image. If false or omitted, make the output image the same
       size as the input image.
 
-    translate
+    translate : tuple, optional
       An optional post-rotate translation (a 2-tuple).
 
-    center
+    center : tuple, optional
       Optional center of rotation (a 2-tuple). Origin is the upper left corner.
 
-    bg_color
+    bg_color : tuple, optional
       An optional color for area outside the rotated image. Only has effect if
       ``expand`` is true.
     """

--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -5,7 +5,7 @@ import numpy as np
 try:
     import PIL
 
-    PIL__rotate_kwargs_supported = {
+    PIL_rotate_kwargs_supported = {
         # [moviepy rotate argument name,
         #  PIL.rotate argument supported,
         #  minimum PIL version required]
@@ -18,9 +18,9 @@ try:
         # check support for PIL.rotate arguments
         PIL__version_info__ = tuple(int(n) for n in PIL.__version__ if n.isdigit())
 
-        for PIL_rotate_kw_name, support_data in PIL__rotate_kwargs_supported.items():
+        for PIL_rotate_kw_name, support_data in PIL_rotate_kwargs_supported.items():
             if PIL__version_info__ >= support_data[2]:
-                PIL__rotate_kwargs_supported[PIL_rotate_kw_name][1] = True
+                PIL_rotate_kwargs_supported[PIL_rotate_kw_name][1] = True
 
     Image = PIL.Image
 
@@ -117,18 +117,17 @@ def rotate(
         if not Image:
             raise ValueError(
                 'Without "Pillow" installed, only angles that are a multiple of 90'
-                " without center, translations and background color transformations"
+                " without centering, translation and background color transformations"
                 ' are supported, please install "Pillow" with `pip install pillow`'
             )
 
         # build PIL.rotate kwargs
         kwargs, _locals = ({}, locals())
-        for PIL_rotate_kw_name, support_data in PIL__rotate_kwargs_supported.items():
-
+        for PIL_rotate_kw_name, support_data in PIL_rotate_kwargs_supported.items():
+            # get the value passed to rotate FX from `locals()` dictionary
             kwarg_value = _locals[support_data[0]]
 
-            # if argument supported by PIL version
-            if support_data[1]:
+            if support_data[1]:  # if argument supported by PIL version
                 kwargs[PIL_rotate_kw_name] = kwarg_value
             else:
                 if kwarg_value is not None:  # if not default value

--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -1,29 +1,48 @@
+import warnings
+
 import numpy as np
 
 try:
-    from PIL import Image
+    import PIL
 
-    PIL_FOUND = True
+    PIL__rotate_kwargs_supported = {
+        # [moviepy rotate argument name,
+        #  PIL.rotate argument supported,
+        #  minimum PIL version required]
+        "fillcolor": ["bg_color", False, (5, 2, 0)],
+        "center": ["center", False, (4, 0, 0)],
+        "translate": ["translate", False, (4, 0, 0)],
+    }
 
-    def pil_rotater(pic, angle, resample, expand):
-        # Ensures that pic is of the correct type
-        return np.array(
-            Image.fromarray(np.array(pic).astype(np.uint8)).rotate(
-                angle, expand=expand, resample=resample
-            )
-        )
+    if hasattr(PIL, "__version__"):
+        # check support for PIL.rotate arguments
+        PIL__version_info__ = tuple(int(n) for n in PIL.__version__ if n.isdigit())
 
+        for PIL_rotate_kw_name, support_data in PIL__rotate_kwargs_supported.items():
+            if PIL__version_info__ >= support_data[2]:
+                PIL__rotate_kwargs_supported[PIL_rotate_kw_name][1] = True
+
+    Image = PIL.Image
 
 except ImportError:
-    PIL_FOUND = False
+    Image = None
 
 
-def rotate(clip, angle, unit="deg", resample="bicubic", expand=True):
+def rotate(
+    clip,
+    angle,
+    unit="deg",
+    resample="bicubic",
+    expand=True,
+    center=None,
+    translate=None,
+    bg_color=None,
+):
     """
     Rotates the specified clip by ``angle`` degrees (or radians) anticlockwise
     If the angle is not a multiple of 90 (degrees), the package ``pillow`` must
     be installed, and there will be black borders. You can make them
-    transparent with
+    transparent with:
 
     >>> new_clip = clip.add_mask().rotate(72)
 
@@ -31,62 +50,100 @@ def rotate(clip, angle, unit="deg", resample="bicubic", expand=True):
     ===========
 
     clip
-      A video clip
+      A video clip.
 
     angle
-      Either a value or a function angle(t) representing the angle of rotation
+      Either a value or a function angle(t) representing the angle of rotation.
 
     unit
       Unit of parameter `angle` (either `deg` for degrees or `rad` for radians).
       Default: `deg`
 
     resample
-      One of "nearest", "bilinear", or "bicubic".
+      An optional resampling filter. One of "nearest", "bilinear", or "bicubic".
 
     expand
-      Only applIf False, the clip will maintain the same True, the clip will be
-      resized so that the whole
+      If true, expands the output image to make it large enough to hold the
+      entire rotated image. If false or omitted, make the output image the same
+      size as the input image.
+
+    translate
+      An optional post-rotate translation (a 2-tuple).
+
+    center
+      Optional center of rotation (a 2-tuple). Origin is the upper left corner.
+
+    bg_color
+      An optional color for area outside the rotated image. Only has effect if
+      ``expand`` is true.
     """
-    if PIL_FOUND:
-        resample = {
-            "bilinear": Image.BILINEAR,
-            "nearest": Image.NEAREST,
-            "bicubic": Image.BICUBIC,
-        }[resample]
+    if Image:
+        try:
+            resample = {
+                "bilinear": Image.BILINEAR,
+                "nearest": Image.NEAREST,
+                "bicubic": Image.BICUBIC,
+            }[resample]
+        except KeyError:
+            raise ValueError(
+                "'resample' argument must be either 'bilinear', 'nearest' or 'bicubic'"
+            )
 
     if hasattr(angle, "__call__"):
-        # angle is a function
         get_angle = angle
     else:
-        # angle is a constant so convert to a constant function
-        def get_angle(t):
-            return angle
+        get_angle = lambda t: angle
 
     def filter(get_frame, t):
-
         angle = get_angle(t)
         im = get_frame(t)
 
         if unit == "rad":
             angle = 360.0 * angle / (2 * np.pi)
 
-        transpose = [1, 0] if len(im.shape) == 2 else [1, 0, 2]
-
         angle %= 360
-        if (angle == 0) and expand:
-            return im
-        if (angle == 90) and expand:
-            return np.transpose(im, axes=transpose)[::-1]
-        elif (angle == 270) and expand:
-            return np.transpose(im, axes=transpose)[:, ::-1]
-        elif (angle == 180) and expand:
-            return im[::-1, ::-1]
-        elif not PIL_FOUND:
+        if not center and not translate and not bg_color:
+            if (angle == 0) and expand:
+                return im
+            if (angle == 90) and expand:
+                transpose = [1, 0] if len(im.shape) == 2 else [1, 0, 2]
+                return np.transpose(im, axes=transpose)[::-1]
+            elif (angle == 270) and expand:
+                transpose = [1, 0] if len(im.shape) == 2 else [1, 0, 2]
+                return np.transpose(im, axes=transpose)[:, ::-1]
+            elif (angle == 180) and expand:
+                return im[::-1, ::-1]
+
+        if not Image:
             raise ValueError(
                 'Without "Pillow" installed, only angles that are a multiple of 90'
+                " without center, translations and background color transformations"
                 ' are supported, please install "Pillow" with `pip install pillow`'
             )
-        else:
-            return pil_rotater(im, angle, resample=resample, expand=expand)
+
+        # build PIL.rotate kwargs
+        kwargs, _locals = ({}, locals())
+        for PIL_rotate_kw_name, support_data in PIL__rotate_kwargs_supported.items():
+
+            kwarg_value = _locals[support_data[0]]
+
+            # if argument supported by PIL version
+            if support_data[1]:
+                kwargs[PIL_rotate_kw_name] = kwarg_value
+            else:
+                if kwarg_value is not None:  # if not default value
+                    warnings.warn(
+                        f"rotate '{support_data[0]}' argument not supported by your"
+                        " Pillow version and is being ignored. Minimum Pillow version"
+                        f" required: v{'.'.join(str(n) for n in support_data[2])}",
+                        UserWarning,
+                    )
+
+        # call PIL.rotate
+        return np.array(
+            Image.fromarray(np.array(im).astype(np.uint8)).rotate(
+                angle, expand=expand, resample=resample, **kwargs
+            )
+        )
 
     return clip.transform(filter, apply_to=["mask"])

--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -123,18 +123,22 @@ def rotate(
 
         # build PIL.rotate kwargs
         kwargs, _locals = ({}, locals())
-        for PIL_rotate_kw_name, support_data in PIL_rotate_kwargs_supported.items():
+        for PIL_rotate_kw_name, (
+            kw_name,
+            supported,
+            min_version,
+        ) in PIL_rotate_kwargs_supported.items():
             # get the value passed to rotate FX from `locals()` dictionary
-            kwarg_value = _locals[support_data[0]]
+            kw_value = _locals[kw_name]
 
-            if support_data[1]:  # if argument supported by PIL version
-                kwargs[PIL_rotate_kw_name] = kwarg_value
+            if supported:  # if argument supported by PIL version
+                kwargs[PIL_rotate_kw_name] = kw_value
             else:
-                if kwarg_value is not None:  # if not default value
+                if kw_value is not None:  # if not default value
                     warnings.warn(
-                        f"rotate '{support_data[0]}' argument not supported by your"
+                        f"rotate '{kw_name}' argument not supported by your"
                         " Pillow version and is being ignored. Minimum Pillow version"
-                        f" required: v{'.'.join(str(n) for n in support_data[2])}",
+                        f" required: v{'.'.join(str(n) for n in min_version)}",
                         UserWarning,
                     )
 


### PR DESCRIPTION
- Added support for arguments `center`, `translate` and `bg_color` (in PIL is named as `fillcolor`).
- Add PIL version checking to make sure that arguments are supported by the PIL version of the user.
- Fix documentation.

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 