### PR TITLE
VideoClip blitting: fix truncation bug to enable fractional opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `fps` not defined in `CompositeAudioClip` at initialization [\#1462](https://github.com/Zulko/moviepy/pull/1462)
 - Fixed `clip.preview()` crashing at exit when running inside Jupyter Notebook in Windows [\#1537](https://github.com/Zulko/moviepy/pull/1537)
 - Fixed rotate FX not being applied to mask images [\#1399](https://github.com/Zulko/moviepy/pull/1399)
+- Fixed opacity error blitting VideoClips [\#1552](https://github.com/Zulko/moviepy/pull/1552)
 
 
 ## [v2.0.0.dev2](https://github.com/zulko/moviepy/tree/v2.0.0.dev2) (2020-10-05)

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -636,8 +636,8 @@ class VideoClip(Clip):
         im_img = Image.fromarray(img)
 
         if self.mask is not None:
-            mask = self.mask.get_frame(ct).astype("uint8")
-            im_mask = Image.fromarray(255 * mask).convert("L")
+            mask = (self.mask.get_frame(ct) * 255).astype("uint8")
+            im_mask = Image.fromarray(mask).convert("L")
 
             if im_img.size != im_mask.size:
                 bg_size = (

--- a/moviepy/video/tools/segmenting.py
+++ b/moviepy/video/tools/segmenting.py
@@ -32,7 +32,7 @@ def find_objects(clip, size_threshold=500, preview=False):
 
     letters = []
     for i, (sy, sx) in indexed_slices:
-        """ crop each letter separately """
+        # crop each letter separately
         sy = slice(sy.start - 1, sy.stop + 1)
         sx = slice(sx.start - 1, sx.stop + 1)
         letter = image[sy, sx]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ per-file-ignores =
     # the version file doesn't need module level docstring
     moviepy/version.py: D100
     # tests doesn't require docstring (although is recommended)
-    tests/*.py: D103
+    tests/*.py: D101,D102,D103
     # allow 'from moviepy import *' in examples
     examples/*.py: F403, F405
 docstring-convention = numpy

--- a/tests/test_compositing.py
+++ b/tests/test_compositing.py
@@ -13,6 +13,22 @@ from moviepy.video.VideoClip import BitmapClip, ColorClip
 
 from tests.test_helper import TMP_DIR
 
+class ClipPixelTest:
+    ALLOWABLE_COLOR_VARIATION = 3 # from 0-767: how much mismatch do we allow
+
+    def __init__(self, clip):
+        self.clip = clip
+
+    def expect_color_at(self, ts, expected, xy=[0, 0]):
+        frame = self.clip.make_frame(ts)
+        r, g, b = expected
+        actual = frame[xy[1]][xy[0]]
+        diff = abs(actual[0] - r) + abs(actual[1] - g) + abs(actual[2] - b)
+
+        mismatch = diff > ClipPixelTest.ALLOWABLE_COLOR_VARIATION
+        assert (not mismatch), ("Expected (%02x,%02x,%02x) but got (%02x,%02x,%02x) at timestamp %s"
+                                % (*expected, *actual, ts))
+
 
 def test_clips_array():
     red = ColorClip((1024, 800), color=(255, 0, 0))
@@ -71,27 +87,17 @@ def test_concatenate_floating_point():
 
 
 def test_blit_with_opacity():
-    ALLOWABLE_COLOR_VARIATION = 3 # from 0-767: how much mismatch do we allow
-
     # bitmap.mp4 has one second R, one second G, one second B
     clip1 = VideoFileClip("media/bitmap.mp4")
     # overlay same clip, shifted by 1 second, at half opacity
     clip2 = VideoFileClip("media/bitmap.mp4").subclip(1, 2).with_start(0).with_end(2).with_opacity(0.5)
     composite = CompositeVideoClip([clip1, clip2])
+    bt = ClipPixelTest(composite)
 
-    def expect_color_at(ts, expected):
-        f = composite.make_frame(ts)
-        r, g, b = expected
-        actual = f[0][0]
-        diff = abs(actual[0] - r) + abs(actual[1] - g) + abs(actual[2] - b)
+    bt.expect_color_at(0.5, (0x7f, 0x7f, 0x00))
+    bt.expect_color_at(1.5, (0x00, 0x7f, 0x7f))
+    bt.expect_color_at(2.5, (0x00, 0x00, 0xff))
 
-        mismatch = diff > ALLOWABLE_COLOR_VARIATION
-        assert (not mismatch), ("Expected (%02x,%02x,%02x) but got (%02x,%02x,%02x) at timestamp %s"
-                                % (*expected, *actual, ts))
-
-    expect_color_at(0.5, (0x7f, 0x7f, 0x00))
-    expect_color_at(1.5, (0x00, 0x7f, 0x7f))
-    expect_color_at(2.5, (0x00, 0x00, 0xff))
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_compositing.py
+++ b/tests/test_compositing.py
@@ -5,7 +5,7 @@ import os
 import pytest
 
 from moviepy.utils import close_all_clips
-from moviepy.video.compositing.CompositeVideoClip import clips_array, CompositeVideoClip
+from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip, clips_array
 from moviepy.video.compositing.concatenate import concatenate_videoclips
 from moviepy.video.fx.resize import resize
 from moviepy.video.io.VideoFileClip import VideoFileClip
@@ -13,8 +13,9 @@ from moviepy.video.VideoClip import BitmapClip, ColorClip
 
 from tests.test_helper import TMP_DIR
 
+
 class ClipPixelTest:
-    ALLOWABLE_COLOR_VARIATION = 3 # from 0-767: how much mismatch do we allow
+    ALLOWABLE_COLOR_VARIATION = 3  # from 0-767: how much mismatch do we allow
 
     def __init__(self, clip):
         self.clip = clip
@@ -26,8 +27,13 @@ class ClipPixelTest:
         diff = abs(actual[0] - r) + abs(actual[1] - g) + abs(actual[2] - b)
 
         mismatch = diff > ClipPixelTest.ALLOWABLE_COLOR_VARIATION
-        assert (not mismatch), ("Expected (%02x,%02x,%02x) but got (%02x,%02x,%02x) at timestamp %s"
-                                % (*expected, *actual, ts))
+        assert (
+            not mismatch
+        ), "Expected (%02x,%02x,%02x) but got (%02x,%02x,%02x) at timestamp %s" % (
+            *expected,
+            *actual,
+            ts,
+        )
 
 
 def test_clips_array():
@@ -90,13 +96,19 @@ def test_blit_with_opacity():
     # bitmap.mp4 has one second R, one second G, one second B
     clip1 = VideoFileClip("media/bitmap.mp4")
     # overlay same clip, shifted by 1 second, at half opacity
-    clip2 = VideoFileClip("media/bitmap.mp4").subclip(1, 2).with_start(0).with_end(2).with_opacity(0.5)
+    clip2 = (
+        VideoFileClip("media/bitmap.mp4")
+        .subclip(1, 2)
+        .with_start(0)
+        .with_end(2)
+        .with_opacity(0.5)
+    )
     composite = CompositeVideoClip([clip1, clip2])
     bt = ClipPixelTest(composite)
 
-    bt.expect_color_at(0.5, (0x7f, 0x7f, 0x00))
-    bt.expect_color_at(1.5, (0x00, 0x7f, 0x7f))
-    bt.expect_color_at(2.5, (0x00, 0x00, 0xff))
+    bt.expect_color_at(0.5, (0x7F, 0x7F, 0x00))
+    bt.expect_color_at(1.5, (0x00, 0x7F, 0x7F))
+    bt.expect_color_at(2.5, (0x00, 0x00, 0xFF))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes #1369 for me, which was broken as of
fe5c782f13212fb1dd678f3bace75b22bb468c65 due to a `truncate before
multiply' bug.

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [X] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [X] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [X] I have properly documented new or changed features in the documentation or in the docstrings
- [X] I have properly explained unusual or unexpected code in the comments around it

Below is the (manual) test that I used:
```
from moviepy.editor import *

video = VideoFileClip('earth.mp4')

fgclip = VideoFileClip('sample-mp4-file.mp4')
fgclip = fgclip.with_end(4)
fgclip = fgclip.with_opacity(0.5)

video = CompositeVideoClip([video, fgclip])

video.subclip(0, 4).write_videofile('out.mp4', fps=5)
```

The second commit adds a unit test.