### PR TITLE
Improve exception handling in 'ffmpeg_parse_info'

### DIFF
--- a/moviepy/audio/io/readers.py
+++ b/moviepy/audio/io/readers.py
@@ -58,7 +58,9 @@ class FFMPEG_AudioReader:
         self.codec = "pcm_s%dle" % (8 * nbytes)
         self.nchannels = nchannels
         infos = ffmpeg_parse_infos(filename, decode_file=decode_file)
-        self.duration = infos.get("video_duration", infos["duration"])
+        self.duration = infos.get("video_duration")
+        if self.duration is None:
+            self.duration = infos["duration"]
         self.bitrate = infos["audio_bitrate"]
         self.infos = infos
         self.proc = None

--- a/moviepy/audio/io/readers.py
+++ b/moviepy/audio/io/readers.py
@@ -58,7 +58,7 @@ class FFMPEG_AudioReader:
         self.codec = "pcm_s%dle" % (8 * nbytes)
         self.nchannels = nchannels
         infos = ffmpeg_parse_infos(filename, decode_file=decode_file)
-        self.duration = infos["duration"]
+        self.duration = infos.get("video_duration", infos["duration"])
         self.bitrate = infos["audio_bitrate"]
         self.infos = infos
         self.proc = None

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -766,4 +766,4 @@ def ffmpeg_parse_infos(
             raise IsADirectoryError(f"'{filename}' is a directory")
         elif not os.path.exists(filename):
             raise FileNotFoundError(f"'{filename}' not found")
-        raise exc
+        raise IOError(f"Error pasing `ffmpeg -i` command output:\n\n{infos}") from exc


### PR DESCRIPTION
These minor changes try to fix the #1487 possible issue and, if not fixes it, improves the error handling in `ffmpeg_parse_infos` function, outputting the result from ffmpeg along with the traceback of the unhandled exception.