### PR TITLE
AudioFileClip/VideoFileClip support io.BytesIO as input.

### DIFF
--- a/moviepy/audio/io/AudioFileClip.py
+++ b/moviepy/audio/io/AudioFileClip.py
@@ -60,7 +60,6 @@ class AudioFileClip(AudioClip):
 
         AudioClip.__init__(self)
 
-        self.filename = filename
         self.reader = FFMPEG_AudioReader(
             filename,
             decode_file=decode_file,
@@ -72,7 +71,7 @@ class AudioFileClip(AudioClip):
         self.duration = self.reader.duration
         self.end = self.reader.duration
         self.buffersize = self.reader.buffersize
-        self.filename = filename
+        self.filename = self.reader.filename
 
         self.make_frame = lambda t: self.reader.get_frame(t)
         self.nchannels = self.reader.nchannels

--- a/moviepy/audio/io/AudioFileClip.py
+++ b/moviepy/audio/io/AudioFileClip.py
@@ -21,7 +21,7 @@ class AudioFileClip(AudioClip):
       as a string or a path-like object,
       or an array representing a sound. If the soundfile is not a .wav,
       it will be converted to .wav first, using the ``fps`` and
-      ``bitrate`` arguments.
+      ``bitrate`` arguments. It also could be a `io.BytesIO` object.
 
     buffersize:
       Size to load in memory (in number of frames)
@@ -50,6 +50,8 @@ class AudioFileClip(AudioClip):
     --------
 
     >>> snd = AudioFileClip("song.wav")
+    >>> snd.close()
+    >>> snd = AudioFileClip(open("song.wav", "rb"))
     >>> snd.close()
     """
 

--- a/moviepy/audio/io/AudioFileClip.py
+++ b/moviepy/audio/io/AudioFileClip.py
@@ -51,7 +51,8 @@ class AudioFileClip(AudioClip):
 
     >>> snd = AudioFileClip("song.wav")
     >>> snd.close()
-    >>> snd = AudioFileClip(open("song.wav", "rb"))
+    >>> import io
+    >>> snd = AudioFileClip(io.BytesIO(open("song.wav", "rb").read()))
     >>> snd.close()
     """
 

--- a/moviepy/audio/io/readers.py
+++ b/moviepy/audio/io/readers.py
@@ -1,10 +1,9 @@
 """MoviePy audio reading with ffmpeg."""
+import io
+import numpy as np
 import shlex
 import subprocess as sp
 import warnings
-import io
-import numpy as np
-import errno
 from moviepy.config import FFMPEG_BINARY
 from moviepy.tools import cross_platform_popen_params
 from moviepy.video.io.ffmpeg_reader import ffmpeg_parse_infos

--- a/moviepy/decorators.py
+++ b/moviepy/decorators.py
@@ -1,5 +1,6 @@
 """Decorators used by moviepy."""
 import inspect
+import io
 import os
 
 import decorator
@@ -102,8 +103,10 @@ def convert_parameter_to_seconds(varnames):
 
 
 def convert_path_to_string(varnames):
-    """Converts the specified variables to a path string."""
-    return preprocess_args(os.fspath, varnames)
+    """Converts the specified variables to a path string.
+    Note: it doesn't deal with `io.BytesIO` variables (for supporting Video/AudioFileClip's input).
+    """
+    return preprocess_args(lambda x: x if isinstance(x, io.BytesIO) else os.fspath(x), varnames)
 
 
 @decorator.decorator

--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -119,7 +119,7 @@ class VideoFileClip(VideoClip):
         self.size = self.reader.size
         self.rotation = self.reader.rotation
 
-        self.filename = filename
+        self.filename = self.reader.filename
 
         if has_mask:
 

--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -10,7 +10,7 @@ class VideoFileClip(VideoClip):
     """
     A video clip originating from a movie file. For instance: ::
 
-import io        >>> clip = VideoFileClip("myHolidays.mp4")
+        >>> clip = VideoFileClip("myHolidays.mp4")
         >>> clip.close()
         >>> with VideoFileClip("myMaskVideo.avi") as clip2:
         >>>    pass  # Implicit close called by context manager.

--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -10,11 +10,12 @@ class VideoFileClip(VideoClip):
     """
     A video clip originating from a movie file. For instance: ::
 
-        >>> clip = VideoFileClip("myHolidays.mp4")
+import io        >>> clip = VideoFileClip("myHolidays.mp4")
         >>> clip.close()
         >>> with VideoFileClip("myMaskVideo.avi") as clip2:
         >>>    pass  # Implicit close called by context manager.
-        >>> clip = VideoFileClip(open("myHolidays.mp4", "rb").read())
+        >>> import io
+        >>> clip = VideoFileClip(io.BytesIO(open("myHolidays.mp4", "rb").read()))
         >>> clip.close()
 
 

--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -14,6 +14,8 @@ class VideoFileClip(VideoClip):
         >>> clip.close()
         >>> with VideoFileClip("myMaskVideo.avi") as clip2:
         >>>    pass  # Implicit close called by context manager.
+        >>> clip = VideoFileClip(open("myHolidays.mp4", "rb").read())
+        >>> clip.close()
 
 
     Parameters
@@ -22,7 +24,7 @@ class VideoFileClip(VideoClip):
     filename:
       The name of the video file, as a string or a path-like object.
       It can have any extension supported by ffmpeg:
-      .ogv, .mp4, .mpeg, .avi, .mov etc.
+      .ogv, .mp4, .mpeg, .avi, .mov etc. It also could be a `io.BytesIO` object.
 
     has_mask:
       Set this to 'True' if there is a mask included in the videofile.

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -1,12 +1,11 @@
 """Implements all the functions to read a video or a picture using ffmpeg."""
-import os
-import re
-import subprocess as sp
-import warnings
 import io
 import numpy as np
+import os
+import re
 import shlex
-import errno
+import subprocess as sp
+import warnings
 from moviepy.config import FFMPEG_BINARY  # ffmpeg, ffmpeg.exe, etc...
 from moviepy.tools import convert_to_seconds, cross_platform_popen_params
 
@@ -85,7 +84,7 @@ class FFMPEG_VideoReader:
         self.close(delete_lastread=False)  # if any
         if isinstance(self.filename, io.BytesIO):
             stream = self.filename
-            self.filename = 'pipe:'
+            self.filename = "pipe:"
             stream.seek(0)
             stdin_pipe, stdin = sp.PIPE, stream.read()
         else:
@@ -93,9 +92,9 @@ class FFMPEG_VideoReader:
 
         if start_time != 0:
             offset = min(1, start_time)
-            i_arg = f'-ss {start_time - offset} -i {self.filename} -ss {offset}'
+            i_arg = f"-ss {start_time - offset} -i {self.filename} -ss {offset}"
         else:
-            i_arg = f'-i {self.filename}'
+            i_arg = f"-i {self.filename}"
         cmd = shlex.split(f"{FFMPEG_BINARY} {i_arg} -loglevel error -f image2pipe -vf scale={self.size[0]}:{self.size[1]} "
                           f"-sws_flags {self.resize_algo} -pix_fmt {self.pixel_format} -vcodec rawvideo pipe:")
 
@@ -773,13 +772,13 @@ def ffmpeg_parse_infos(
     # Open the file in a pipe, read output
     if isinstance(filename, io.BytesIO):
         stream = filename
-        filename = 'pipe:'
+        filename = "pipe:"
         stream.seek(0)
         stdin_pipe, stdin = sp.PIPE, stream.read()
-        cmd = shlex.split(f'{FFMPEG_BINARY} -i {filename} -f rawvideo -hide_banner pipe:')
+        cmd = shlex.split(f"{FFMPEG_BINARY} -i {filename} -f rawvideo -hide_banner pipe:")
     else:
         stdin_pipe, stdin = sp.DEVNULL, None
-        cmd = shlex.split(f'{FFMPEG_BINARY} -i {filename} -hide_banner')
+        cmd = shlex.split(f"{FFMPEG_BINARY} -i {filename} -hide_banner")
     if decode_file:
         cmd.extend(["-f", "null", "-"])
 


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
Sometimes, people may receive a mp4 format buffer and want to open it as `VideoFileClip` without save it to disk.
So, it's convenient to support `io.BytesIO` as parameter of VideoFileClip or AudioFileClip.

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
