### PR TITLE
Test 'resize' FX against all implementations and arguments

### DIFF
--- a/moviepy/video/fx/resize.py
+++ b/moviepy/video/fx/resize.py
@@ -1,3 +1,6 @@
+import numbers
+
+
 def _get_cv2_resizer():
     try:
         import cv2
@@ -152,7 +155,7 @@ def resize(clip, new_size=None, height=None, width=None, apply_to_mask=True):
             scalar, then work out the correct pair using the clip's size.
             Otherwise just return `new_size_`
             """
-            if isinstance(new_size_, (int, float)):
+            if isinstance(new_size_, numbers.Number):
                 return [new_size_ * w, new_size_ * h]
             else:
                 return new_size_
@@ -210,6 +213,8 @@ def resize(clip, new_size=None, height=None, width=None, apply_to_mask=True):
 
         else:
             new_size = [width, h * width / w]
+    else:
+        raise ValueError("You must provide either 'new_size' or 'height' or 'width'")
 
     # From here, the resizing is constant (not a function of time), size=newsize
 

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -1,6 +1,9 @@
+import decimal
 import math
+import numbers
 import os
 import random
+import sys
 
 import numpy as np
 import pytest
@@ -585,27 +588,153 @@ def test_painting():
     pass
 
 
-def test_resize():
-    # TODO update to use BitmapClip
-    clip = get_test_video().subclip(0.2, 0.3)
+@pytest.mark.parametrize(("library"), ("PIL", "cv2", "scipy"))
+@pytest.mark.parametrize(
+    (
+        "size",
+        "duration",
+        "new_size",
+        "width",
+        "height",
+    ),
+    (
+        (
+            [8, 2],
+            1,
+            [4, 1],
+            None,
+            None,
+        ),
+        (
+            [8, 2],
+            1,
+            None,
+            4,
+            None,
+        ),
+        (
+            [2, 8],
+            1,
+            None,
+            None,
+            4,
+        ),
+        # neither 'new_size', 'height' or 'width'
+        (
+            [2, 2],
+            1,
+            None,
+            None,
+            None,
+        ),
+        # `new_size` as scaling factor
+        (
+            [5, 5],
+            1,
+            2,
+            None,
+            None,
+        ),
+        (
+            [5, 5],
+            1,
+            decimal.Decimal(2.5),
+            None,
+            None,
+        ),
+        # arguments as functions
+        (
+            [2, 2],
+            4,
+            lambda t: {0: [4, 4], 1: [8, 8], 2: [11, 11], 3: [5, 8]}[t],
+            None,
+            None,
+        ),
+        (
+            [2, 4],
+            2,
+            None,
+            None,
+            lambda t: {0: 3, 1: 4}[t],
+        ),
+        (
+            [5, 2],
+            2,
+            None,
+            lambda t: {0: 3, 1: 4}[t],
+            None,
+        ),
+    ),
+)
+def test_resize(library, size, duration, new_size, height, width, monkeypatch):
+    """Checks ``resize`` FX behaviours using all argument and third party
+    implementation combinations.
+    """
+    # mock implementation
+    resize_fx_mod = sys.modules[resize.__module__]
+    resizer_func, error_msgs = {
+        "PIL": resize_fx_mod._get_PIL_resizer,
+        "cv2": resize_fx_mod._get_cv2_resizer,
+        "scipy": resize_fx_mod._get_scipy_resizer,
+    }[library]()
 
-    clip1 = resize(clip, (460, 720))  # New resolution: (460,720)
-    assert clip1.size == (460, 720)
-    clip1.write_videofile(os.path.join(TMP_DIR, "resize1.webm"))
+    # if function is not available, skip test for implementation
+    if error_msgs:
+        pytest.skip(error_msgs[0].split(" (")[0])
+    monkeypatch.setattr(resize_fx_mod, "resizer", resizer_func)
 
-    clip2 = resize(clip, 0.6)  # width and heigth multiplied by 0.6
-    assert clip2.size == (clip.size[0] * 0.6, clip.size[1] * 0.6)
-    clip2.write_videofile(os.path.join(TMP_DIR, "resize2.webm"))
+    # build expected sizes (using `width` or `height` arguments will be proportional
+    # to original size)
+    if new_size:
+        if hasattr(new_size, "__call__"):
+            # function
+            expected_new_sizes = [new_size(t) for t in range(duration)]
+        elif isinstance(new_size, numbers.Number):
+            # scaling factor
+            expected_new_sizes = [[int(size[0] * new_size), int(size[1] * new_size)]]
+        else:
+            # tuple or list
+            expected_new_sizes = [new_size]
+    elif height:
+        if hasattr(height, "__call__"):
+            expected_new_sizes = []
+            for t in range(duration):
+                new_height = height(t)
+                expected_new_sizes.append(
+                    [int(size[0] * new_height / size[1]), new_height]
+                )
+        else:
+            expected_new_sizes = [[size[0] * height / size[1], height]]
+    elif width:
+        if hasattr(width, "__call__"):
+            expected_new_sizes = []
+            for t in range(duration):
+                new_width = width(t)
+                expected_new_sizes.append(
+                    [new_width, int(size[1] * new_width / size[0])]
+                )
+        else:
+            expected_new_sizes = [[width, size[1] * width / size[0]]]
+    else:
+        expected_new_sizes = None
 
-    clip3 = resize(clip, width=800)  # height computed automatically.
-    assert clip3.w == 800
-    # assert clip3.h == ??
-    clip3.write_videofile(os.path.join(TMP_DIR, "resize3.webm"))
-    close_all_clips(locals())
+    clip = ColorClip(size=size, color=(255, 0, 0), duration=duration)
+    clip.fps = 1
 
-    # I get a general stream error when playing this video.
-    # clip4=clip.resize(lambda t : 1+0.02*t) # slow swelling of the clip
-    # clip4.write_videofile(os.path.join(TMP_DIR, "resize4.webm"))
+    # any resizing argument passed, raises `ValueError`
+    if expected_new_sizes is None:
+        with pytest.raises(ValueError):
+            resized_clip = clip.resize(new_size=new_size, height=height, width=width)
+        resized_clip = clip
+        expected_new_sizes = [size]
+    else:
+        resized_clip = clip.resize(new_size=new_size, height=height, width=width)
+
+    # assert new size for each frame
+    for t in range(duration):
+        frame = resized_clip.get_frame(t)
+        assert len(frame[0]) == expected_new_sizes[t][0]
+        assert len(frame) == expected_new_sizes[t][1]
 
 
 # Run several times to ensure that adding 360 to rotation angles has no effect

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -718,7 +718,7 @@ def test_resize(library, size, duration, new_size, height, width, monkeypatch):
     else:
         expected_new_sizes = None
 
-    clip = ColorClip(size=size, color=(255, 0, 0), duration=duration)
+    clip = ColorClip(size=size, color=(0, 0, 0), duration=duration)
     clip.fps = 1
 
     # any resizing argument passed, raises `ValueError`


### PR DESCRIPTION
- Handled case when `new_size`, `height` and `width` arguments are `None` raising `ValueError`.
- Added support for other numeric types (like `decimal.Decimal`) to `new_size` when passed as scaling factor.
- Tested `resize` against all arguments combinations using all available third party libraries (currently `scipy` is not tested because the current installed version is v1.6.0 and `scipy.misc.imresize` was removed in v1.3.0).

Contributes to #1355 

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
