### PR TITLE
Add tests for HTML tools

### DIFF
--- a/tests/test_videotools.py
+++ b/tests/test_videotools.py
@@ -1,10 +1,13 @@
 """Video file clip tests meant to be run with pytest."""
 
+import importlib
 import math
 import os
+import sys
 
 import pytest
 
+from moviepy.audio.AudioClip import AudioClip
 from moviepy.video.compositing.concatenate import concatenate_videoclips
 from moviepy.video.io.VideoFileClip import VideoFileClip
 from moviepy.video.tools.credits import CreditsClip
@@ -14,9 +17,18 @@ from moviepy.video.tools.cuts import (
     detect_scenes,
     find_video_period,
 )
-from moviepy.video.VideoClip import BitmapClip, ColorClip
+from moviepy.video.VideoClip import BitmapClip, ColorClip, ImageClip, VideoClip
 
-from tests.test_helper import FONT, TMP_DIR
+from tests.test_helper import FONT, TMP_DIR, get_stereo_wave
+
+
+try:
+    importlib.import_module("ipython.display")
+except ImportError:
+    ipython_available = False
+else:
+    ipython_available = True
+    del sys.modules["ipython.display"]
 
 
 def test_credits():
@@ -216,5 +228,213 @@ def test_FramesMatches_save_load():
         assert frames_match == input_matching_frames[i]
 
 
+@pytest.mark.parametrize(
+    ("clip", "filetype", "fps", "maxduration", "t", "expected_error"),
+    (
+        pytest.param(
+            AudioClip(get_stereo_wave(), duration=0.2, fps=44100),
+            None,
+            None,
+            None,
+            None,
+            None,
+            id="AudioClip",
+        ),
+        pytest.param(
+            VideoFileClip("media/bitmap.mp4"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            id="VideoFileClip",
+        ),
+        pytest.param(
+            BitmapClip([["RR", "RR"], ["GG", "GG"]], duration=0.25),
+            None,
+            4,
+            None,
+            None,
+            None,
+            id="BitmapClip",
+        ),
+        pytest.param(
+            ImageClip("media/python_logo.png"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            id="ImageClip(.png)",
+        ),
+        pytest.param(
+            ImageClip("media/pigs_in_a_polka.gif"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            id="ImageClip(.gif)",
+        ),
+        pytest.param(
+            os.path.join("media", "pigs_in_a_polka.gif"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            id="filename(.gif)",
+        ),
+        pytest.param(
+            os.path.join("media", "vacation_2017.jpg"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            id="filename(.jpg)",
+        ),
+        pytest.param(
+            os.path.join(TMP_DIR, "moviepy_ipython_display.foo"),
+            None,  # unknown filetype
+            None,
+            None,
+            None,
+            (ValueError, "No file type is known for the provided file."),
+            id="filename(.foo)",
+        ),
+        pytest.param(
+            os.path.join(TMP_DIR, "moviepy_ipython_display.foo"),
+            "video",  # unsupported filetype for '.foo' extension
+            None,
+            None,
+            None,
+            (
+                ValueError,
+                "This video extension cannot be displayed in the IPython Notebook.",
+            ),
+            id="filename(.foo)[filetype=video]",
+        ),
+        pytest.param(
+            VideoFileClip("media/bitmap.mp4"),
+            "video",
+            None,
+            0,
+            None,
+            (
+                ValueError,
+                "You can increase 'maxduration', by passing 'maxduration'",
+            ),
+            id="VideoFileClip(.mp4)[filetype=video, maxduration > clip.duration]",
+        ),
+        pytest.param(
+            type("FakeClip", (), {})(),
+            None,
+            None,
+            None,
+            None,
+            (ValueError, "Unknown class for the clip. Cannot embed and preview"),
+            id="FakeClip",
+        ),
+        pytest.param(
+            VideoFileClip("media/chaplin.mp4").subclip(0, 1),
+            None,
+            None,
+            None,
+            0.5,
+            None,
+            id="VideoFileClip(.mp4)[filetype=video, t=0.5]",
+        ),
+        pytest.param(
+            ImageClip("media/pigs_in_a_polka.gif"),
+            None,
+            None,
+            None,
+            0.2,
+            None,
+            id="ImageClip(.gif)[t=0.2]",
+        ),
+    ),
+)
+def test_ipython_display(
+    clip, filetype, fps, maxduration, t, expected_error, monkeypatch
+):
+    # patch module to use it without ipython installed
+    video_io_html_tools_module = importlib.import_module("moviepy.video.io.html_tools")
+
+    monkeypatch.setattr(video_io_html_tools_module, "ipython_available", True)
+
+    kwargs = {}
+    if fps is not None:
+        kwargs["fps"] = fps
+    if maxduration is not None:
+        kwargs["maxduration"] = maxduration
+    if t is not None:
+        kwargs["t"] = t
+
+    if expected_error is None:
+        html_content = video_io_html_tools_module.ipython_display(
+            clip,
+            rd_kwargs={"logger": None},
+            filetype=filetype,
+            **kwargs,
+        )
+    else:
+        with pytest.raises(expected_error[0]) as exc:
+            video_io_html_tools_module.ipython_display(
+                clip,
+                rd_kwargs=None if not kwargs else dict(logger=None),
+                filetype=filetype,
+                **kwargs,
+            )
+        assert expected_error[1] in str(exc.value)
+        return
+
+    HTML5_support_message = (
+        "Sorry, seems like your browser doesn't support HTML5 audio/video"
+    )
+
+    def image_contents():
+        return ("></div>", "<div align=middle><img  src=")
+
+    if isinstance(clip, AudioClip):
+        content_end = f">{HTML5_support_message}</audio></div>"
+        content_start = "<div align=middle><audio controls><source   src="
+    elif isinstance(clip, ImageClip) or t is not None:  # t -> ImageClip
+        content_end, content_start = image_contents()
+    elif isinstance(clip, VideoClip):
+        content_end = f" controls>{HTML5_support_message}</video></div>"
+        content_start = "<div align=middle><video src="
+    else:
+        ext = os.path.splitext(clip)[1]
+        if ext in [".jpg", ".gif"]:
+            content_end, content_start = image_contents()
+        else:
+            raise NotImplementedError(
+                f"'test_ipython_display' must handle '{ext}' extension types!"
+            )
+
+    assert html_content.startswith(content_start)
+    assert html_content.endswith(content_end)
+
+    del sys.modules["moviepy.video.io.html_tools"]
+    if "ipython" in sys.modules:
+        del sys.modules["ipython"]
+
+
+@pytest.mark.skipif(
+    ipython_available,
+    reason="ipython must not be installed in order to run this test",
+)
+def test_ipython_display_not_available():
+    video_io_html_tools_module = importlib.import_module("moviepy.video.io.html_tools")
+
+    with pytest.raises(ImportError) as exc:
+        video_io_html_tools_module.ipython_display("foo")
+    assert str(exc.value) == "Only works inside an IPython Notebook"
+
+    del sys.modules["moviepy.video.io.html_tools"]
+
+
 if __name__ == "__main__":
-    test_credits()
+    pytest.main()


### PR DESCRIPTION
+ Add tests for `video.io.html_tools` module and improve its function docstrings.
+ Fixed invalid `rd_kwargs` passed to `ImageClip.save_frame` like `rd_kwargs(logger=None)` when `isinstance(clip, ImageClip)`.

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
