### PR TITLE
Raise `ValueError` if invalid arguments passed to `TextClip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `accel_decel` FX raises `ValueError` if `sooness` parameter value is lower than zero [\#1546](https://github.com/Zulko/moviepy/pull/1546)
 - `Clip.subclip` raise `ValueError` if `start_time >= clip.duration` (previously printing a message to stdout only if `start_time > clip.duration`) [\#1589](https://github.com/Zulko/moviepy/pull/1589)
 - Allow to pass times in `HH:MM:SS` format to `t` argument of `clip.show` method [\#1594](https://github.com/Zulko/moviepy/pull/1594)
+- `TextClip` now raises `ValueError` if none of the `text` or `filename` arguments are specified [\#1842](https://github.com/Zulko/moviepy/pull/1842)
 
 ### Deprecated <!-- for soon-to-be removed features -->
 - `moviepy.video.fx.all` and `moviepy.audio.fx.all`. Use the fx method directly from the clip instance or import the fx function from `moviepy.video.fx` and `moviepy.audio.fx`. [\#1105](https://github.com/Zulko/moviepy/pull/1105)

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1254,9 +1254,13 @@ class TextClip(ImageClip):
                     os.write(temptxt_fd, text)
                 os.close(temptxt_fd)
             text = "@" + temptxt
-        else:
+        elif filename is not None:
             # use a file instead of a text.
             text = "@" + filename
+        else:
+            raise ValueError(
+                "You must provide either 'text' or 'filename' arguments to TextClip"
+            )
 
         if size is not None:
             size = (

--- a/tests/test_TextClip.py
+++ b/tests/test_TextClip.py
@@ -77,5 +77,22 @@ def test_text_filename_arguments_consistence(util):
     assert np.equal(frames_from_text[0], frames_from_file[0]).all()
 
 
+@pytest.mark.parametrize(
+    "method", ("caption", "label"), ids=("method=caption", "method=label")
+)
+def test_no_text_nor_filename_arguments(method, util):
+    expected_error_msg = (
+        "^You must provide either 'text' or 'filename' arguments to TextClip$"
+    )
+    with pytest.raises(ValueError, match=expected_error_msg):
+        TextClip(
+            size=(20, 20),
+            color="#000",
+            bg_color="#FFF",
+            font=util.FONT,
+            method=method,
+        )
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
At least one of `filename` or `text` arguments of `TextClip` are required. Now raises `ValueError` if no `filename` and `text` arguments are provided.
