### PR TITLE
Fix black version in Code Format Check workflow of CI

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: Black
-        uses: psf/black@stable  # already includes args "--check --diff"
+        uses: psf/black@20.8b1  # already includes args "--check --diff"
   flake8:
     runs-on: ubuntu-latest
     name: Flake8


### PR DESCRIPTION
Just an update to the format check workflow to keep it green again.
