### PR TITLE
Bump decorator to <6.0

### DIFF
--- a/moviepy/decorators.py
+++ b/moviepy/decorators.py
@@ -1,4 +1,5 @@
 """Decorators used by moviepy."""
+import inspect
 import os
 
 import decorator
@@ -81,9 +82,7 @@ def preprocess_args(fun, varnames):
     """Applies fun to variables in varnames before launching the function."""
 
     def wrapper(func, *args, **kwargs):
-        func_code = func.__code__
-
-        names = func_code.co_varnames
+        names = inspect.getfullargspec(func).args
         new_args = [
             fun(arg) if (name in varnames) and (arg is not None) else arg
             for (arg, name) in zip(args, names)
@@ -131,9 +130,7 @@ def use_clip_fps_by_default(func, clip, *args, **kwargs):
             " the clip's fps with `clip.fps=24`" % func.__name__
         )
 
-    func_code = func.__code__
-
-    names = func_code.co_varnames[1:]
+    names = inspect.getfullargspec(func).args[1:]
 
     new_args = [
         find_fps(arg) if (name == "fps") else arg for (arg, name) in zip(args, names)

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ with open(os.path.join("moviepy", "version.py"), "r", "utf-8") as f:
 
 # Define the requirements for specific execution needs.
 requires = [
-    "decorator>=4.0.2,<5.0",
+    "decorator>=4.0.2,<6.0",
     "imageio>=2.5,<3.0",
     "imageio_ffmpeg>=0.2.0",
     "numpy>=1.17.3,<=1.20",


### PR DESCRIPTION
Closes #1556

- Decorator 5 needs the usage of `inspect.getfullargspec` to get function argument names. This change is backwards compatible with previous versions of `decorator`.