### PR TITLE
Fix GitHub workflow badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ MoviePy
 .. image:: https://img.shields.io/gitter/room/movie-py/gitter?color=46BC99&logo=gitter
     :target: Gitter_
     :alt: Discuss MoviePy on Gitter
-.. image:: https://img.shields.io/github/workflow/status/Zulko/moviepy/Run%20Test%20Suite?logo=github
-    :target: https://github.com/Zulko/moviepy/actions?query=workflow%3A%22Run+Test+Suite%22
+.. image:: https://img.shields.io/github/actions/workflow/status/Zulko/moviepy/test_suite.yml?logo=github
+    :target: https://github.com/Zulko/moviepy/actions/workflows/test_suite.yml
     :alt: Build status on gh-actions
 .. image:: https://img.shields.io/coveralls/github/Zulko/moviepy/master?logo=coveralls
     :target: https://coveralls.io/github/Zulko/moviepy?branch=master


### PR DESCRIPTION
The build badge is currently broken:

![Screenshot 2023-02-05 at 17 48 55](https://user-images.githubusercontent.com/20516159/216836229-7c2c0645-2962-426f-819d-60a8fede68e8.png)

This PR fixes it, so it looks like:

![Screenshot 2023-02-05 at 17 49 34](https://user-images.githubusercontent.com/20516159/216836265-654fbc9b-ebcf-4a04-ad17-451c925e4c32.png)


In summary, this badge was changed in a breaking fashion such that the badge was just linking to the github issue rather than showing the data. Updating the url resolves this.

See the linked GitHub issue from the previous version of the badge for further details: badges/shields#8671

I also updated the link for the badge, so it matches the behaviour of the badge more closely (matching on the workflow file, rather than the name).

I don't think any of the PR template check boxes applies, since this is a doc-only change - but hopefully the screenshots above are evidence of the 'fix'.
