### PR TITLE
Add 'multiply_volume' FX tests

### DIFF
--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -6,7 +6,10 @@ import pytest
 
 from moviepy import AudioClip, AudioFileClip, BitmapClip, ColorClip, VideoFileClip
 from moviepy.audio.fx import audio_normalize
-from moviepy.audio.fx import multiply_stereo_volume
+from moviepy.audio.fx import (
+    multiply_volume,
+    multiply_stereo_volume,
+)
 from moviepy.utils import close_all_clips
 from moviepy.video.fx import (
     blackwhite,
@@ -638,10 +641,54 @@ def test_audio_normalize_muted():
     close_all_clips(locals())
 
 
+def test_multiply_volume():
+    clip = AudioFileClip("media/crunching.mp3")
+    clip_array = clip.to_soundarray()
+
+    # stereo mute
+    clip_muted = multiply_volume(clip, 0)
+
+    left_channel_muted = clip_muted.to_soundarray()[:, 0]
+    right_channel_muted = clip_muted.to_soundarray()[:, 1]
+
+    z_channel = np.zeros(len(left_channel_muted))
+
+    assert np.array_equal(left_channel_muted, z_channel)
+    assert np.array_equal(right_channel_muted, z_channel)
+
+    # stereo level doubled
+    clip_doubled = multiply_volume(clip, 2)
+    clip_doubled_array = clip_doubled.to_soundarray()
+    left_channel_doubled = clip_doubled_array[:, 0]
+    right_channel_doubled = clip_doubled_array[:, 1]
+    expected_left_channel_doubled = clip_array[:, 0] * 2
+    expected_right_channel_doubled = clip_array[:, 1] * 2
+
+    assert np.array_equal(left_channel_doubled, expected_left_channel_doubled)
+    assert np.array_equal(right_channel_doubled, expected_right_channel_doubled)
+
+    # mono muted
+    sinus_wave = lambda t: [np.sin(440 * 2 * np.pi * t)]
+    mono_clip = AudioClip(sinus_wave, duration=1, fps=22050)
+    muted_mono_clip = multiply_volume(mono_clip, 0)
+    mono_channel_muted = muted_mono_clip.to_soundarray()
+
+    z_channel = np.zeros(len(mono_channel_muted))
+    assert np.array_equal(mono_channel_muted, z_channel)
+
+    mono_clip = AudioClip(sinus_wave, duration=1, fps=22050)
+    doubled_mono_clip = multiply_volume(mono_clip, 2)
+    mono_channel_doubled = doubled_mono_clip.to_soundarray()
+    d_channel = mono_clip.to_soundarray() * 2
+    assert np.array_equal(mono_channel_doubled, d_channel)
+
+    close_all_clips(locals())
+
+
 def test_multiply_stereo_volume():
     clip = AudioFileClip("media/crunching.mp3")
 
-    # mute
+    # stereo mute
     clip_left_channel_muted = multiply_stereo_volume(clip, left=0)
     clip_right_channel_muted = multiply_stereo_volume(clip, right=0, left=2)
 
@@ -653,14 +700,14 @@ def test_multiply_stereo_volume():
     assert np.array_equal(left_channel_muted, z_channel)
     assert np.array_equal(right_channel_muted, z_channel)
 
-    # double level
+    # stereo level doubled
     left_channel_doubled = clip_right_channel_muted.to_soundarray()[:, 0]
-    d_channel = clip.to_soundarray()[:, 0] * 2
-    assert np.array_equal(left_channel_doubled, d_channel)
+    expected_left_channel_doubled = clip.to_soundarray()[:, 0] * 2
+    assert np.array_equal(left_channel_doubled, expected_left_channel_doubled)
 
     # mono muted
     sinus_wave = lambda t: [np.sin(440 * 2 * np.pi * t)]
-    mono_clip = AudioClip(sinus_wave, duration=2, fps=22050)
+    mono_clip = AudioClip(sinus_wave, duration=1, fps=22050)
     muted_mono_clip = multiply_stereo_volume(mono_clip, left=0)
     mono_channel_muted = muted_mono_clip.to_soundarray()
 
@@ -668,7 +715,7 @@ def test_multiply_stereo_volume():
     assert np.array_equal(mono_channel_muted, z_channel)
 
     # mono doubled
-    mono_clip = AudioClip(sinus_wave, duration=2, fps=22050)
+    mono_clip = AudioClip(sinus_wave, duration=1, fps=22050)
     doubled_mono_clip = multiply_stereo_volume(
         mono_clip, left=None, right=2
     )  # using right


### PR DESCRIPTION
Contributes to #1355

- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
- [x] I have formatted my code using `black -t py36` 