### PR TITLE
Add tests for rotate FX behaviour when Pillow is not installed

### DIFF
--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -26,7 +26,7 @@ try:
 
     Image = PIL.Image
 
-except ImportError:
+except ImportError:  # pragma: no cover
     Image = None
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,7 @@ include_trailing_comma = True
 py_version = 36
 known_tests = tests
 sections = STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -1,4 +1,5 @@
 import decimal
+import importlib
 import math
 import numbers
 import os
@@ -759,6 +760,7 @@ def test_resize(
 
 
 # Run several times to ensure that adding 360 to rotation angles has no effect
+@pytest.mark.parametrize("PIL_installed", (True, False))
 @pytest.mark.parametrize("angle_offset", [-360, 0, 360, 720])
 @pytest.mark.parametrize("unit", ["deg", "rad"])
 @pytest.mark.parametrize("resample", ["bilinear", "nearest", "bicubic", "unknown"])
@@ -839,6 +841,7 @@ def test_resize(
     ),
 )
 def test_rotate(
+    PIL_installed,
     angle_offset,
     angle,
     unit,
@@ -847,6 +850,7 @@ def test_rotate(
     center,
     bg_color,
     expected_frames,
+    monkeypatch,
 ):
     """Check ``rotate`` FX behaviour against possible combinations of arguments."""
     original_frames = [["AAAA", "BBBB", "CCCC"], ["ABCD", "BCDE", "CDEA"]]
@@ -875,11 +879,40 @@ def test_rotate(
             "'resample' argument must be either 'bilinear', 'nearest' or 'bicubic'"
         ) == str(exc.value)
         return
-    else:
-        rotated_clip = clip.rotate(_angle, **kwargs)
 
-    expected_clip = BitmapClip(expected_frames, fps=1)
-    assert rotated_clip.to_bitmap() == expected_clip.to_bitmap()
+    # if the scenario implies that PIL is not installed, monkeypatch the
+    # module in which 'rotate' function resides
+    if not PIL_installed:
+        rotate_module = importlib.import_module("moviepy.video.fx.rotate")
+        monkeypatch.setattr(rotate_module, "Image", None)
+        rotate_func = rotate_module.rotate
+    else:
+        rotate_func = rotate
+
+    # resolve the angle, because if is a multiple of 90 the rotation can be
+    # computed event without installing PIL
+    if hasattr(_angle, "__call__"):
+        _resolved_angle = _angle(0)
+    else:
+        _resolved_angle = _angle
+    if unit == "rad":
+        _resolved_angle = math.degrees(_resolved_angle)
+
+    if not PIL_installed and (
+        (_resolved_angle % 90 != 0) or center or translate or bg_color
+    ):
+        with pytest.raises(ValueError) as exc:
+            rotated_clip = clip.fx(rotate_func, _angle, **kwargs)
+
+        assert (
+            'Without "Pillow" installed, only angles that are a multiple of 90'
+        ) in str(exc.value)
+
+    else:
+        rotated_clip = clip.fx(rotate_func, _angle, **kwargs)
+        expected_clip = BitmapClip(expected_frames, fps=1)
+
+        assert rotated_clip.to_bitmap() == expected_clip.to_bitmap()
 
 
 def test_rotate_nonstandard_angles():

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -889,8 +889,8 @@ def test_rotate(
     else:
         rotate_func = rotate
 
-    # resolve the angle, because if is a multiple of 90 the rotation can be
-    # computed event without installing PIL
+    # resolve the angle, because if it is a multiple of 90, the rotation
+    # can be computed event without an available PIL installation
     if hasattr(_angle, "__call__"):
         _resolved_angle = _angle(0)
     else:


### PR DESCRIPTION
Add tests for `rotate` FX when Pillow is not installed (`moviepy/video/fx/rotate.Image` is `None`). Contributes to #1355

- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
