### PR TITLE
Add tests to prevent decorators arguments inconsistency

### DIFF
--- a/moviepy/audio/fx/__init__.py
+++ b/moviepy/audio/fx/__init__.py
@@ -13,7 +13,6 @@ __all__ = (
     "audio_delay",
     "audio_fadein",
     "audio_fadeout",
-    "audio_left_right",
     "audio_loop",
     "audio_normalize",
     "multiply_stereo_volume",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -291,7 +291,7 @@ def test_decorators_argument_converters_consistency(decorator_name):
     This test is util to prevent next case in which the parameter names doesn't
     match between the decorator and the function definition:
 
-    >>> @convert_parameter_to_seconds(["foo"])
+    >>> @convert_parameter_to_seconds(['foo'])  # doctest: +SKIP
     >>> def whatever_function(bar):  # bar not converted to seconds
     ...     pass
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,7 +13,12 @@ import pytest
 import moviepy.tools as tools
 from moviepy.video.io.downloader import download_webfile
 
-from tests.test_helper import TMP_DIR, static_files_server
+from tests.test_helper import (
+    TMP_DIR,
+    get_functions_with_decorator_defined,
+    get_moviepy_modules,
+    static_files_server,
+)
 
 
 @pytest.mark.parametrize(
@@ -272,6 +277,49 @@ def test_config_check():
 
     if "moviepy.config" in sys.modules:
         del sys.modules["moviepy.config"]
+
+
+@pytest.mark.parametrize(
+    "decorator_name",
+    ("convert_parameter_to_seconds", "convert_path_to_string"),
+)
+def test_decorators_argument_converters_consistency(decorator_name):
+    """Checks that for all functions that have a decorator defined (like
+    ``@convert_parameter_to_seconds``), the parameters passed to the decorator
+    correspond to the parameters taken by the function.
+
+    This test is util to prevent next case in which the parameter names doesn't
+    match between the decorator and the function definition:
+
+    >>> @convert_parameter_to_seconds(["foo"])
+    >>> def whatever_function(bar):  # bar not converted to seconds
+    ...     pass
+
+    Some wrong defintions remained unnoticed in the past before this test was
+    added.
+    """
+    with contextlib.redirect_stdout(io.StringIO()):
+        for modname, ispkg in get_moviepy_modules():
+            if ispkg:
+                continue
+            module = importlib.import_module(modname)
+
+            functions_with_decorator = get_functions_with_decorator_defined(
+                module,
+                decorator_name,
+            )
+
+            for function_data in functions_with_decorator:
+                for argument_name in function_data["decorator_arguments"]:
+                    funcname = function_data["function_name"]
+                    assert argument_name in function_data["function_arguments"], (
+                        f"Wrong argument name '{argument_name}' in"
+                        f" '@{decorator_name}' decorator for function"
+                        f" '{funcname}' found inside module '{modname}'"
+                    )
+
+                assert function_data["decorator_arguments"]
+                assert function_data["function_arguments"]
 
 
 if __name__ == "__main__":

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -279,6 +279,7 @@ def test_config_check():
         del sys.modules["moviepy.config"]
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires Python 3.8 or greater")
 @pytest.mark.parametrize(
     "decorator_name",
     ("convert_parameter_to_seconds", "convert_path_to_string"),
@@ -302,7 +303,11 @@ def test_decorators_argument_converters_consistency(decorator_name):
         for modname, ispkg in get_moviepy_modules():
             if ispkg:
                 continue
-            module = importlib.import_module(modname)
+
+            try:
+                module = importlib.import_module(modname)
+            except ImportError:
+                continue
 
             functions_with_decorator = get_functions_with_decorator_defined(
                 module,


### PR DESCRIPTION
This add two tests for decorators `@convert_parameter_to_seconds` and `@convert_path_to_string`, which check that the decorator call definition's arguments match with the wrapped function definition's arguments. Prevents #1609 from happening again.