### PR TITLE
Fixing ffmpeg error with opus audio in mp4

### DIFF
--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -19,6 +19,7 @@ def ffmpeg_movie_from_frames(filename, folder, fps, digits=6, bitrate='v'):
              "-i", os.path.join(folder,folder) + '/' + s,
              "-b", "%dk"%bitrate,
              "-r", "%d"%fps,
+             "-strict", "-2",
              filename]
     
     subprocess_call(cmd)
@@ -47,7 +48,7 @@ def ffmpeg_merge_video_audio(video,audio,output, vcodec='copy',
     """ merges video file ``video`` and audio file ``audio`` into one
         movie file ``output``. """
     cmd = [get_setting("FFMPEG_BINARY"), "-y", "-i", audio,"-i", video,
-             "-vcodec", vcodec, "-acodec", acodec, output]
+             "-vcodec", vcodec, "-acodec", acodec, "-strict", "-2", output]
              
     subprocess_call(cmd, logger = logger)
     
@@ -55,14 +56,14 @@ def ffmpeg_merge_video_audio(video,audio,output, vcodec='copy',
 def ffmpeg_extract_audio(inputfile,output,bitrate=3000,fps=44100):
     """ extract the sound from a video file and save it in ``output`` """
     cmd = [get_setting("FFMPEG_BINARY"), "-y", "-i", inputfile, "-ab", "%dk"%bitrate,
-         "-ar", "%d"%fps, output]
+         "-ar", "%d"%fps, "-strict", "-2", output]
     subprocess_call(cmd)
     
 
 def ffmpeg_resize(video,output,size):
     """ resizes ``video`` to new size ``size`` and write the result
         in file ``output``. """
-    cmd= [get_setting("FFMPEG_BINARY"), "-i", video, "-vf", "scale=%d:%d"%(size[0], size[1]),
+    cmd= [get_setting("FFMPEG_BINARY"), "-i", video, "-vf", "scale=%d:%d"%(size[0], size[1]), "-strict", "-2",
              output]
              
     subprocess_call(cmd)

--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -36,7 +36,7 @@ def ffmpeg_extract_subclip(filename, t1, t2, targetname=None):
            "-ss", "%0.2f"%t1,
            "-i", filename,
            "-t", "%0.2f"%(t2-t1),
-           "-map", "0", "-vcodec", "copy", "-acodec", "copy", targetname]
+           "-map", "0", "-vcodec", "copy", "-acodec", "copy", "-strict", "-2", targetname]
     
     subprocess_call(cmd)
 


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix

I have fixed a bug with mp4 when ffmpeg does not clip the video due to opus support being experimental. My fix only adds a command flag to enable this support so the error does not occur. This is the error in the image below:

![image](https://user-images.githubusercontent.com/84601340/171687597-f6ae1460-414b-42a5-a72f-3efd26bc3997.png)

I have further added this flag to the other functions in the file so as to fix the problem elsewhere. I have not, however, tested these functions. The function that I originally added the fix to was the clipping one, although I assume the flag to work in the other commands.
Please make changes as needed. Thank you.