### PR TITLE
Don't execute 'version.py' file in installation script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """MoviePy setup script."""
 
+import os
 import sys
 from codecs import open
 
@@ -65,8 +66,10 @@ if "build_docs" in sys.argv:
 
     cmdclass["build_docs"] = BuildDoc
 
-__version__ = None  # Explicitly set version to quieten static code checkers.
-exec(open("moviepy/version.py").read())  # loads __version__
+__version__ = None
+with open(os.path.join("moviepy", "version.py"), "r", "utf-8") as f:
+    __version__ = f.read().split(" ")[2].strip("\n").strip('"')
+
 
 # Define the requirements for specific execution needs.
 requires = [


### PR DESCRIPTION
It seems to me a bit risky to execute the `version.py` file installing moviepy. This could open the door to the execution of malicious code, so I've replaced the logic of discovering the version of moviepy in the installation script.
