### PR TITLE
Test 'rotate' FX supported arguments by PIL version

### DIFF
--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -137,9 +137,10 @@ def rotate(
             else:
                 if kw_value is not None:  # if not default value
                     warnings.warn(
-                        f"rotate '{kw_name}' argument not supported by your"
-                        " Pillow version and is being ignored. Minimum Pillow version"
-                        f" required: v{'.'.join(str(n) for n in min_version)}",
+                        f"rotate '{PIL_rotate_kw_name}' argument is not supported"
+                        " by your Pillow version and is being ignored. Minimum"
+                        " Pillow version required:"
+                        f" v{'.'.join(str(n) for n in min_version)}",
                         UserWarning,
                     )
 

--- a/moviepy/video/fx/rotate.py
+++ b/moviepy/video/fx/rotate.py
@@ -137,7 +137,7 @@ def rotate(
             else:
                 if kw_value is not None:  # if not default value
                     warnings.warn(
-                        f"rotate '{PIL_rotate_kw_name}' argument is not supported"
+                        f"rotate '{kw_name}' argument is not supported"
                         " by your Pillow version and is being ignored. Minimum"
                         " Pillow version required:"
                         f" v{'.'.join(str(n) for n in min_version)}",

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -975,7 +975,7 @@ def test_rotate_supported_PIL_kwargs(
         new_PIL_rotate_kwargs_supported,
     )
 
-    with pytest.warns(UserWarning) as records:
+    with pytest.warns(UserWarning) as record:
         BitmapClip([["R", "G", "B"]], fps=1).fx(
             rotate_module.rotate,
             45,
@@ -985,12 +985,12 @@ def test_rotate_supported_PIL_kwargs(
         )
 
     # assert number of warnings
-    assert len(records.list) == len(unsupported_kwargs)
+    assert len(record.list) == len(unsupported_kwargs)
 
     # assert messages contents
     messages = []
-    for record in records.list:
-        messages.append(record.message.args[0])
+    for warning in record.list:
+        messages.append(warning.message.args[0])
 
     for unsupported_kwarg in unsupported_kwargs:
         expected_message = (

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -936,18 +936,18 @@ def test_rotate_mask():
 @pytest.mark.parametrize(
     ("unsupported_kwargs",),
     (
-        (["fillcolor"],),
+        (["bg_color"],),
         (["center"],),
         (["translate"],),
         (["translate", "center"],),
-        (["center", "fillcolor", "translate"],),
+        (["center", "bg_color", "translate"],),
     ),
     ids=(
-        "fillcolor",
+        "bg_color",
         "center",
         "translate",
         "translate,center",
-        "center,fillcolor,translate",
+        "center,bg_color,translate",
     ),
 )
 def test_rotate_supported_PIL_kwargs(
@@ -959,9 +959,17 @@ def test_rotate_supported_PIL_kwargs(
 
     # patch supported kwargs data by PIL version
     new_PIL_rotate_kwargs_supported = {}
-    for kwarg, support_data in rotate_module.PIL_rotate_kwargs_supported.items():
-        support_data[1] = kwarg not in unsupported_kwargs
-        new_PIL_rotate_kwargs_supported[kwarg] = support_data
+
+    min_version_by_kwarg_name = {}
+    for kwarg, (
+        kw_name,
+        supported,
+        min_version,
+    ) in rotate_module.PIL_rotate_kwargs_supported.items():
+        supported = kw_name not in unsupported_kwargs
+        new_PIL_rotate_kwargs_supported[kwarg] = [kw_name, supported, min_version]
+
+        min_version_by_kwarg_name[kw_name] = min_version
 
     monkeypatch.setattr(
         rotate_module,
@@ -988,7 +996,7 @@ def test_rotate_supported_PIL_kwargs(
 
     for unsupported_kwarg in unsupported_kwargs:
         min_version_required = ".".join(
-            str(n) for n in new_PIL_rotate_kwargs_supported[unsupported_kwarg][2]
+            str(n) for n in min_version_by_kwarg_name[unsupported_kwarg]
         )
         expected_message = (
             f"rotate '{unsupported_kwarg}' argument is not supported by your"

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -958,9 +958,7 @@ def test_rotate_supported_PIL_kwargs(
     rotate_module = importlib.import_module("moviepy.video.fx.rotate")
 
     # patch supported kwargs data by PIL version
-    new_PIL_rotate_kwargs_supported = {}
-
-    min_version_by_kwarg_name = {}
+    new_PIL_rotate_kwargs_supported, min_version_by_kwarg_name = ({}, {})
     for kwarg, (
         kw_name,
         supported,
@@ -969,7 +967,7 @@ def test_rotate_supported_PIL_kwargs(
         supported = kw_name not in unsupported_kwargs
         new_PIL_rotate_kwargs_supported[kwarg] = [kw_name, supported, min_version]
 
-        min_version_by_kwarg_name[kw_name] = min_version
+        min_version_by_kwarg_name[kw_name] = ".".join(str(n) for n in min_version)
 
     monkeypatch.setattr(
         rotate_module,
@@ -995,13 +993,10 @@ def test_rotate_supported_PIL_kwargs(
         messages.append(record.message.args[0])
 
     for unsupported_kwarg in unsupported_kwargs:
-        min_version_required = ".".join(
-            str(n) for n in min_version_by_kwarg_name[unsupported_kwarg]
-        )
         expected_message = (
             f"rotate '{unsupported_kwarg}' argument is not supported by your"
             " Pillow version and is being ignored. Minimum Pillow version"
-            f" required: v{min_version_required}"
+            f" required: v{min_version_by_kwarg_name[unsupported_kwarg]}"
         )
         assert expected_message in messages
 


### PR DESCRIPTION
Adds tests for ensure that the behaviour of `rotate` FX is right, patching PIL `Image.rotate` kwargs support. Minor change in the warnings raised when the installed PIL version doesn't supports an argument. Contributes to #1355

- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
