### PR TITLE
Test mask rotation

### DIFF
--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -889,6 +889,18 @@ def test_rotate_nonstandard_angles():
     clip.write_videofile(os.path.join(TMP_DIR, "color_rotate.webm"))
 
 
+def test_rotate_mask():
+    # Before https://github.com/Zulko/moviepy/pull/1399
+    # all the pixels of the resulting video were 0
+    clip = (
+        ColorClip(color=0.5, size=(1, 1), is_mask=True)
+        .with_fps(1)
+        .with_duration(1)
+        .fx(rotate, 45)
+    )
+    assert clip.get_frame(0)[1][1] != 0
+
+
 def test_scroll():
     pass
 

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -890,7 +890,7 @@ def test_rotate_nonstandard_angles():
 
 
 def test_rotate_mask():
-    # Before https://github.com/Zulko/moviepy/pull/1399
+    # Prior to https://github.com/Zulko/moviepy/pull/1399
     # all the pixels of the resulting video were 0
     clip = (
         ColorClip(color=0.5, size=(1, 1), is_mask=True)


### PR DESCRIPTION
Add mask rotation test to avoid regression of the bug fixed in #1399. Contributes to #1355.

- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
