### PR TITLE
fix autodetection of imagemagick

### DIFF
--- a/moviepy/config.py
+++ b/moviepy/config.py
@@ -74,7 +74,7 @@ if IMAGEMAGICK_BINARY == "auto-detect":
                         encoding="utf-8",
                     ).split("\n")[0]
                     IMAGEMAGICK_BINARY = sp.check_output(  # pragma: no cover
-                        rf'dir /B /S "C:\Program Files\{imagemagick_path}\''
+                        rf'dir /B /S "C:\Program Files\{imagemagick_path}\\'
                         f'*{imagemagick_filename}"',
                         shell=True,
                         encoding="utf-8",


### PR DESCRIPTION
removed additional '

@mondeja 
fix for https://github.com/Zulko/moviepy/pull/1689/commits/f7f2224fc4396f3f53d8bb60d74545be70eaa920

Otherwise this adds an apostrophe to the path making it invalid and it will ***always fail***.
<img src="https://i.imgur.com/rCp3ht2.png">