### PR TITLE
ImageMagick change detection from convert.exe to magick.exe

### DIFF
--- a/moviepy/config.py
+++ b/moviepy/config.py
@@ -69,12 +69,13 @@ if IMAGEMAGICK_BINARY == "auto-detect":
             for imagemagick_filename in ["convert.exe", "magick.exe"]:
                 try:
                     imagemagick_path = sp.check_output(
-                        r'dir /B /O-N "C:\Program Files\ImageMagick-*"',
+                        r'dir /B /O-N "C:\\Program Files\\ImageMagick-*"',
                         shell=True,
                         encoding="utf-8",
                     ).split("\n")[0]
                     IMAGEMAGICK_BINARY = sp.check_output(  # pragma: no cover
-                        rf'dir /B /S "C:\Program Files\{imagemagick_path}\*{imagemagick_filename}"',
+                        rf'dir /B /S "C:\Program Files\{imagemagick_path}\''
+                        f'*{imagemagick_filename}"',
                         shell=True,
                         encoding="utf-8",
                     ).split("\n")[0]

--- a/moviepy/config.py
+++ b/moviepy/config.py
@@ -66,19 +66,21 @@ if IMAGEMAGICK_BINARY == "auto-detect":
             IMAGEMAGICK_BINARY = wr.QueryValueEx(key, "BinPath")[0] + r"\magick.exe"
             key.Close()
         except Exception:
-            try:
-                imagemagick_path = sp.check_output(
-                    r'dir /B /O-N "C:\Program Files\ImageMagick-*"',
-                    shell=True,
-                    encoding="utf-8",
-                ).split("\n")[0]
-                IMAGEMAGICK_BINARY = sp.check_output(  # pragma: no cover
-                    rf'dir /B /S "C:\Program Files\{imagemagick_path}\*magick.exe"',
-                    shell=True,
-                    encoding="utf-8",
-                ).split("\n")[0]
-            except Exception:
-                IMAGEMAGICK_BINARY = "unset"
+            for imagemagick_filename in ["convert.exe", "magick.exe"]:
+                try:
+                    imagemagick_path = sp.check_output(
+                        r'dir /B /O-N "C:\Program Files\ImageMagick-*"',
+                        shell=True,
+                        encoding="utf-8",
+                    ).split("\n")[0]
+                    IMAGEMAGICK_BINARY = sp.check_output(  # pragma: no cover
+                        rf'dir /B /S "C:\Program Files\{imagemagick_path}\*{imagemagick_filename}"',
+                        shell=True,
+                        encoding="utf-8",
+                    ).split("\n")[0]
+                    break
+                except Exception:
+                    IMAGEMAGICK_BINARY = "unset"
 
     if IMAGEMAGICK_BINARY in ["unset", "auto-detect"]:
         if try_cmd(["convert"])[0]:

--- a/moviepy/config.py
+++ b/moviepy/config.py
@@ -73,7 +73,7 @@ if IMAGEMAGICK_BINARY == "auto-detect":
                     encoding="utf-8",
                 ).split("\n")[0]
                 IMAGEMAGICK_BINARY = sp.check_output(  # pragma: no cover
-                    rf'dir /B /S "C:\Program Files\{imagemagick_path}\*convert.exe"',
+                    rf'dir /B /S "C:\Program Files\{imagemagick_path}\*magick.exe"',
                     shell=True,
                     encoding="utf-8",
                 ).split("\n")[0]


### PR DESCRIPTION
convert.exe only exists when you explicitly add it during installation -> magick.exe always exists

Dialog during installation (on win 10)
<img src="https://i.imgur.com/fI4erq6.png">