### PR TITLE
Rename 'colorx' FX by 'multiply_color'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `audio.fx.volumex` to `audio.fx.multiply_volume` [\#1424](https://github.com/Zulko/moviepy/pull/1424)
 - Renamed `cols_widths` argument of `clips_array` function by `cols_heights` [\#1465](https://github.com/Zulko/moviepy/pull/1465)
 - `video_nframes` attribute of dictionary returned from `ffmpeg_parse_infos` renamed to `video_n_frames` [\#1471](https://github.com/Zulko/moviepy/pull/1471)
+- Renamed `colorx` FX by `multiply_color` [\#1475](https://github.com/Zulko/moviepy/pull/1475)
 
 ### Deprecated <!-- for soon-to-be removed features -->
 - `moviepy.video.fx.all` and `moviepy.audio.fx.all`. Use the fx method directly from the clip instance or import the fx function from `moviepy.video.fx` and `moviepy.audio.fx`. [\#1105](https://github.com/Zulko/moviepy/pull/1105)

--- a/docs/getting_started/effects.rst
+++ b/docs/getting_started/effects.rst
@@ -53,7 +53,7 @@ Much better! There are already many effects implemented in the modules ``moviepy
     clip = (VideoFileClip("myvideo.avi")
             .fx( vfx.resize, width=460) # resize (keep aspect ratio)
             .fx( vfx.speedx, 2) # double the speed
-            .fx( vfx.colorx, 0.5)) # darken the picture
+            .fx( vfx.multiply_color, 0.5)) # darken the picture
 
 For convenience, fx methods such as ``resize`` can be called in a simpler way: ``clip.resize(...)`` instead of ``clip.fx( vfx.resize, ...)``
 

--- a/docs/ref/videofx.rst
+++ b/docs/ref/videofx.rst
@@ -24,7 +24,7 @@ When you type: ::
 
     from moviepy import *
 
-the module ``video.fx`` is loaded as ``vfx`` and you can use ``vfx.colorx``, ``vfx.resize`` etc.
+the module ``video.fx`` is loaded as ``vfx`` and you can use ``vfx.multiply_color``, ``vfx.resize`` etc.
 
 
 .. currentmodule:: moviepy.video.fx.all
@@ -36,7 +36,6 @@ the module ``video.fx`` is loaded as ``vfx`` and you can use ``vfx.colorx``, ``v
     accel_decel
     blackwhite
     blink
-    colorx
     crop
     even_size
     fadein
@@ -55,6 +54,7 @@ the module ``video.fx`` is loaded as ``vfx`` and you can use ``vfx.colorx``, ``v
     mask_or
     mirror_x
     mirror_y
+    multiply_color
     painting
     resize
     rotate

--- a/docs/ref/videofx/moviepy.video.fx.all.colorx.rst
+++ b/docs/ref/videofx/moviepy.video.fx.all.colorx.rst
@@ -1,6 +1,6 @@
-moviepy.video.fx.all.colorx
-===========================
+moviepy.video.fx.all.multiply_color
+===================================
 
 .. currentmodule:: moviepy.video.fx.all
 
-.. autofunction:: colorx
+.. autofunction:: multiply_color

--- a/moviepy/video/fx/__init__.py
+++ b/moviepy/video/fx/__init__.py
@@ -3,7 +3,6 @@
 from moviepy.video.fx.accel_decel import accel_decel
 from moviepy.video.fx.blackwhite import blackwhite
 from moviepy.video.fx.blink import blink
-from moviepy.video.fx.colorx import colorx
 from moviepy.video.fx.crop import crop
 from moviepy.video.fx.even_size import even_size
 from moviepy.video.fx.fadein import fadein
@@ -22,6 +21,7 @@ from moviepy.video.fx.mask_color import mask_color
 from moviepy.video.fx.mask_or import mask_or
 from moviepy.video.fx.mirror_x import mirror_x
 from moviepy.video.fx.mirror_y import mirror_y
+from moviepy.video.fx.multiply_color import multiply_color
 from moviepy.video.fx.painting import painting
 from moviepy.video.fx.resize import resize
 from moviepy.video.fx.rotate import rotate
@@ -36,7 +36,6 @@ __all__ = (
     "accel_decel",
     "blackwhite",
     "blink",
-    "colorx",
     "crop",
     "even_size",
     "fadein",
@@ -55,6 +54,7 @@ __all__ = (
     "mask_or",
     "mirror_x",
     "mirror_y",
+    "multiply_color",
     "painting",
     "resize",
     "rotate",

--- a/moviepy/video/fx/multiply_color.py
+++ b/moviepy/video/fx/multiply_color.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def colorx(clip, factor):
+def multiply_color(clip, factor):
     """
     Multiplies the clip's colors by the given factor, can be used
     to decrease or increase the clip's brightness (is that the

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -10,7 +10,7 @@ from moviepy.audio.fx import multiply_stereo_volume
 from moviepy.utils import close_all_clips
 from moviepy.video.fx import (
     blackwhite,
-    colorx,
+    multiply_color,
     crop,
     even_size,
     fadein,
@@ -120,11 +120,11 @@ def test_blackwhite():
 #       clip1.write_videofile(os.path.join(TMP_DIR,"blink1.webm"))
 
 
-def test_colorx():
+def test_multiply_color():
     color_dict = {"H": (0, 0, 200), "L": (0, 0, 50), "B": (0, 0, 255), "O": (0, 0, 0)}
     clip = BitmapClip([["LLO", "BLO"]], color_dict=color_dict, fps=1)
 
-    clipfx = colorx(clip, 4)
+    clipfx = multiply_color(clip, 4)
     target = BitmapClip([["HHO", "BHO"]], color_dict=color_dict, fps=1)
     assert target == clipfx
 


### PR DESCRIPTION
Following from #1424, renamed `colorx` FX by `multiply_color`, link #1170.