### PR TITLE
Document 'find_video_period'

### DIFF
--- a/moviepy/video/tools/cuts.py
+++ b/moviepy/video/tools/cuts.py
@@ -15,7 +15,7 @@ def find_video_period(clip, fps=None, start_time=0.3):
     Parameters
     ----------
 
-    clip : :py:class:`moviepy.Clip.Clip`
+    clip : moviepy.Clip.Clip
       Clip for which the video period will be computed.
 
     fps : int, optional
@@ -28,11 +28,11 @@ def find_video_period(clip, fps=None, start_time=0.3):
     Examples
     --------
 
-    >>> from moviepy.video.io.VideoFileClip import VideoFileClip
+    >>> from moviepy.editor import *
     >>> from moviepy.video.tools.cuts import find_video_period
     >>>
     >>> clip = VideoFileClip("media/chaplin.mp4").subclip(0, 1).loop(2)
-    >>> round(find_video_period(clip, fps=80), 6)
+    >>> round(videotools.find_video_period(clip, fps=80), 6)
     1
     """
 

--- a/moviepy/video/tools/cuts.py
+++ b/moviepy/video/tools/cuts.py
@@ -4,17 +4,42 @@ from collections import defaultdict
 
 import numpy as np
 
-from moviepy.decorators import use_clip_fps_by_default
+from moviepy.decorators import convert_parameter_to_seconds, use_clip_fps_by_default
 
 
 @use_clip_fps_by_default
+@convert_parameter_to_seconds(["start_time"])
 def find_video_period(clip, fps=None, start_time=0.3):
-    """Finds the period of a video based on frames correlation."""
+    """Find the period of a video based on frames correlation.
+
+    Parameters
+    ----------
+
+    clip : :py:class:`moviepy.Clip.Clip`
+      Clip for which the video period will be computed.
+
+    fps : int, optional
+      Number of frames per second used computing the period. Higher values will
+      produce more accurate periods, but the execution time will be longer.
+
+    start_time : float, optional
+      First timeframe used to calculate the period of the clip.
+
+    Examples
+    --------
+
+    >>> from moviepy.video.io.VideoFileClip import VideoFileClip
+    >>> from moviepy.video.tools.cuts import find_video_period
+    >>>
+    >>> clip = VideoFileClip("media/chaplin.mp4").subclip(0, 1).loop(2)
+    >>> round(find_video_period(clip, fps=80), 6)
+    1
+    """
 
     def frame(t):
         return clip.get_frame(t).flatten()
 
-    timings = np.arange(start_time, clip.duration, 1.0 / fps)[1:]
+    timings = np.arange(start_time, clip.duration, 1 / fps)[1:]
     ref = frame(0)
     corrs = [np.corrcoef(ref, frame(t))[0, 1] for t in timings]
     return timings[np.argmax(corrs)]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,9 +5,6 @@ import pytest
 from moviepy.utils import close_all_clips
 from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
 from moviepy.video.compositing.concatenate import concatenate_videoclips
-from moviepy.video.fx.resize import resize
-from moviepy.video.io.VideoFileClip import VideoFileClip
-from moviepy.video.tools.cuts import find_video_period
 from moviepy.video.tools.subtitles import SubtitlesClip, file_to_subtitles
 from moviepy.video.VideoClip import ColorClip, TextClip
 
@@ -25,12 +22,6 @@ MEDIA_SUBTITLES_DATA = [
 MEDIA_SUBTITLES_UNICODE_DATA = [
     ([0, 5.0], "ÁÉíöÙ"),
 ]
-
-
-def test_cuts1():
-    clip = VideoFileClip("media/big_buck_bunny_432_433.webm").fx(resize, 0.2)
-    find_video_period(clip) == pytest.approx(0.966666666667, 0.0001)
-    close_all_clips(locals())
 
 
 def test_subtitles():

--- a/tests/test_videotools.py
+++ b/tests/test_videotools.py
@@ -3,8 +3,9 @@
 import os
 
 from moviepy.video.compositing.concatenate import concatenate_videoclips
+from moviepy.video.io.VideoFileClip import VideoFileClip
 from moviepy.video.tools.credits import CreditsClip
-from moviepy.video.tools.cuts import detect_scenes
+from moviepy.video.tools.cuts import detect_scenes, find_video_period
 from moviepy.video.VideoClip import ColorClip
 
 from tests.test_helper import FONT, TMP_DIR
@@ -52,6 +53,13 @@ def test_detect_scenes():
     cuts, luminosities = detect_scenes(video, fps=10, logger=None)
 
     assert len(cuts) == 2
+
+
+def test_find_video_period():
+    clip = VideoFileClip("media/chaplin.mp4").subclip(0, 0.5).loop(2)  # fps=25
+
+    # you need to increase the fps to get correct results
+    assert round(find_video_period(clip, fps=70), 6) == 0.5
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
+ Reformat `find_video_period` test, moving it from `test_misc` to `test_videotools`.
+ Document properly all parameters of `find_video_period` function.
+ Allow to pass `start_time` parameter as time format (`AA:BB:CC`, tuples...).
+ Update Python2 division which was using floating point unity as numerator. 

- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
