### PR TITLE
Add MKV support allowing h264 w/ alt. sound codecs

### DIFF
--- a/moviepy/tools.py
+++ b/moviepy/tools.py
@@ -131,6 +131,7 @@ def deprecated_version_of(func, old_name):
 
 extensions_dict = {
     "mp4": {"type": "video", "codec": ["libx264", "libmpeg4", "aac"]},
+    "mkv": {"type": "video", "codec": ["libx264", "libmpeg4", "aac"]},
     "ogv": {"type": "video", "codec": ["libtheora"]},
     "webm": {"type": "video", "codec": ["libvpx"]},
     "avi": {"type": "video"},


### PR DESCRIPTION
Added 1 line for moviepy to be able to use FFMPEG to make matroska mkv files that can handle a variety of sound codecs as well has h264 video codecs. It has allowed me to output a mkv with h264 video and pcm_s16le audio :-)

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
