### PR TITLE
Update pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: master
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
     hooks:
       - id: flake8
         additional_dependencies:
@@ -9,7 +9,7 @@ repos:
         name: flake8-test
         files: \.py$
   - repo: https://github.com/PyCQA/isort
-    rev: master
+    rev: 5.8.0
     hooks:
       - id: isort
         args:


### PR DESCRIPTION
- Flake8 repository [has been moved to Github](https://github.com/PyCQA/flake8).
- Use flake8 3.9.2 instead of master.
- Use isort 5.8.0 instead of master (has been renamed by main).
