### PR TITLE
Parse rotation from displaymatrix

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -504,7 +504,9 @@ class FFmpegInfosParser:
 
                 if self._current_stream["stream_type"] == "video":
                     if field == "displaymatrix":
-                        match = re.search(r"rotation of (-?\d+\.\d+) degrees", value.strip())
+                        match = re.search(
+                            r"rotation of (-?\d+\.\d+) degrees", value.strip()
+                        )
                         if match is not None:
                             rotation = float(match.groups()[0])
                             self.result["video_rotation"] = rotation
@@ -736,6 +738,7 @@ class FFmpegInfosParser:
         """
         raw_field, raw_value = line.split(":", 1)
         return (raw_field.strip(" "), raw_value.strip(" "))
+
 
 def ffmpeg_parse_infos(
     filename,

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -503,9 +503,11 @@ class FFmpegInfosParser:
                 field, value = self.parse_metadata_field_value(line)
 
                 if self._current_stream["stream_type"] == "video":
-                    field, value = self.video_metadata_type_casting(field, value)
-                    if field == "rotate":
-                        self.result["video_rotation"] = value
+                    if field == "displaymatrix":
+                        match = re.search(r"rotation of (-?\d+\.\d+) degrees", value.strip())
+                        if match is not None:
+                            rotation = float(match.groups()[0])
+                            self.result["video_rotation"] = rotation
 
                 # multiline metadata value parsing
                 if field == "":
@@ -734,13 +736,6 @@ class FFmpegInfosParser:
         """
         raw_field, raw_value = line.split(":", 1)
         return (raw_field.strip(" "), raw_value.strip(" "))
-
-    def video_metadata_type_casting(self, field, value):
-        """Cast needed video metadata fields to other types than the default str."""
-        if field == "rotate":
-            return (field, float(value))
-        return (field, value)
-
 
 def ffmpeg_parse_infos(
     filename,

--- a/tests/test_ffmpeg_reader.py
+++ b/tests/test_ffmpeg_reader.py
@@ -285,14 +285,14 @@ def test_ffmpeg_parse_infos_metadata_with_attached_pic():
 
 
 def test_ffmpeg_parse_video_rotation():
-    d = ffmpeg_parse_infos("media/rotated-90-degrees.mp4")
-    assert d["video_rotation"] == 90
+    d = ffmpeg_parse_infos("media/rotated-270-degrees.mp4")
+    assert d["video_rotation"] == -90
     assert d["video_size"] == [1920, 1080]
 
 
 def test_correct_video_rotation(util):
     """See https://github.com/Zulko/moviepy/pull/577"""
-    clip = VideoFileClip("media/rotated-90-degrees.mp4").subclip(0.2, 0.4)
+    clip = VideoFileClip("media/rotated-270-degrees.mp4").subclip(0.2, 0.4)
 
     corrected_rotation_filename = os.path.join(
         util.TMP_DIR,


### PR DESCRIPTION
Newer ffmpeg versions no longer provide `rotate` field in `Metadata` section. So I changed the parsing to get this value from `Side data`'s `displaymatrix` field. But that angle value is in opposite direction, however it's in-line with ffmpegs rotation. I.e. if we rotate video using ffmpeg with `rotate="90"`, old value would show `270`, while new value shows `90`. So it's potentially a breaking change (but IMO for the better). Also, I think this new value is in range `-180:180`, instead of `0:360`, not sure if that could cause other problems.
Older ffmpeg versions (4.4) do provide `displaymatrix` field as well, so this code works for both older and newer versions.

I renamed the test file and changed the test value, instead of changing the file contents, to avoid increasing repo size.
