### PR TITLE
Test all 'rotate' FX arguments combinations

### DIFF
--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 
 import numpy as np
@@ -99,7 +100,7 @@ def rotate(
         im = get_frame(t)
 
         if unit == "rad":
-            angle = 360.0 * angle / (2 * np.pi)
+            angle = math.degrees(angle)
 
         angle %= 360
         if not center and not translate and not bg_color:

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -1,3 +1,4 @@
+import math
 import os
 import random
 
@@ -495,30 +496,117 @@ def test_resize():
     # clip4.write_videofile(os.path.join(TMP_DIR, "resize4.webm"))
 
 
+# Run several times to ensure that adding 360 to rotation angles has no effect
 @pytest.mark.parametrize("angle_offset", [-360, 0, 360, 720])
-def test_rotate(angle_offset):
-    # Run several times to ensure that adding 360 to rotation angles has no effect
-    clip = BitmapClip([["AAAA", "BBBB", "CCCC"], ["ABCD", "BCDE", "CDEA"]], fps=1)
+@pytest.mark.parametrize("unit", ["deg", "rad"])
+@pytest.mark.parametrize("resample", ["bilinear", "nearest", "bicubic", "unknown"])
+@pytest.mark.parametrize(
+    (
+        "angle",
+        "translate",
+        "center",
+        "bg_color",
+        "expected_frames",
+    ),
+    (
+        (
+            0,
+            None,
+            None,
+            None,
+            [["AAAA", "BBBB", "CCCC"], ["ABCD", "BCDE", "CDEA"]],
+        ),
+        (
+            90,
+            None,
+            None,
+            None,
+            [["ABC", "ABC", "ABC", "ABC"], ["DEA", "CDE", "BCD", "ABC"]],
+        ),
+        (
+            180,
+            None,
+            None,
+            None,
+            [["CCCC", "BBBB", "AAAA"], ["AEDC", "EDCB", "DCBA"]],
+        ),
+        (
+            270,
+            None,
+            None,
+            None,
+            [["CBA", "CBA", "CBA", "CBA"], ["CBA", "DCB", "EDC", "AED"]],
+        ),
+        (
+            45,
+            (50, 50),
+            None,
+            (0, 255, 0),
+            [
+                ["GGGGGG", "GGGGGG", "GGGGGG", "GGGGGG", "GGGGGG", "GGGGGG"],
+                ["GGGGGG", "GGGGGG", "GGGGGG", "GGGGGG", "GGGGGG", "GGGGGG"],
+            ],
+        ),
+        (
+            45,
+            (50, 50),
+            (20, 20),
+            (255, 0, 0),
+            [
+                ["RRRRRR", "RRRRRR", "RRRRRR", "RRRRRR", "RRRRRR"],
+                ["RRRRRR", "RRRRRR", "RRRRRR", "RRRRRR", "RRRRRR"],
+            ],
+        ),
+        (
+            135,
+            (-100, -100),
+            None,
+            (0, 0, 255),
+            [
+                ["BBBBBB", "BBBBBB", "BBBBBB", "BBBBBB", "BBBBBB"],
+                ["BBBBBB", "BBBBBB", "BBBBBB", "BBBBBB", "BBBBBB"],
+            ],
+        ),
+    ),
+)
+def test_rotate(
+    angle_offset,
+    angle,
+    unit,
+    resample,
+    translate,
+    center,
+    bg_color,
+    expected_frames,
+):
+    """Check ``rotate`` FX behaviour against possible combinations of arguments."""
+    original_frames = [["AAAA", "BBBB", "CCCC"], ["ABCD", "BCDE", "CDEA"]]
 
-    clip1 = rotate(clip, 0 + angle_offset)
-    target1 = BitmapClip([["AAAA", "BBBB", "CCCC"], ["ABCD", "BCDE", "CDEA"]], fps=1)
-    assert clip1 == target1
+    # angles are defined in degrees, so convert to radians testing ``unit="rad"``
+    if unit == "rad":
+        angle = math.radians(angle)
 
-    clip2 = rotate(clip, 90 + angle_offset)
-    target2 = BitmapClip(
-        [["ABC", "ABC", "ABC", "ABC"], ["DEA", "CDE", "BCD", "ABC"]], fps=1
-    )
-    assert clip2 == target2, clip2.to_bitmap()
+    clip = BitmapClip(original_frames, fps=1)
 
-    clip3 = rotate(clip, 180 + angle_offset)
-    target3 = BitmapClip([["CCCC", "BBBB", "AAAA"], ["AEDC", "EDCB", "DCBA"]], fps=1)
-    assert clip3 == target3
+    kwargs = {
+        "unit": unit,
+        "resample": resample,
+        "translate": translate,
+        "center": center,
+        "bg_color": bg_color,
+    }
+    if resample not in ["bilinear", "nearest", "bicubic"]:
+        with pytest.raises(ValueError) as exc:
+            clip.rotate(angle, **kwargs)
+        assert (
+            "'resample' argument must be either 'bilinear', 'nearest' or 'bicubic'"
+        ) == str(exc.value)
+        return
+    else:
+        rotated_clip = clip.rotate(angle, **kwargs)
 
-    clip4 = rotate(clip, 270 + angle_offset)
-    target4 = BitmapClip(
-        [["CBA", "CBA", "CBA", "CBA"], ["CBA", "DCB", "EDC", "AED"]], fps=1
-    )
-    assert clip4 == target4
+    expected_clip = BitmapClip(expected_frames, fps=1)
+    assert rotated_clip.to_bitmap() == expected_clip.to_bitmap()
 
 
 def test_rotate_nonstandard_angles():

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -524,6 +524,13 @@ def test_resize():
             [["ABC", "ABC", "ABC", "ABC"], ["DEA", "CDE", "BCD", "ABC"]],
         ),
         (
+            lambda t: 90,
+            None,
+            None,
+            None,
+            [["ABC", "ABC", "ABC", "ABC"], ["DEA", "CDE", "BCD", "ABC"]],
+        ),
+        (
             180,
             None,
             None,
@@ -584,8 +591,12 @@ def test_rotate(
 
     # angles are defined in degrees, so convert to radians testing ``unit="rad"``
     if unit == "rad":
-        angle = math.radians(angle)
-
+        if hasattr(angle, "__call__"):
+            _angle = lambda t: math.radians(angle(0))
+        else:
+            _angle = math.radians(angle)
+    else:
+        _angle = angle
     clip = BitmapClip(original_frames, fps=1)
 
     kwargs = {
@@ -597,13 +608,13 @@ def test_rotate(
     }
     if resample not in ["bilinear", "nearest", "bicubic"]:
         with pytest.raises(ValueError) as exc:
-            clip.rotate(angle, **kwargs)
+            clip.rotate(_angle, **kwargs)
         assert (
             "'resample' argument must be either 'bilinear', 'nearest' or 'bicubic'"
         ) == str(exc.value)
         return
     else:
-        rotated_clip = clip.rotate(angle, **kwargs)
+        rotated_clip = clip.rotate(_angle, **kwargs)
 
     expected_clip = BitmapClip(expected_frames, fps=1)
     assert rotated_clip.to_bitmap() == expected_clip.to_bitmap()


### PR DESCRIPTION
Contributes to #1355

- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
