### PR TITLE
Update preview.py, fix issue #575

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Clip.cutout` transformation not being applied to audio [\#1468](https://github.com/Zulko/moviepy/pull/1468)
 - Fixed arguments inconsistency in `video.tools.drawing.color_gradient` [\#1467](https://github.com/Zulko/moviepy/pull/1467)
 - Fixed `fps` not defined in `CompositeAudioClip` at initialization [\#1462](https://github.com/Zulko/moviepy/pull/1462)
+- Fixed `clip.preview()` crashing at exit when running inside Jupyter Notebook in Windows [\#1537](https://github.com/Zulko/moviepy/pull/1537)
 
 
 ## [v2.0.0.dev2](https://github.com/zulko/moviepy/tree/v2.0.0.dev2) (2020-10-05)

--- a/moviepy/video/io/preview.py
+++ b/moviepy/video/io/preview.py
@@ -143,6 +143,7 @@ def preview(
                 if audio:
                     video_flag.clear()
                 print("Interrupt")
+                pg.quit()
                 return result
 
             elif event.type == pg.MOUSEBUTTONDOWN:
@@ -157,3 +158,5 @@ def preview(
         t1 = time.time()
         time.sleep(max(0, t - (t1 - t0)))
         imdisplay(img, screen)
+
+    pg.quit()


### PR DESCRIPTION
Fixed issue #575. Added two pg.quit statements at lines 146 and 162. For line 146, this statement adds quit functionality for " event.type == pg.KEYDOWN and event.key == pg.K_ESCAPE". This allows the window to close whenever the event triggers. For line 162, once the for loop ends (the video ends), the window closes instead of crashing.

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
