### PR TITLE
Allow to pass 't' argument of 'clip.show' as 'HH:MM:SS' format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `copy.copy(clip)` and `copy.deepcopy(clip)` with same behaviour as `clip.copy()` [\#1442](https://github.com/Zulko/moviepy/pull/1442)
 - `audio.fx.multiply_stereo_volume` to control volume by audio channels [\#1424](https://github.com/Zulko/moviepy/pull/1424)
 - Support for retrieve clip frames number using `clip.n_frames` [\#1471](https://github.com/Zulko/moviepy/pull/1471)
+- `AudioClip.max_volume(stereo=True)` now can return more than 2 channels [\#1464](https://github.com/Zulko/moviepy/pull/1464)
 - `video.io.ffmpeg_reader.ffmpeg_parse_infos` returns data from all streams by FFmpeg inputs in attribute `inputs` [\#1466](https://github.com/Zulko/moviepy/pull/1466)
 - `video.io.ffmpeg_reader.ffmpeg_parse_infos` returns metadata of the container in attribute `metadata` [\#1466](https://github.com/Zulko/moviepy/pull/1466)
 - `center`, `translate` and `bg_color` arguments to `video.fx.rotate` [\#1474](https://github.com/Zulko/moviepy/pull/1474)
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `requests` package is no longer a dependency [\#1566](https://github.com/Zulko/moviepy/pull/1566)
 - `accel_decel` FX raises `ValueError` if `sooness` parameter value is lower than zero [\#1546](https://github.com/Zulko/moviepy/pull/1546)
 - `Clip.subclip` raise `ValueError` if `start_time >= clip.duration` (previously printing a message to stdout only if `start_time > clip.duration`) [\#1589](https://github.com/Zulko/moviepy/pull/1589)
+- Allow to pass times in `HH:MM:SS` format to `t` argument of `clip.show` method [\#1594](https://github.com/Zulko/moviepy/pull/1594)
 
 ### Deprecated <!-- for soon-to-be removed features -->
 - `moviepy.video.fx.all` and `moviepy.audio.fx.all`. Use the fx method directly from the clip instance or import the fx function from `moviepy.video.fx` and `moviepy.audio.fx`. [\#1105](https://github.com/Zulko/moviepy/pull/1105)
@@ -49,7 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed deprecated `tostring` method by `tobytes` in `video.io.gif_writers::write_gif` [\#1429](https://github.com/Zulko/moviepy/pull/1429)
 - Fixed calling `audio_normalize` on a clip with no sound causing `ZeroDivisionError` [\#1401](https://github.com/Zulko/moviepy/pull/1401)
 - Fixed `freeze` FX was freezing at time minus 1 second as the end [\#1461](https://github.com/Zulko/moviepy/pull/1461)
-- `AudioClip.max_volume(stereo=True)` now can return more than 2 channels [\#1464](https://github.com/Zulko/moviepy/pull/1464)
 - Fixed `Clip.cutout` transformation not being applied to audio [\#1468](https://github.com/Zulko/moviepy/pull/1468)
 - Fixed arguments inconsistency in `video.tools.drawing.color_gradient` [\#1467](https://github.com/Zulko/moviepy/pull/1467)
 - Fixed `fps` not defined in `CompositeAudioClip` at initialization [\#1462](https://github.com/Zulko/moviepy/pull/1462)

--- a/moviepy/utils.py
+++ b/moviepy/utils.py
@@ -30,7 +30,7 @@ def close_all_clips(objects="globals", types=("audio", "video", "image")):
       Set of types of clips to close, being "audio", "video" or "image" the supported
       values.
     """
-    if objects == "globals":
+    if objects == "globals":  # pragma: no cover
         objects = globals()
     if hasattr(objects, "values"):
         objects = objects.values()

--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -168,5 +168,5 @@ class VideoFileClip(VideoClip):
             if self.audio:
                 self.audio.close()
                 self.audio = None
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             pass

--- a/moviepy/video/io/preview.py
+++ b/moviepy/video/io/preview.py
@@ -4,8 +4,11 @@ import time
 import numpy as np
 import pygame as pg
 
-from moviepy.decorators import convert_masks_to_RGB, requires_duration
-from moviepy.tools import convert_to_seconds
+from moviepy.decorators import (
+    convert_masks_to_RGB,
+    convert_parameter_to_seconds,
+    requires_duration,
+)
 from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
 
 
@@ -23,6 +26,7 @@ def imdisplay(imarray, screen=None):
 
 
 @convert_masks_to_RGB
+@convert_parameter_to_seconds(["t"])
 def show(clip, t=0, with_mask=True, interactive=False):
     """
     Splashes the frame of clip corresponding to time ``t``.
@@ -30,17 +34,25 @@ def show(clip, t=0, with_mask=True, interactive=False):
     Parameters
     ----------
 
-    t
+    t : float or tuple or str, optional
       Time in seconds of the frame to display.
 
-    with_mask
-      ``False`` if the clip has a mask but you want to see the clip
-      without the mask.
+    with_mask : bool, optional
+      ``False`` if the clip has a mask but you want to see the clip without
+      the mask.
 
+    interactive : bool, optional
+      Displays the image freezed and you can clip in each pixel to see the
+      pixel number and its color.
+
+    Examples
+    --------
+
+    >>> from moviepy.editor import *
+    >>>
+    >>> clip = VideoFileClip("media/chaplin.mp4")
+    >>> clip.show(t=4, interactive=True)
     """
-    if isinstance(t, tuple):
-        t = convert_to_seconds(*t)
-
     if with_mask and (clip.mask is not None):
         clip = CompositeVideoClip([clip.with_position((0, 0))])
 
@@ -75,28 +87,40 @@ def preview(
     fullscreen=False,
 ):
     """
-    Displays the clip in a window, at the given frames per second
-    (of movie) rate. It will avoid that the clip be played faster
-    than normal, but it cannot avoid the clip to be played slower
-    than normal if the computations are complex. In this case, try
-    reducing the ``fps``.
+    Displays the clip in a window, at the given frames per second (of movie)
+    rate. It will avoid that the clip be played faster than normal, but it
+    cannot avoid the clip to be played slower than normal if the computations
+    are complex. In this case, try reducing the ``fps``.
 
     Parameters
     ----------
 
-    fps
+    fps : int, optional
       Number of frames per seconds in the displayed video.
 
-    audio
+    audio : bool, optional
       ``True`` (default) if you want the clip's audio be played during
       the preview.
 
-    audio_fps
+    audio_fps : int, optional
       The frames per second to use when generating the audio sound.
 
-    fullscreen
+    audio_buffersize : int, optional
+      The sized of the buffer used generating the audio sound.
+
+    audio_nbytes : int, optional
+      The number of bytes used generating the audio sound.
+
+    fullscreen : bool, optional
       ``True`` if you want the preview to be displayed fullscreen.
 
+    Examples
+    --------
+
+    >>> from moviepy.editor import *
+    >>>
+    >>> clip = VideoFileClip("media/chaplin.mp4")
+    >>> clip.preview(fps=10, audio=False)
     """
     if fullscreen:
         flags = pg.FULLSCREEN

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -71,5 +71,25 @@ def test_cross_platform_popen_params(os_name, monkeypatch):
     assert len(params) == (1 if os_name == "nt" else 0)
 
 
+@pytest.mark.parametrize("old_name", ("bar", "foo"))
+def test_deprecated_version_of(old_name):
+    def to_file(*args, **kwargs):
+        return
+
+    func = tools.deprecated_version_of(to_file, old_name)
+
+    expected_warning_message = (
+        f"MoviePy: The function ``{old_name}`` is deprecated and is kept"
+        " temporarily for backwards compatibility.\nPlease use the new name"
+        f", ``{to_file.__name__}``, instead."
+    )
+
+    with pytest.warns(PendingDeprecationWarning) as record:
+        func(1, b=2)
+
+    assert len(record) == 1
+    assert record[0].message.args[0] == expected_warning_message
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
+ `t` argument of `clip.show` method accepts `HH:MM:SS` time formats.
+ Add test for internal tool and proper documentation to `preview` methods.

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
