### PR TITLE
Adding default behaviour for clips array when input shape isn't adequate

### DIFF
--- a/moviepy/video/compositing/CompositeVideoClip.py
+++ b/moviepy/video/compositing/CompositeVideoClip.py
@@ -154,7 +154,7 @@ def fix_clips_shape(clips, background_color, ismask = False):
     In other words, this function places a placeholder clip where there are missing collums
 
     clip_array
-        Array of clips to be mutated
+        Array of clips to be processed
 
     background_color
         The color placeholder clips are given

--- a/moviepy/video/compositing/CompositeVideoClip.py
+++ b/moviepy/video/compositing/CompositeVideoClip.py
@@ -168,7 +168,7 @@ def fix_clips_shape(clips, background_color, ismask = False):
     if background_color is None: background_color = 0.0 if ismask else (0, 0, 0) #same as CompositeVideoClip
     placeholder_clip = ColorClip((0, 0), background_color, duration = minimum_time_spent)
 
-    for i in range(len(clips)):
+    for i in range(len(clips)): # for each row, we will check if there are enough clips
         current_row = list(clips[i])
         for j in range(maximum_row_length - len(clips[i])): # adding however many collums are missing
             current_row.append(placeholder_clip)
@@ -204,8 +204,8 @@ def clips_array(array, rows_widths=None, cols_heights=None, bg_color=None):
     ```
 
     If some clips doesn't fulfill the space required by the rows or columns
-    in which are placed, that space will be filled by the color defined in
-    ``bg_color``.
+    in which are placed, or no clips are given for an expected tile,
+    that space will be filled by the color defined in ``bg_color``.
 
     array
       Matrix of clips included in the returned composited video clip.


### PR DESCRIPTION
**This PR Includes:**
- Implemented changes for clips_array default behaviour. Previously when a non-rectangular array was passed in ( ex: [ [1, 2], [3] ] ), it would throw an error. Now, the remaining space is just filled with the background color as default behaviour instead

**Checklist:**
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [X] I have properly documented new or changed features in the documentation or in the docstrings
- [X] I have properly explained unusual or unexpected code in the comments around it
