### PR TITLE
Remove requests as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `colorx` FX by `multiply_color` [\#1475](https://github.com/Zulko/moviepy/pull/1475)
 - Renamed `speedx` FX by `multiply_speed` [\#1478](https://github.com/Zulko/moviepy/pull/1478)
 - `make_loopable` transition must be used as FX [\#1477](https://github.com/Zulko/moviepy/pull/1477)
+- `requests` package is no longer a dependency [\#1566](https://github.com/Zulko/moviepy/pull/1566)
 
 ### Deprecated <!-- for soon-to-be removed features -->
 - `moviepy.video.fx.all` and `moviepy.audio.fx.all`. Use the fx method directly from the clip instance or import the fx function from `moviepy.video.fx` and `moviepy.audio.fx`. [\#1105](https://github.com/Zulko/moviepy/pull/1105)

--- a/moviepy/video/io/downloader.py
+++ b/moviepy/video/io/downloader.py
@@ -1,8 +1,8 @@
 """Utilities to get a file from the internet."""
 
 import os
-
-import requests
+import shutil
+import urllib.request
 
 from moviepy.tools import subprocess_call
 
@@ -18,10 +18,8 @@ def download_webfile(url, filename, overwrite=False):
         return
 
     if "." in url:
-        r = requests.get(url, stream=True)
-        with open(filename, "wb") as fd:
-            for chunk in r.iter_content(chunk_size=128):
-                fd.write(chunk)
+        with urllib.request.urlopen(url) as req, open(filename, "wb") as f:
+            shutil.copyfileobj(req, f, 128)
 
     else:
         try:

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ requires = [
     "imageio>=2.5,<3.0",
     "imageio_ffmpeg>=0.2.0",
     "numpy>=1.17.3,<=1.20",
-    "requests>=2.8.1,<3.0",
     "proglog<=1.0.0",
 ]
 


### PR DESCRIPTION
Requests is only used one time downloading files from internet. The same can be accomplished using the standard libraries [`urllib.request`](https://docs.python.org/3.8/library/urllib.request.html#module-urllib.request) and [`shutil`](https://docs.python.org/3.8/library/shutil.html?highlight=shutil), so I've replaced `requests` with these libraries in `moviepy.video.io.downloader::download_webfile` function.