### PR TITLE
Fix TextClip with text as empty string

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        language_version: python3.6
+        language_version: python3
         files: \.py$
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1246,6 +1246,8 @@ class TextClip(ImageClip):
     ):
 
         if text is not None:
+            if not text:
+                text = " "
             if temptxt is None:
                 temptxt_fd, temptxt = tempfile.mkstemp(suffix=".txt")
                 try:  # only in Python3 will this work

--- a/tests/test_TextClip.py
+++ b/tests/test_TextClip.py
@@ -51,7 +51,7 @@ def test_if_textclip_crashes_in_caption_mode(util):
 def test_if_textclip_crashes_in_label_mode(util):
     TextClip(text="foo", method="label", font=util.FONT).close()
 
-    
+
 def test_empty_string_as_text(util):
     TextClip(text="").close()
 

--- a/tests/test_TextClip.py
+++ b/tests/test_TextClip.py
@@ -51,6 +51,9 @@ def test_if_textclip_crashes_in_caption_mode(util):
 def test_if_textclip_crashes_in_label_mode(util):
     TextClip(text="foo", method="label", font=util.FONT).close()
 
+def test_empty_string_as_text(util):
+    TextClip(text="").close()
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_TextClip.py
+++ b/tests/test_TextClip.py
@@ -51,6 +51,7 @@ def test_if_textclip_crashes_in_caption_mode(util):
 def test_if_textclip_crashes_in_label_mode(util):
     TextClip(text="foo", method="label", font=util.FONT).close()
 
+    
 def test_empty_string_as_text(util):
     TextClip(text="").close()
 


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->

For issue #1800, I tested multiple cases with ImageMagick using same arguments that moviepy uses.

### 1. Empty text
empty.txt (Without any character in the file)
```
```
When executing `convert` with `convert -background transparent -fill black -font Courier -gravity center label:@/home/gooday2die/empty.txt -type truecolormatte ~/empty.png` parameters, this will cause following error:
```
convert: no images defined `/home/gooday2die/empty.png' @ error/convert.c/ConvertImageCommand/3229.
```
(Also empty string with bare `label:` failed as well.)

###  2. Not Empty text
nonempty.txt 
```
this is not empty!
```
When executing `convert` with `convert -background transparent -fill black -font Courier -gravity center label:@/home/gooday2die/nonempty.txt -type truecolormatte ~/nonempty.png` parameters, this will generate image successfuly.

### Conclusion
https://github.com/Zulko/moviepy/blob/18e9f57d1abbae8051b9aef75de3f19b4d1f0630/moviepy/video/VideoClip.py#L1304-L1306
When this subprocess was used, it will throw error since ImageMagick was not able to process empty string. Since this is an error of ImageMagick, it seems like an alternative way of making an empty string `""` is to convert it to `" "`.

### Sumary
- ImageMagick was not able to process empty string `""` itself, it is not a problem of moviepy
- Add a simple script that changes `""` into `" "`
- Tested with `tests/tests_TextClip.py`'s `test_empty_string_as_text` as well as checking it in personal Python environment.


- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
