### PR TITLE
Fix textclip filename parameter in wrong format

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1256,7 +1256,7 @@ class TextClip(ImageClip):
             text = "@" + temptxt
         else:
             # use a file instead of a text.
-            text = "@%" + filename
+            text = "@" + filename
 
         if size is not None:
             size = (

--- a/tests/test_TextClip.py
+++ b/tests/test_TextClip.py
@@ -76,5 +76,6 @@ def test_text_filename_arguments_consistence(util):
     assert len(frames_from_file) == 1
     assert np.equal(frames_from_text[0], frames_from_file[0]).all()
 
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_TextClip.py
+++ b/tests/test_TextClip.py
@@ -55,7 +55,6 @@ def test_if_textclip_crashes_in_label_mode(util):
     TextClip(text="foo", method="label", font=util.FONT).close()
 
 
-@pytest.mark.xfail(raises=AssertionError)
 def test_textclip_filename_parameter_actually_work(util):
     """
     Regardless you provide a filename or text paramter,
@@ -66,6 +65,7 @@ def test_textclip_filename_parameter_actually_work(util):
     # the exact name to use it later when checking
     # both methods result in the same parameter value
     tempfile_fd, temp_text_filename = tempfile.mkstemp(suffix=".txt")
+    # TextClip instantiation will delete the file
     os.close(tempfile_fd)
 
     text_clip_with_text = TextClip(
@@ -86,8 +86,6 @@ def test_textclip_filename_parameter_actually_work(util):
 
     text_clip_with_file.close()
     text_clip_with_text.close()
-
-    os.remove(temp_text_filename)
 
 
 if __name__ == "__main__":

--- a/tests/test_TextClip.py
+++ b/tests/test_TextClip.py
@@ -1,5 +1,8 @@
 """TextClip tests."""
 
+import os
+import tempfile
+
 import pytest
 
 from moviepy.video.fx.blink import blink
@@ -50,6 +53,41 @@ def test_if_textclip_crashes_in_caption_mode(util):
 
 def test_if_textclip_crashes_in_label_mode(util):
     TextClip(text="foo", method="label", font=util.FONT).close()
+
+
+@pytest.mark.xfail(raises=AssertionError)
+def test_textclip_filename_parameter_actually_work(util):
+    """
+    Regardless you provide a filename or text paramter,
+    the final text attribute should be of the format @<file_name>
+    not @%<file_name> which is how it's set before this fix.
+    """
+    # Create the temp text file to make sure we know
+    # the exact name to use it later when checking
+    # both methods result in the same parameter value
+    tempfile_fd, temp_text_filename = tempfile.mkstemp(suffix=".txt")
+    os.close(tempfile_fd)
+
+    text_clip_with_text = TextClip(
+        text="foo",
+        temptxt=temp_text_filename,
+        method="caption",
+        size=(220, 134),
+        font=util.FONT,
+    )
+    text_clip_with_file = TextClip(
+        filename=temp_text_filename,
+        method="caption",
+        size=(220, 134),
+        font=util.FONT,
+    )
+
+    assert text_clip_with_file.text == text_clip_with_text.text
+
+    text_clip_with_file.close()
+    text_clip_with_text.close()
+
+    os.remove(temp_text_filename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it

closes #1787