### PR TITLE
Use audio_codec option even if audio is given as filename

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -376,6 +376,7 @@ class VideoClip(Clip):
                 write_logfile=write_logfile,
                 logger=logger,
             )
+            audio_codec = "copy"
 
         ffmpeg_write_video(
             self,
@@ -386,6 +387,7 @@ class VideoClip(Clip):
             preset=preset,
             write_logfile=write_logfile,
             audiofile=audiofile,
+            audio_codec=audio_codec,
             threads=threads,
             ffmpeg_params=ffmpeg_params,
             logger=logger,

--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -44,6 +44,9 @@ class FFMPEG_VideoWriter:
     audiofile : str, optional
       The name of an audio file that will be incorporated to the video.
 
+    audio_codec : str, optional
+      FFMPEG audio codec.
+
     preset : str, optional
       Sets the time that FFMPEG will take to compress the video. The slower,
       the better the compression rate. Possibilities are: ``"ultrafast"``,
@@ -119,7 +122,9 @@ class FFMPEG_VideoWriter:
             "-",
         ]
         if audiofile is not None:
-            cmd.extend(["-i", audiofile, "-acodec", "copy"])
+            if audio_codec is None:
+                audio_codec = "copy"
+            cmd.extend(["-i", audiofile, "-acodec", audio_codec])
         cmd.extend(["-vcodec", codec, "-preset", preset])
         if ffmpeg_params is not None:
             cmd.extend(ffmpeg_params)
@@ -226,6 +231,7 @@ def ffmpeg_write_video(
     with_mask=False,
     write_logfile=False,
     audiofile=None,
+    audio_codec=None,
     threads=None,
     ffmpeg_params=None,
     logger="bar",
@@ -252,6 +258,7 @@ def ffmpeg_write_video(
         bitrate=bitrate,
         logfile=logfile,
         audiofile=audiofile,
+        audio_codec=audio_codec,
         threads=threads,
         ffmpeg_params=ffmpeg_params,
         pixel_format=pixel_format,


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it

`moviepy.video.VideoClip.write_videofile` ignores `audio_codec` when `audio` is a file name. I have fixed it in this PR.
