### PR TITLE
Fix #1895 printing `File Not Found` on Windows

### DIFF
--- a/moviepy/config.py
+++ b/moviepy/config.py
@@ -38,6 +38,37 @@ def try_cmd(cmd):
         return True, None
 
 
+def detect_imagemagick_for_windows():
+    """Detects imagemagick binary for Windows."""
+
+    # Try a few different ways of finding the ImageMagick binary on Windows
+    try:
+        key = wr.OpenKey(wr.HKEY_LOCAL_MACHINE, r"SOFTWARE\ImageMagick\Current")
+        result = wr.QueryValueEx(key, "BinPath")[0] + r"\magick.exe"
+        key.Close()
+        return result
+    except Exception:
+        pass
+
+    imagemagick_dir = [
+        d for d in Path(r"C:\Program Files").iterdir()
+        if d.name.startswith("ImageMagick-")
+    ]
+
+    if not imagemagick_dir:
+        return "unset"
+
+    # No matter how many versions the user installed, we use the first, because
+    # IMAGEMAGICK_BINARY can be specified through environmental variable.
+    imagemagick_dir = imagemagick_dir[0]
+    for imagemagick_filename in ["convert.exe", "magick.exe"]:
+        p = imagemagick_dir / imagemagick_filename
+        if p.exists():
+            return str(p)
+
+    return "unset"
+
+
 if FFMPEG_BINARY == "ffmpeg-imageio":
     from imageio.plugins.ffmpeg import get_exe
 
@@ -60,28 +91,7 @@ else:
 
 if IMAGEMAGICK_BINARY == "auto-detect":
     if os.name == "nt":
-        # Try a few different ways of finding the ImageMagick binary on Windows
-        try:
-            key = wr.OpenKey(wr.HKEY_LOCAL_MACHINE, "SOFTWARE\\ImageMagick\\Current")
-            IMAGEMAGICK_BINARY = wr.QueryValueEx(key, "BinPath")[0] + r"\magick.exe"
-            key.Close()
-        except Exception:
-            for imagemagick_filename in ["convert.exe", "magick.exe"]:
-                try:
-                    imagemagick_path = sp.check_output(
-                        r'dir /B /O-N "C:\\Program Files\\ImageMagick-*"',
-                        shell=True,
-                        encoding="utf-8",
-                    ).split("\n")[0]
-                    IMAGEMAGICK_BINARY = sp.check_output(  # pragma: no cover
-                        rf'dir /B /S "C:\Program Files\{imagemagick_path}\\'
-                        f'*{imagemagick_filename}"',
-                        shell=True,
-                        encoding="utf-8",
-                    ).split("\n")[0]
-                    break
-                except Exception:
-                    IMAGEMAGICK_BINARY = "unset"
+        IMAGEMAGICK_BINARY = detect_imagemagick_for_windows()  # pragma: no cover
 
     if IMAGEMAGICK_BINARY in ["unset", "auto-detect"]:
         if try_cmd(["convert"])[0]:

--- a/moviepy/config.py
+++ b/moviepy/config.py
@@ -40,17 +40,16 @@ def try_cmd(cmd):
 
 def detect_imagemagick_for_windows():
     """Detects imagemagick binary for Windows."""
-
-    # Find the directory from registry, otherwise
-    # use C:\Program Files\ImageMagick-xxx directly.
     try:
-        # When is key does not exist, it will raise OSError.
+        # When the key does not exist, it will raise OSError.
         key = wr.OpenKey(wr.HKEY_LOCAL_MACHINE, r"SOFTWARE\ImageMagick\Current")
         imagemagick_dir = Path(wr.QueryValueEx(key, "BinPath")[0])
         key.Close()
     except OSError:
+        # Find it under C:\Program Files\ImageMagick-xxx directory.
         imagemagick_dirs = [
-            d for d in Path(r"C:\Program Files").iterdir()
+            d
+            for d in Path(r"C:\Program Files").iterdir()
             if d.name.startswith("ImageMagick-")
         ]
         if not imagemagick_dirs:
@@ -77,7 +76,6 @@ if FFMPEG_BINARY == "ffmpeg-imageio":
     FFMPEG_BINARY = get_exe()
 
 elif FFMPEG_BINARY == "auto-detect":
-
     if try_cmd(["ffmpeg"])[0]:
         FFMPEG_BINARY = "ffmpeg"
     elif not IS_POSIX_OS and try_cmd(["ffmpeg.exe"])[0]:


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it

Fix #1895.

Stop using system commands and use `pathlib` to find the ImageMagick binary under `C:\Program Files\ImageMagick-*` instead.