### PR TITLE
Fix audio bitrate discovering for files without default audio stream

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,8 @@ repos:
     rev: master
     hooks:
       - id: isort
-        args: ['--check-only', '--filter-files']
+        args:
+          - '--filter-files'
         files: \.py$
   - repo: https://github.com/psf/black
     rev: stable

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -566,6 +566,16 @@ class FFmpegInfosParser:
         # We could have also recomputed duration from the number of frames, as follows:
         # >>> result['video_duration'] = result['video_n_frames'] / result['video_fps']
 
+        # not default audio found, assume first audio stream is the default
+        if self.result["audio_found"] and not self.result.get("audio_bitrate"):
+            for streams_input in self.result["inputs"]:
+                for stream in streams_input["streams"]:
+                    if stream["stream_type"] == "audio" and stream.get("bitrate"):
+                        self.result["audio_bitrate"] = stream["bitrate"]
+                        break
+                if self.result.get("audio_bitrate"):
+                    break
+
         result = self.result
 
         # reset state of the parser

--- a/tests/test_ffmpeg_reader.py
+++ b/tests/test_ffmpeg_reader.py
@@ -468,6 +468,19 @@ stDim:unit="pixel"/>
     assert streams[2]["metadata"]["handler_name"] == "Baz\nFoo"
 
 
+def test_not_default_audio_stream_audio_bitrate():
+    infos = """Input #0, avi, from 'file_example_AVI_1280_1_5MG.avi':
+  Metadata:
+    encoder         : Lavf57.19.100
+  Duration: 00:00:30.61, start: 0.000000, bitrate: 387 kb/s
+    Stream #0:0: Video: ..., 30 tbr, 60 tbc
+    Stream #0:1: Audio: aac (LC) (...), 48000 Hz, stereo, fltp, 139 kb/s
+"""
+
+    d = FFmpegInfosParser(infos, "foo.avi").parse()
+    assert d["audio_bitrate"] == 139
+
+
 def test_sequential_frame_pos():
     """test_video.mp4 contains 5 frames at 1 fps.
     Each frame is 1x1 pixels and the sequence is Red, Green, Blue, Black, White.


### PR DESCRIPTION
This patch fixes [this problem](https://github.com/Zulko/moviepy/issues/1487#issuecomment-782860533) and improves the `isort` pre-commit hook configuration.