### PR TITLE
Add tests for Clip class and improve its documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `make_loopable` transition must be used as FX [\#1477](https://github.com/Zulko/moviepy/pull/1477)
 - `requests` package is no longer a dependency [\#1566](https://github.com/Zulko/moviepy/pull/1566)
 - `accel_decel` FX raises `ValueError` if `sooness` parameter value is lower than zero [\#1546](https://github.com/Zulko/moviepy/pull/1546)
+- `Clip.subclip` raise `ValueError` if `start_time >= clip.duration` (previously printing a message to stdout only if `start_time > clip.duration`) [\#1589](https://github.com/Zulko/moviepy/pull/1589)
 
 ### Deprecated <!-- for soon-to-be removed features -->
 - `moviepy.video.fx.all` and `moviepy.audio.fx.all`. Use the fx method directly from the clip instance or import the fx function from `moviepy.video.fx` and `moviepy.audio.fx`. [\#1105](https://github.com/Zulko/moviepy/pull/1105)

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -266,8 +266,8 @@ class Clip:
         (hour, min, sec), or as a string: '01:03:05.35'. Also sets the duration
         of the mask and audio, if any, of the returned clip.
 
-        If change_end is False, the start attribute of the clip will be modified
-        in function of the duration and the preset end of the clip.
+        If ``change_end is False``, the start attribute of the clip will be
+        modified in function of the duration and the preset end of the clip.
 
         Parameters
         ----------
@@ -297,7 +297,7 @@ class Clip:
         ----------
 
         make_frame : function
-          New frame creator function.
+          New frame creator function for the clip.
         """
         self.make_frame = make_frame
 
@@ -404,7 +404,7 @@ class Clip:
           For instance:
 
           >>> # cut the last two seconds of the clip:
-          >>> new_clip = clip.subclip(0,-2)
+          >>> new_clip = clip.subclip(0, -2)
 
           If ``end_time`` is provided or if the clip has a duration attribute,
           the duration of the returned clip is set automatically.
@@ -430,11 +430,12 @@ class Clip:
         elif (end_time is not None) and (end_time < 0):
 
             if self.duration is None:
-
                 raise ValueError(
-                    "Error: subclip with negative times (here %s)"
+                    (
+                        "Subclip with negative times (here %s)"
+                        " can only be extracted from clips with a ``duration``"
+                    )
                     % (str((start_time, end_time)))
-                    + " can only be extracted from clips with a ``duration``"
                 )
 
             else:
@@ -490,9 +491,9 @@ class Clip:
         Returns each frame of the clip as a HxWxN Numpy array,
         where N=1 for mask clips and N=3 for RGB clips.
 
-        This function is not really meant for video editing.
-        It provides an easy way to do frame-by-frame treatment of
-        a video, for fields like science, computer vision...
+        This function is not really meant for video editing. It provides an
+        easy way to do frame-by-frame treatment of a video, for fields like
+        science, computer vision...
 
         Parameters
         ----------

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -356,7 +356,7 @@ class Clip:
         of the clip. ``t`` can be expressed in seconds (15.35), in (min, sec), in
         (hour, min, sec), or as a string: '01:03:05.35'. If ``t`` is a numpy
         array, returns False if none of the ``t`` is in the clip, else returns a
-        vector [b_1, b_2, b_3...] where b_i is true iff tti is in the clip.
+        vector [b_1, b_2, b_3...] where b_i is true if tti is in the clip.
         """
         if isinstance(t, np.ndarray):
             # is the whole list of t outside the clip ?

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -58,8 +58,14 @@ class Clip:
 
     @convert_parameter_to_seconds(["t"])
     def get_frame(self, t):
-        """Gets a numpy array representing the RGB picture of the clip at time ``t``
-        or (mono or stereo) value for a sound clip.
+        """Gets a numpy array representing the RGB picture of the clip,
+        or (mono or stereo) value for a sound clip, at time ``t``.
+
+        Parameters
+        ----------
+
+        t : float or tuple or str
+          Moment of the clip whose frame will be returned.
         """
         # Coming soon: smart error handling for debugging at this point
         if self.memoize:
@@ -202,17 +208,22 @@ class Clip:
         to ``t``, which can be expressed in seconds (15.35), in (min, sec),
         in (hour, min, sec), or as a string: '01:03:05.35'.
 
-
-        If ``change_end=True`` and the clip has a ``duration`` attribute,
-        the ``end`` atrribute of the clip will be updated to
-        ``start+duration``.
-
-        If ``change_end=False`` and the clip has a ``end`` attribute,
-        the ``duration`` attribute of the clip will be updated to
-        ``end-start``
-
         These changes are also applied to the ``audio`` and ``mask``
         clips of the current clip, if they exist.
+
+        Parameters
+        ----------
+
+        t : float or tuple or str
+          New ``start`` attribute value for the clip.
+
+        change_end : bool optional
+          Indicates if the ``end`` attribute value must be changed accordingly,
+          if possible. If ``change_end=True`` and the clip has a ``duration``
+          attribute, the ``end`` atrribute of the clip will be updated to
+          ``start + duration``. If ``change_end=False`` and the clip has a
+          ``end`` attribute, the ``duration`` attribute of the clip will be
+          updated to ``end - start``.
         """
         self.start = t
         if (self.duration is not None) and change_end:
@@ -225,10 +236,16 @@ class Clip:
     @convert_parameter_to_seconds(["t"])
     @outplace
     def with_end(self, t):
-        """Returns a copy of the clip, with the ``end`` attribute set to ``t``, which
-        can be expressed in seconds (15.35), in (min, sec), in (hour, min, sec), or as
-        a string: '01:03:05.35'. Also sets the duration of the mask and audio, if any,
-        of the returned clip.
+        """Returns a copy of the clip, with the ``end`` attribute set to ``t``,
+        which can be expressed in seconds (15.35), in (min, sec), in
+        (hour, min, sec), or as a string: '01:03:05.35'. Also sets the duration
+        of the mask and audio, if any, of the returned clip.
+
+        Parameters
+        ----------
+
+        t : float or tuple or str
+          New ``end`` attribute value for the clip.
         """
         self.end = t
         if self.end is None:
@@ -244,14 +261,23 @@ class Clip:
     @convert_parameter_to_seconds(["t"])
     @outplace
     def with_duration(self, duration, change_end=True):
-        """Returns a copy of the clip, with the  ``duration`` attribute set to ``t``,
-        which can be expressed in seconds (15.35), in (min, sec), in (hour, min, sec),
-        or as a string: '01:03:05.35'. Also sets the duration of the mask and audio,
-        if any, of the returned clip.
+        """Returns a copy of the clip, with the  ``duration`` attribute set to
+        ``t``, which can be expressed in seconds (15.35), in (min, sec), in
+        (hour, min, sec), or as a string: '01:03:05.35'. Also sets the duration
+        of the mask and audio, if any, of the returned clip.
 
-        If change_end is False, the start attribute of the clip will
-        be modified in function of the duration and the preset end
-        of the clip.
+        If change_end is False, the start attribute of the clip will be modified
+        in function of the duration and the preset end of the clip.
+
+        Parameters
+        ----------
+
+        duration : float
+          New duration attribute value for the clip.
+
+        change_end : bool, optional
+          If ``True``, the ``end`` attribute value of the clip will be adjusted
+          acordingly to the new duration using ``clip.start + duration``.
         """
         self.duration = duration
 
@@ -259,13 +285,19 @@ class Clip:
             self.end = None if (duration is None) else (self.start + duration)
         else:
             if self.duration is None:
-                raise Exception("Cannot change clip start when new duration is None")
+                raise ValueError("Cannot change clip start when new duration is None")
             self.start = self.end - duration
 
     @outplace
     def with_make_frame(self, make_frame):
         """Sets a ``make_frame`` attribute for the clip. Useful for setting
         arbitrary/complicated videoclips.
+
+        Parameters
+        ----------
+
+        make_frame : function
+          New frame creator function.
         """
         self.make_frame = make_frame
 
@@ -273,9 +305,16 @@ class Clip:
         """Returns a copy of the clip with a new default fps for functions like
         write_videofile, iterframe, etc.
 
-        If ``change_duration=True``, then the video speed will change to match the
-        new fps (conserving all frames 1:1). For example, if the fps is
-        halved in this mode, the duration will be doubled.
+        Parameters
+        ----------
+
+        fps : int
+          New ``fps`` attribute value for the clip.
+
+        change_duration : bool, optional
+          If ``change_duration=True``, then the video speed will change to
+          match the new fps (conserving all frames 1:1). For example, if the
+          fps is halved in this mode, the duration will be doubled.
         """
         if change_duration:
             from moviepy.video.fx.multiply_speed import multiply_speed
@@ -289,21 +328,35 @@ class Clip:
 
     @outplace
     def with_is_mask(self, is_mask):
-        """Says wheter the clip is a mask or not (is_mask is a boolean)."""
+        """Says wheter the clip is a mask or not.
+
+        Parameters
+        ----------
+
+        is_mask : bool
+          New ``is_mask`` attribute value for the clip.
+        """
         self.is_mask = is_mask
 
     @outplace
     def with_memoize(self, memoize):
-        """Sets wheter the clip should keep the last frame read in memory."""
+        """Sets wheter the clip should keep the last frame read in memory.
+
+        Parameters
+        ----------
+
+        memoize : bool
+          Indicates if the clip should keep the last frame read in memory.
+        """
         self.memoize = memoize
 
     @convert_parameter_to_seconds(["t"])
     def is_playing(self, t):
         """If ``t`` is a time, returns true if t is between the start and the end
-        of the clip. t can be expressed in seconds (15.35), in (min, sec), in
-        (hour, min, sec), or as a string: '01:03:05.35'. If t is a numpy array,
-        returns False if none of the t is in the clip, else returns a vector
-        [b_1, b_2, b_3...] where b_i is true iff tti is in the clip.
+        of the clip. ``t`` can be expressed in seconds (15.35), in (min, sec), in
+        (hour, min, sec), or as a string: '01:03:05.35'. If ``t`` is a numpy
+        array, returns False if none of the ``t`` is in the clip, else returns a
+        vector [b_1, b_2, b_3...] where b_i is true iff tti is in the clip.
         """
         if isinstance(t, np.ndarray):
             # is the whole list of t outside the clip ?
@@ -330,30 +383,38 @@ class Clip:
     @apply_to_audio
     def subclip(self, start_time=0, end_time=None):
         """Returns a clip playing the content of the current clip between times
-        ``start_time`` and ``end_time``, which can be expressed in seconds (15.35),
-        in (min, sec), in (hour, min, sec), or as a string: '01:03:05.35'.
+        ``start_time`` and ``end_time``, which can be expressed in seconds
+        (15.35), in (min, sec), in (hour, min, sec), or as a string:
+        '01:03:05.35'.
 
-        If ``end_time`` is not provided, it is assumed to be the duration of the clip
-        (potentially infinite).
+        The ``mask`` and ``audio`` of the resulting subclip will be subclips of
+        ``mask`` and ``audio`` the original clip, if they exist.
 
-        If ``end_time`` is negative, it is reset to ``clip.duration + end_time``.
-        For instance::
+        Parameters
+        ----------
 
-            >>> # cut the last two seconds of the clip:
-            >>> new_clip = clip.subclip(0,-2)
+        start_time : float or tuple or str, optional
+          Moment that will be chosen as the beginning of the produced clip. If
+          is negative, it is reset to ``clip.duration + start_time``.
 
-        If ``end_time`` is provided or if the clip has a duration attribute, the
-        duration of the returned clip is set automatically.
+        end_time : float or tuple or str, optional
+          Moment that will be chosen as the end of the produced clip. If not
+          provided, it is assumed to be the duration of the clip (potentially
+          infinite). If is negative, it is reset to ``clip.duration + end_time``.
+          For instance:
 
-        The ``mask`` and ``audio`` of the resulting subclip will be subclips of ``mask``
-        and ``audio`` the original clip, if they exist.
+          >>> # cut the last two seconds of the clip:
+          >>> new_clip = clip.subclip(0,-2)
+
+          If ``end_time`` is provided or if the clip has a duration attribute,
+          the duration of the returned clip is set automatically.
         """
         if start_time < 0:
             # Make this more Python-like, a negative value means to move
             # backward from the end of the clip
             start_time = self.duration + start_time  # Remember start_time is negative
 
-        if (self.duration is not None) and (start_time > self.duration):
+        if (self.duration is not None) and (start_time >= self.duration):
             raise ValueError(
                 "start_time (%.02f) " % start_time
                 + "should be smaller than the clip's "
@@ -370,7 +431,7 @@ class Clip:
 
             if self.duration is None:
 
-                print(
+                raise ValueError(
                     "Error: subclip with negative times (here %s)"
                     % (str((start_time, end_time)))
                     + " can only be extracted from clips with a ``duration``"
@@ -394,12 +455,22 @@ class Clip:
         skips the extract between ``start_time`` and ``end_time``, which can be
         expressed in seconds (15.35), in (min, sec), in (hour, min, sec),
         or as a string: '01:03:05.35'.
+
         If the original clip has a ``duration`` attribute set,
         the duration of the returned clip  is automatically computed as
         `` duration - (end_time - start_time)``.
 
         The resulting clip's ``audio`` and ``mask`` will also be cutout
         if they exist.
+
+        Parameters
+        ----------
+
+        start_time : float or tuple or str
+          Moment from which frames will be ignored in the resulting output.
+
+        end_time : float or tuple or str
+          Moment until which frames will be ignored in the resulting output.
         """
         new_clip = self.time_transform(
             lambda t: t + (t >= start_time) * (end_time - start_time),
@@ -408,7 +479,7 @@ class Clip:
 
         if self.duration is not None:
             return new_clip.with_duration(self.duration - (end_time - start_time))
-        else:
+        else:  # pragma: no cover
             return new_clip
 
     @requires_duration
@@ -416,17 +487,30 @@ class Clip:
     def iter_frames(self, fps=None, with_times=False, logger=None, dtype=None):
         """Iterates over all the frames of the clip.
 
-        Returns each frame of the clip as a HxWxN np.array,
+        Returns each frame of the clip as a HxWxN Numpy array,
         where N=1 for mask clips and N=3 for RGB clips.
 
         This function is not really meant for video editing.
         It provides an easy way to do frame-by-frame treatment of
         a video, for fields like science, computer vision...
 
-        The ``fps`` (frames per second) parameter is optional if the
-        clip already has a ``fps`` attribute.
+        Parameters
+        ----------
 
-        Use dtype="uint8" when using the pictures to write video, images...
+        fps : int, optional
+          Frames per second for clip iteration. Is optional if the clip already
+          has a ``fps`` attribute.
+
+        with_times : bool, optional
+          Ff ``True`` yield tuples of ``(t, frame)`` where ``t`` is the current
+          time for the frame, otherwise only a ``frame`` object.
+
+        logger : str, optional
+          Either ``"bar"`` for progress bar or ``None`` or any Proglog logger.
+
+        dtype : type, optional
+          Type to cast Numpy array frames. Use ``dtype="uint8"`` when using the
+          pictures to write video, images...
 
         Examples
         --------

--- a/tests/test_Clip.py
+++ b/tests/test_Clip.py
@@ -1,22 +1,139 @@
 import copy
 
+import numpy as np
 import pytest
 
 from moviepy.Clip import Clip
-from moviepy.video.VideoClip import BitmapClip
+from moviepy.video.VideoClip import BitmapClip, ColorClip
 
 
 def test_clip_equality():
     bitmap = [["RR", "RR"], ["RB", "RB"]]
     different_bitmap = [["RR", "RB"], ["RB", "RB"]]
+    different_duration_bitmap = [["RR", "RR"], ["RB", "RB"], ["RR", "RR"]]
 
     clip = BitmapClip(bitmap, fps=1)
     same_clip = BitmapClip(bitmap, fps=1)
 
     different_clip = BitmapClip(different_bitmap, fps=1)
+    different_duration_clip = BitmapClip(different_duration_bitmap, fps=1)
 
     assert clip == same_clip
     assert clip != different_clip
+    assert clip != different_duration_clip
+    assert different_clip != different_duration_clip
+
+
+def test_clip_with_is_mask():
+    clip = BitmapClip([["RR", "GG"]], fps=1)
+    assert not clip.is_mask
+
+    assert clip.with_is_mask(True).is_mask
+
+    assert not clip.with_is_mask(False).is_mask
+
+
+@pytest.mark.parametrize(
+    (
+        "start",
+        "end",
+        "duration",
+        "new_start",
+        "change_end",
+        "expected_end",
+        "expected_duration",
+    ),
+    (
+        (0, 3, 3, 1, True, 4, 3),
+        (0, 3, 3, 1, False, 3, 2),  # not change_end
+    ),
+)
+def test_clip_with_start(
+    start,
+    end,
+    duration,
+    new_start,
+    change_end,
+    expected_end,
+    expected_duration,
+):
+    clip = (
+        ColorClip(color=(255, 0, 0), size=(2, 2))
+        .with_fps(1)
+        .with_duration(duration)
+        .with_end(end)
+        .with_start(start)
+    )
+
+    new_clip = clip.with_start(new_start, change_end=change_end)
+
+    assert new_clip.end == expected_end
+    assert new_clip.duration == expected_duration
+
+
+@pytest.mark.parametrize(
+    ("duration", "start", "end", "expected_start", "expected_duration"),
+    (
+        (3, 1, 2, 1, 1),
+        (3, 1, None, 1, 3),  # end is None
+        (3, None, 4, 1, 3),  # start is None
+    ),
+)
+def test_clip_with_end(duration, start, end, expected_start, expected_duration):
+    clip = ColorClip(color=(255, 0, 0), size=(2, 2), duration=duration).with_fps(1)
+    if start is not None:
+        clip = clip.with_start(start)
+    else:
+        clip.start = None
+    clip = clip.with_end(end)
+
+    assert clip.start == expected_start
+    assert clip.duration == expected_duration
+
+
+@pytest.mark.parametrize(
+    (
+        "duration",
+        "start",
+        "end",
+        "new_duration",
+        "change_end",
+        "expected_duration",
+        "expected_start",
+        "expected_end",
+    ),
+    (
+        (5, None, None, 3, True, 3, 0, 3),
+        (5, 1, 6, 3, True, 3, 1, 4),  # change end
+        (5, 1, 6, 3, False, 3, 3, 6),  # change start
+        (5, None, None, None, False, ValueError, None, None),
+    ),
+)
+def test_clip_with_duration(
+    duration,
+    start,
+    end,
+    new_duration,
+    change_end,
+    expected_duration,
+    expected_start,
+    expected_end,
+):
+    clip = ColorClip(color=(255, 0, 0), size=(2, 2)).with_fps(1).with_duration(duration)
+    if start is not None:
+        clip = clip.with_start(start)
+    if end is not None:
+        clip = clip.with_end(end)
+
+    if hasattr(expected_duration, "__traceback__"):
+        with pytest.raises(expected_duration):
+            clip.with_duration(new_duration, change_end=change_end)
+    else:
+        clip = clip.with_duration(new_duration, change_end=change_end)
+
+        assert clip.duration == expected_duration
+        assert clip.start == expected_start
+        assert clip.end == expected_end
 
 
 @pytest.mark.parametrize(
@@ -51,6 +168,87 @@ def test_clip_copy(copy_func):
 
         # other instances are not edited
         assert getattr(copied_clip, attr) != getattr(other_clip, attr)
+
+
+@pytest.mark.parametrize(
+    ("duration", "start_time", "end_time", "expected_duration"),
+    (
+        (1, 0, None, 1),
+        (3, 0, 2, 2),
+        (3, 1, 2, 1),
+        (3, -2, 2, 1),  # negative start_time
+        (3, 4, None, ValueError),  # start_time > duration
+        (3, 3, None, ValueError),  # start_time == duration
+        (3, 1, -1, 1),  # negative end_time
+        (None, 1, -1, ValueError),  # negative end_time for clip without duration
+    ),
+)
+def test_clip_subclip(duration, start_time, end_time, expected_duration):
+    if duration is None:
+        clip = ColorClip(color=(255, 0, 0), size=(2, 2)).with_fps(1)
+    else:
+        clip = BitmapClip([["RR", "GG"] for _ in range(duration)], fps=1)
+
+    if hasattr(expected_duration, "__traceback__"):
+        with pytest.raises(expected_duration):
+            clip.subclip(start_time=start_time, end_time=end_time)
+    else:
+        sub_clip = clip.subclip(start_time=start_time, end_time=end_time)
+        assert sub_clip.duration == expected_duration
+
+
+@pytest.mark.parametrize(
+    ("start_time", "end_time", "expected_frames"),
+    (
+        (
+            1,
+            2,
+            [["RR", "RR"], ["BB", "BB"]],
+        ),
+        (
+            1,
+            3,
+            [["RR", "RR"]],
+        ),
+        (
+            2,
+            3,
+            [["RR", "RR"], ["GG", "GG"]],
+        ),
+        (
+            0,
+            1,
+            [["GG", "GG"], ["BB", "BB"]],
+        ),
+        (
+            0,
+            2,
+            [["BB", "BB"]],
+        ),
+    ),
+)
+def test_clip_cutout(start_time, end_time, expected_frames):
+    clip = BitmapClip([["RR", "RR"], ["GG", "GG"], ["BB", "BB"]], fps=1)
+    new_clip = clip.cutout(start_time, end_time)
+
+    assert new_clip == BitmapClip(expected_frames, fps=1)
+
+
+def test_clip_memoize():
+    clip = BitmapClip([["RR", "RR"], ["GG", "GG"], ["BB", "BB"]], fps=1)
+
+    assert not clip.memoize
+
+    memoize_clip = clip.with_memoize(True)
+    assert memoize_clip.memoize
+
+    # get_frame memoizing
+    memoize_clip.memoized_t = 5
+    memoize_clip.memoized_frame = "foo"
+
+    assert memoize_clip.get_frame(5) == "foo"
+
+    assert isinstance(memoize_clip.get_frame(1), np.ndarray)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
+ Add missing tests for `Clip` class.
+ Improve `Clip` methods documentation.
+ If `start_time >= clip.duration` in `Clip.subclip` method, raise `ValueError` (previously raised only if `start_time > clip.duration`).
+ If `end_time < 0` and `clip.duration is None` in `Clip.subclip` method, raise `ValueError` instead of printing a message to stdout.
+ Raise `ValueError` instead of `Exception` in `Clip.with_duration` method.

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
