### PR TITLE
Test editor preview methods

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -56,7 +56,7 @@ jobs:
         brew install pkg-config
         python -m pip install --upgrade wheel
         python -m pip install --upgrade setuptools
-        python -m pip install ".[test, optional]"
+        python -m pip install ".[test]"
 
     - name: Test with pytest
       run: |
@@ -139,7 +139,7 @@ jobs:
         run: |
           python -m pip install --upgrade wheel
           python -m pip install --upgrade setuptools
-          python -m pip install ".[test, doc]"
+          python -m pip install ".[test, optional, doc]"
           cat /etc/ImageMagick-6/policy.xml | sed 's/none/read,write/g' | sudo tee /etc/ImageMagick-6/policy.xml
 
       - name: PyTest

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           python -m pip install --upgrade wheel
           python -m pip install --upgrade setuptools
-          python -m pip install ".[test, optional, doc]"
+          python -m pip install ".[test, doc]"
           cat /etc/ImageMagick-6/policy.xml | sed 's/none/read,write/g' | sudo tee /etc/ImageMagick-6/policy.xml
 
       - name: PyTest

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -56,7 +56,7 @@ jobs:
         brew install pkg-config
         python -m pip install --upgrade wheel
         python -m pip install --upgrade setuptools
-        python -m pip install ".[test]"
+        python -m pip install ".[test, optional]"
 
     - name: Test with pytest
       run: |
@@ -139,7 +139,7 @@ jobs:
         run: |
           python -m pip install --upgrade wheel
           python -m pip install --upgrade setuptools
-          python -m pip install ".[test, optional, doc]"
+          python -m pip install ".[test, doc]"
           cat /etc/ImageMagick-6/policy.xml | sed 's/none/read,write/g' | sudo tee /etc/ImageMagick-6/policy.xml
 
       - name: PyTest

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -135,12 +135,25 @@ jobs:
           which python
           python -m site --user-site
 
-      - name: Install Dependencies
+      - name: Install common requirements
         run: |
-          python -m pip install --upgrade wheel
-          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade wheel setuptools
+
+      - name: Install test requirements
+        if: ${{ matrix.python-version == '3.7' }}
+        run: |
           python -m pip install ".[test, doc]"
-          cat /etc/ImageMagick-6/policy.xml | sed 's/none/read,write/g' | sudo tee /etc/ImageMagick-6/policy.xml
+
+      - name: Install test and optional requirements
+        if: ${{ matrix.python-version != '3.7' }}
+        run: |
+          python -m pip install ".[test, optional, doc]"
+
+      - name: Configure ImageMagick policy
+        run: |
+          cat /etc/ImageMagick-6/policy.xml \
+          | sed 's/none/read,write/g' \
+          | sudo tee /etc/ImageMagick-6/policy.xml
 
       - name: PyTest
         run: |

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,0 +1,50 @@
+"""Moviepy editor tests."""
+
+import importlib
+import io
+from contextlib import redirect_stdout
+
+import pytest
+
+from moviepy.audio.AudioClip import AudioClip
+from moviepy.video.VideoClip import VideoClip
+
+
+def test_preview_methods():
+    stdout = io.StringIO()
+    with redirect_stdout(stdout):
+        try:
+            preview_module = importlib.import_module("moviepy.video.io.preview")
+            assert preview_module.preview.__hash__() != VideoClip.preview.__hash__()
+        except ImportError:
+            editor_module = importlib.import_module("moviepy.editor")
+            with pytest.raises(ImportError) as exc:
+                VideoClip.preview(True)
+            assert str(exc.value) == "clip.preview requires Pygame installed"
+
+            with pytest.raises(ImportError) as exc:
+                VideoClip.show(True)
+            assert str(exc.value) == "clip.show requires Pygame installed"
+
+            with pytest.raises(ImportError) as exc:
+                AudioClip.preview(True)
+            assert str(exc.value) == "clip.preview requires Pygame installed"
+        else:
+            editor_module = importlib.import_module("moviepy.editor")
+            assert (
+                editor_module.VideoClip.preview.__hash__()
+                == preview_module.preview.__hash__()
+            )
+
+        try:
+            importlib.import_module("matplotlib")
+        except ImportError:
+            editor_module = importlib.import_module("moviepy.editor")
+            with pytest.raises(ImportError) as exc:
+                editor_module.sliders()
+
+            assert str(exc.value) == "sliders requires matplotlib installed"
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
- In CI, Linux with Python v3.7 workflow, the optional requirements are not installed to check the behaviour of the tests without `pygame`, `matplotlib`, `PIL`... installed.
- Add tests for editor preview methods.