### PR TITLE
Add 'start_time' and 'end_time' parameters to multiply_volume FX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `video.io.ffmpeg_reader.ffmpeg_parse_infos` returns metadata of the container in attribute `metadata` [\#1466](https://github.com/Zulko/moviepy/pull/1466)
 - `center`, `translate` and `bg_color` arguments to `video.fx.rotate` [\#1474](https://github.com/Zulko/moviepy/pull/1474)
 - `audio.fx.audio_delay` FX [\#1481](https://github.com/Zulko/moviepy/pull/1481)
+- `start` and `end` optional arguments to `multiply_volume` FX which allow to specify a range applying the transformation [\#1572](https://github.com/Zulko/moviepy/pull/1572)
 
 ### Changed <!-- for changes in existing functionality -->
 - Lots of method and parameter names have been changed. This will be explained better in the documentation soon. See https://github.com/Zulko/moviepy/pull/1170 for more information. [\#1170](https://github.com/Zulko/moviepy/pull/1170)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `video.io.ffmpeg_reader.ffmpeg_parse_infos` returns metadata of the container in attribute `metadata` [\#1466](https://github.com/Zulko/moviepy/pull/1466)
 - `center`, `translate` and `bg_color` arguments to `video.fx.rotate` [\#1474](https://github.com/Zulko/moviepy/pull/1474)
 - `audio.fx.audio_delay` FX [\#1481](https://github.com/Zulko/moviepy/pull/1481)
-- `start` and `end` optional arguments to `multiply_volume` FX which allow to specify a range applying the transformation [\#1572](https://github.com/Zulko/moviepy/pull/1572)
+- `start_time` and `end_time` optional arguments to `multiply_volume` FX which allow to specify a range applying the transformation [\#1572](https://github.com/Zulko/moviepy/pull/1572)
 
 ### Changed <!-- for changes in existing functionality -->
 - Lots of method and parameter names have been changed. This will be explained better in the documentation soon. See https://github.com/Zulko/moviepy/pull/1170 for more information. [\#1170](https://github.com/Zulko/moviepy/pull/1170)

--- a/moviepy/audio/fx/multiply_volume.py
+++ b/moviepy/audio/fx/multiply_volume.py
@@ -57,10 +57,12 @@ def multiply_volume(clip, factor, start=None, end=None):
             keep_duration=True,
         )
 
-    start = clip.start if start is None else start
-    end = clip.duration if end is None else end
-
     return clip.transform(
-        _multiply_volume_in_range(factor, start, end, clip.nchannels),
+        _multiply_volume_in_range(
+            factor,
+            clip.start if start is None else start,
+            clip.duration if end is None else end,
+            clip.nchannels,
+        ),
         keep_duration=True,
     )

--- a/moviepy/audio/fx/multiply_volume.py
+++ b/moviepy/audio/fx/multiply_volume.py
@@ -59,17 +59,7 @@ def multiply_volume(clip, factor, start=None, end=None):
     start = clip.start if start is None else start
     end = clip.duration if end is None else end
 
-    if hasattr(clip, "nchannels"):
-        nchannels = clip.nchannels
-    else:
-        first_frame = clip.get_frame(start)
-        nchannels = (
-            first_frame.shape[1]
-            if (hasattr(first_frame, "shape") and len(first_frame.shape) > 1)
-            else 1
-        )
-
     return clip.transform(
-        _multiply_volume_in_range(factor, start, end, nchannels),
+        _multiply_volume_in_range(factor, start, end, clip.nchannels),
         keep_duration=True,
     )

--- a/moviepy/audio/fx/multiply_volume.py
+++ b/moviepy/audio/fx/multiply_volume.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from moviepy.decorators import audio_video_fx
+from moviepy.decorators import audio_video_fx, convert_parameter_to_seconds
 
 
 def _multiply_volume_in_range(factor, start, end, nchannels):
@@ -20,6 +20,7 @@ def _multiply_volume_in_range(factor, start, end, nchannels):
 
 
 @audio_video_fx
+@convert_parameter_to_seconds(["start", "end"])
 def multiply_volume(clip, factor, start=None, end=None):
     """Returns a clip with audio volume multiplied by the
     value `factor`. Can be applied to both audio and video clips.

--- a/moviepy/audio/fx/multiply_volume.py
+++ b/moviepy/audio/fx/multiply_volume.py
@@ -3,9 +3,9 @@ import numpy as np
 from moviepy.decorators import audio_video_fx, convert_parameter_to_seconds
 
 
-def _multiply_volume_in_range(factor, start, end, nchannels):
+def _multiply_volume_in_range(factor, start_time, end_time, nchannels):
     def factors_filter(factor, t):
-        return np.array([factor if start <= t_ <= end else 1 for t_ in t])
+        return np.array([factor if start_time <= t_ <= end_time else 1 for t_ in t])
 
     def multiply_stereo_volume(get_frame, t):
         return np.multiply(
@@ -20,8 +20,8 @@ def _multiply_volume_in_range(factor, start, end, nchannels):
 
 
 @audio_video_fx
-@convert_parameter_to_seconds(["start", "end"])
-def multiply_volume(clip, factor, start=None, end=None):
+@convert_parameter_to_seconds(["start_time", "end_time"])
+def multiply_volume(clip, factor, start_time=None, end_time=None):
     """Returns a clip with audio volume multiplied by the
     value `factor`. Can be applied to both audio and video clips.
 
@@ -31,11 +31,11 @@ def multiply_volume(clip, factor, start=None, end=None):
     factor : float
       Volume multiplication factor.
 
-    start : float, optional
+    start_time : float, optional
       Time from the beginning of the clip until the volume transformation
       begins to take effect, in seconds. By default at the beginning.
 
-    end : float, optional
+    end_time : float, optional
       Time from the beginning of the clip until the volume transformation
       ends to take effect, in seconds. By default at the end.
 
@@ -49,9 +49,9 @@ def multiply_volume(clip, factor, start=None, end=None):
     >>> half_audio_clip = clip.multiply_volume(0.5)  # half audio
     >>>
     >>> # silenced clip during one second at third
-    >>> silenced_range_audio_clip = clip.multiply_volume(0, start=2, end=3)
+    >>> silenced_clip = clip.multiply_volume(0, start_time=2, end_time=3)
     """
-    if start is None and end is None:
+    if start_time is None and end_time is None:
         return clip.transform(
             lambda get_frame, t: factor * get_frame(t),
             keep_duration=True,
@@ -60,8 +60,8 @@ def multiply_volume(clip, factor, start=None, end=None):
     return clip.transform(
         _multiply_volume_in_range(
             factor,
-            clip.start if start is None else start,
-            clip.end if end is None else end,
+            clip.start if start_time is None else start_time,
+            clip.end if end_time is None else end_time,
             clip.nchannels,
         ),
         keep_duration=True,

--- a/moviepy/audio/fx/multiply_volume.py
+++ b/moviepy/audio/fx/multiply_volume.py
@@ -61,7 +61,7 @@ def multiply_volume(clip, factor, start=None, end=None):
         _multiply_volume_in_range(
             factor,
             clip.start if start is None else start,
-            clip.duration if end is None else end,
+            clip.end if end is None else end,
             clip.nchannels,
         ),
         keep_duration=True,

--- a/moviepy/audio/fx/multiply_volume.py
+++ b/moviepy/audio/fx/multiply_volume.py
@@ -1,22 +1,75 @@
+import numpy as np
+
 from moviepy.decorators import audio_video_fx
 
 
+def _multiply_volume_in_range(factor, start, end, nchannels):
+    def factors_filter(factor, t):
+        return np.array([factor if start <= t_ <= end else 1 for t_ in t])
+
+    def multiply_stereo_volume(get_frame, t):
+        return np.multiply(
+            get_frame(t),
+            np.array([factors_filter(factor, t) for _ in range(nchannels)]).T,
+        )
+
+    def multiply_mono_volume(get_frame, t):
+        return np.multiply(get_frame(t), factors_filter(factor, t))
+
+    return multiply_mono_volume if nchannels == 1 else multiply_stereo_volume
+
+
 @audio_video_fx
-def multiply_volume(clip, factor):
+def multiply_volume(clip, factor, start=None, end=None):
     """Returns a clip with audio volume multiplied by the
     value `factor`. Can be applied to both audio and video clips.
 
-    This effect is loaded as a clip method when you use moviepy.editor,
-    so you can just write ``clip.multiply_volume(2)``
+    Parameters
+    ----------
+
+    factor : float
+      Volume multiplication factor.
+
+    start : float, optional
+      Time from the beginning of the clip until the volume transformation
+      begins to take effect, in seconds. By default at the beginning.
+
+    end : float, optional
+      Time from the beginning of the clip until the volume transformation
+      ends to take effect, in seconds. By default at the end.
 
     Examples
     --------
 
     >>> from moviepy import AudioFileClip
+    >>>
     >>> music = AudioFileClip('music.ogg')
-    >>> new_clip = clip.multiply_volume(2)  # doubles audio volume
-    >>> new_clip = clip.multiply_volume(0.5)  # half audio
+    >>> doubled_audio_clip = clip.multiply_volume(2)  # doubles audio volume
+    >>> half_audio_clip = clip.multiply_volume(0.5)  # half audio
+    >>>
+    >>> # silenced clip during one second at third
+    >>> silenced_range_audio_clip = clip.multiply_volume(0, start=2, end=3)
     """
+    if start is None and end is None:
+        return clip.transform(
+            lambda get_frame, t: factor * get_frame(t),
+            keep_duration=True,
+        )
+
+    start = clip.start if start is None else start
+    end = clip.duration if end is None else end
+
+    if hasattr(clip, "nchannels"):
+        nchannels = clip.nchannels
+    else:
+        first_frame = clip.get_frame(start)
+        nchannels = (
+            first_frame.shape[1]
+            if (hasattr(first_frame, "shape") and len(first_frame.shape) > 1)
+            else 1
+        )
+
     return clip.transform(
-        lambda get_frame, t: factor * get_frame(t), keep_duration=True
+        _multiply_volume_in_range(factor, start, end, nchannels),
+        keep_duration=True,
     )

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -1110,48 +1110,175 @@ def test_audio_normalize_muted():
     close_all_clips(locals())
 
 
-def test_multiply_volume():
-    clip = AudioFileClip("media/crunching.mp3")
+@pytest.mark.parametrize(
+    ("sound_type", "factor", "duration", "start", "end"),
+    (
+        pytest.param(
+            "stereo",
+            0,
+            None,
+            None,
+            None,
+            id="stereo-0",
+        ),
+        pytest.param(
+            "stereo",
+            2,
+            None,
+            None,
+            None,
+            id="stereo-2",
+        ),
+        pytest.param(
+            "mono",
+            3,
+            None,
+            None,
+            None,
+            id="mono-3",
+        ),
+        pytest.param(
+            "stereo",
+            0,
+            0.2,
+            0.1,
+            None,
+            id="stereo-0-start=.1",
+        ),
+        pytest.param(
+            "stereo",
+            0,
+            0.3,
+            None,
+            0.2,
+            id="stereo-0-end=.2",
+        ),
+        pytest.param(
+            "stereo",
+            0,
+            0.3,
+            0.1,
+            0.2,
+            id="stereo-0-start=.1-end=.2",
+        ),
+        pytest.param(
+            "mono",
+            0,
+            0.3,
+            0.2,
+            None,
+            id="mono-0-start=.2",
+        ),
+        pytest.param(
+            "mono",
+            0,
+            0.2,
+            None,
+            0.1,
+            id="mono-0-end=.1",
+        ),
+        pytest.param(
+            "mono",
+            2,
+            0.3,
+            0.1,
+            0.2,
+            id="mono-0-start=.1-end=.2",
+        ),
+    ),
+)
+def test_multiply_volume(sound_type, factor, duration, start, end):
+    if sound_type == "stereo":
+        make_frame = lambda t: np.array(
+            [
+                np.sin(440 * 2 * np.pi * t),
+                np.sin(160 * 2 * np.pi * t),
+            ]
+        ).T.copy(order="C")
+    else:
+        make_frame = lambda t: [np.sin(440 * 2 * np.pi * t)]
+
+    clip = AudioClip(
+        make_frame,
+        duration=duration if duration else 0.1,
+        fps=22050,
+    )
     clip_array = clip.to_soundarray()
 
-    # stereo mute
-    clip_muted = multiply_volume(clip, 0)
+    clip_transformed = multiply_volume(clip, factor, start=start, end=end)
+    clip_transformed_array = clip_transformed.to_soundarray()
 
-    left_channel_muted = clip_muted.to_soundarray()[:, 0]
-    right_channel_muted = clip_muted.to_soundarray()[:, 1]
+    assert len(clip_transformed_array)
 
-    z_channel = np.zeros(len(left_channel_muted))
+    if hasattr(clip_array, "shape") and len(clip_array.shape) > 1:
+        # stereo clip
+        left_channel_transformed = clip_transformed_array[:, 0]
+        right_channel_transformed = clip_transformed_array[:, 1]
 
-    assert np.array_equal(left_channel_muted, z_channel)
-    assert np.array_equal(right_channel_muted, z_channel)
+        if start is None and end is None:
+            expected_left_channel_transformed = clip_array[:, 0] * factor
+            expected_right_channel_transformed = clip_array[:, 1] * factor
+        else:
+            start = start if start else clip.start
+            end = end if end else clip.duration
 
-    # stereo level doubled
-    clip_doubled = multiply_volume(clip, 2)
-    clip_doubled_array = clip_doubled.to_soundarray()
-    left_channel_doubled = clip_doubled_array[:, 0]
-    right_channel_doubled = clip_doubled_array[:, 1]
-    expected_left_channel_doubled = clip_array[:, 0] * 2
-    expected_right_channel_doubled = clip_array[:, 1] * 2
+            expected_left_channel_transformed = np.array([])
+            expected_right_channel_transformed = np.array([])
+            for i, frame in enumerate(clip_array):
+                t = i / clip.fps
+                transformed_frame = frame * (factor if start <= t <= end else 1)
+                expected_left_channel_transformed = np.append(
+                    expected_left_channel_transformed,
+                    transformed_frame[0],
+                )
+                expected_right_channel_transformed = np.append(
+                    expected_right_channel_transformed,
+                    transformed_frame[1],
+                )
 
-    assert np.array_equal(left_channel_doubled, expected_left_channel_doubled)
-    assert np.array_equal(right_channel_doubled, expected_right_channel_doubled)
+        assert len(left_channel_transformed)
+        assert len(expected_left_channel_transformed)
+        assert np.array_equal(
+            left_channel_transformed,
+            expected_left_channel_transformed,
+        )
 
-    # mono muted
-    sinus_wave = lambda t: [np.sin(440 * 2 * np.pi * t)]
-    mono_clip = AudioClip(sinus_wave, duration=1, fps=22050)
-    muted_mono_clip = multiply_volume(mono_clip, 0)
-    mono_channel_muted = muted_mono_clip.to_soundarray()
+        assert len(right_channel_transformed)
+        assert len(expected_right_channel_transformed)
+        assert np.array_equal(
+            right_channel_transformed,
+            expected_right_channel_transformed,
+        )
 
-    z_channel = np.zeros(len(mono_channel_muted))
-    assert np.array_equal(mono_channel_muted, z_channel)
+    else:
+        # mono clip
 
-    mono_clip = AudioClip(sinus_wave, duration=1, fps=22050)
-    doubled_mono_clip = multiply_volume(mono_clip, 2)
-    mono_channel_doubled = doubled_mono_clip.to_soundarray()
-    d_channel = mono_clip.to_soundarray() * 2
-    assert np.array_equal(mono_channel_doubled, d_channel)
+        if start is None and end is None:
+            expected_clip_transformed_array = clip_array * factor
+        else:
+            start = start if start else clip.start
+            end = end if end else clip.duration
 
-    close_all_clips(locals())
+            expected_clip_transformed_array = np.array([])
+            for i, frame in enumerate(clip_array[0]):
+                t = i / clip.fps
+                transformed_frame = frame * (factor if start <= t <= end else 1)
+                expected_clip_transformed_array = np.append(
+                    expected_clip_transformed_array,
+                    transformed_frame,
+                )
+            expected_clip_transformed_array = np.array(
+                [
+                    expected_clip_transformed_array,
+                ]
+            )
+
+        assert len(expected_clip_transformed_array)
+
+        assert np.array_equal(
+            expected_clip_transformed_array,
+            clip_transformed_array,
+        )
 
 
 def test_multiply_stereo_volume():

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -1187,7 +1187,7 @@ def test_audio_normalize_muted():
         ),
     ),
 )
-def test_multiply_volume(sound_type, factor, duration, start, end):
+def test_multiply_volume_audioclip(sound_type, factor, duration, start, end):
     if sound_type == "stereo":
         make_frame = lambda t: np.array(
             [
@@ -1279,6 +1279,29 @@ def test_multiply_volume(sound_type, factor, duration, start, end):
             expected_clip_transformed_array,
             clip_transformed_array,
         )
+
+
+def test_multiply_volume_videoclip():
+    start, end = (0.1, 0.2)
+
+    clip = multiply_volume(
+        VideoFileClip("media/chaplin.mp4").subclip(0, 0.3),
+        0,
+        start=start,
+        end=end,
+    )
+    clip_soundarray = clip.audio.to_soundarray()
+
+    assert len(clip_soundarray)
+
+    expected_silence = np.zeros(clip_soundarray.shape[1])
+
+    for i, frame in enumerate(clip_soundarray):
+        t = i / clip.audio.fps
+        if start <= t <= end:
+            assert np.array_equal(frame, expected_silence)
+        else:
+            assert not np.array_equal(frame, expected_silence)
 
 
 def test_multiply_stereo_volume():

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -23,6 +23,7 @@ from moviepy.audio.fx import (
     multiply_stereo_volume,
     multiply_volume,
 )
+from moviepy.tools import convert_to_seconds
 from moviepy.utils import close_all_clips
 from moviepy.video.fx import (
     blackwhite,
@@ -1141,7 +1142,7 @@ def test_audio_normalize_muted():
             "stereo",
             0,
             0.2,
-            0.1,
+            "00:00:00,1",
             None,
             id="stereo-0-start=.1",
         ),
@@ -1150,7 +1151,7 @@ def test_audio_normalize_muted():
             0,
             0.3,
             None,
-            0.2,
+            (0, 0, 0.2),
             id="stereo-0-end=.2",
         ),
         pytest.param(
@@ -1174,7 +1175,7 @@ def test_audio_normalize_muted():
             0,
             0.2,
             None,
-            0.1,
+            "00:00:00.1",
             id="mono-0-end=.1",
         ),
         pytest.param(
@@ -1219,8 +1220,8 @@ def test_multiply_volume_audioclip(sound_type, factor, duration, start, end):
             expected_left_channel_transformed = clip_array[:, 0] * factor
             expected_right_channel_transformed = clip_array[:, 1] * factor
         else:
-            start = start if start else clip.start
-            end = end if end else clip.duration
+            start = convert_to_seconds(start) if start else clip.start
+            end = convert_to_seconds(end) if end else clip.duration
 
             expected_left_channel_transformed = np.array([])
             expected_right_channel_transformed = np.array([])
@@ -1256,8 +1257,8 @@ def test_multiply_volume_audioclip(sound_type, factor, duration, start, end):
         if start is None and end is None:
             expected_clip_transformed_array = clip_array * factor
         else:
-            start = start if start else clip.start
-            end = end if end else clip.duration
+            start = convert_to_seconds(start) if start else clip.start
+            end = convert_to_seconds(end) if end else clip.duration
 
             expected_clip_transformed_array = np.array([])
             for i, frame in enumerate(clip_array[0]):


### PR DESCRIPTION
This introduces the optional arguments `start_time` and `end_time` for `multiply_volume` FX. The volume multiplication, if these parameters are not `None`, is only applied to the seconds in the range from `start_time` to `end_time`. Note that after this, is a lot easier to introduce silences in a clip: `clip.multiply_volume(0, start_time=5, end_time=10)`. The code is totally backwards compatible. I've also properly documented the function and rewritten the tests parametrizing them.

> Closes #1571

- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
