### PR TITLE
Correct variable name in progress bar

### DIFF
--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -439,7 +439,7 @@ class Clip:
                      for frame in myclip.iter_frames()])
         """
         logger = proglog.default_bar_logger(logger)
-        for frame_index in logger.iter_bar(t=np.arange(0, int(self.duration * fps))):
+        for frame_index in logger.iter_bar(frame_index=np.arange(0, int(self.duration * fps))):
             # int is used to ensure that floating point errors are rounded
             # down to the nearest integer
             t = frame_index / fps

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -439,7 +439,9 @@ class Clip:
                      for frame in myclip.iter_frames()])
         """
         logger = proglog.default_bar_logger(logger)
-        for frame_index in logger.iter_bar(frame_index=np.arange(0, int(self.duration * fps))):
+        for frame_index in logger.iter_bar(
+            frame_index=np.arange(0, int(self.duration * fps))
+        ):
             # int is used to ensure that floating point errors are rounded
             # down to the nearest integer
             t = frame_index / fps


### PR DESCRIPTION
The progress bar is using "t" to represent what is actually a frame index, making it confusing for people implementing custom progress bars.

This is not retro-compatible for people who have already implemented a custom progress bar since the "t" was introduced, so it would be for a v2.0.