### PR TITLE
Relax Numpy constraints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ requires = [
     "decorator>=4.0.2,<6.0",
     "imageio>=2.5,<3.0",
     "imageio_ffmpeg>=0.2.0",
-    "numpy>=1.17.3,<=1.20",
+    "numpy<=1.20",
     "proglog<=1.0.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ requires = [
     "decorator>=4.0.2,<6.0",
     "imageio>=2.5,<3.0",
     "imageio_ffmpeg>=0.2.0",
-    "numpy<=1.20",
+    "numpy>=1.17.3",
     "proglog<=1.0.0",
 ]
 


### PR DESCRIPTION
In a different repo we have been running into problems caused by moviepy's numpy version constraints. I suspected that these constraints were unnecessary so I cloned the repo and tested under different versions of numpy.

I have found that versions 1.17.3, 1.18.0, 1.20.0, 1.21.5, and 1.22.3 (latest version) all result in passing tests.

I also tested 1.17.0 which fails to install. Nevertheless it seems like all numpy versions going forward from 1.17.3 are compatible with moviepy. I would recommend that the `<=1.20.0` constraint be removed and to allow numpy versions going forward to prevent against unnecessary version conflicts for other packages.

Another idea would be to add `<2.0.0` for a potentially backwards incompatible major version jump, or a more conservative `<1.23.0` for minor revision changes. Patches are very safe to assume will continue to work correctly.

Thanks!

PS I tested locally on a mac, I'll be checking to make sure CI here also works as expected for this change.