### PR TITLE
Added code to raise exception with string

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1149,6 +1149,10 @@ class ColorClip(ImageClip):
                 color = (0, 0, 0)
             elif not hasattr(color, "__getitem__"):
                 raise Exception("Color has to contain RGB of the clip")
+            elif isinstance(color, str):
+                raise Exception(
+                    "Color cannot be string. Color has to contain RGB of the clip"
+                )
             shape = (h, w, len(color))
 
         super().__init__(

--- a/tests/test_VideoClip.py
+++ b/tests/test_VideoClip.py
@@ -264,7 +264,10 @@ def test_oncolor(util):
         clip = ColorClip(size=(100, 60), color=(255, 0, 0), is_mask=True)
 
     with pytest.raises(Exception):
-        clip = ColorClip(size=(100, 60), color=0.4, is_mask=False)
+        clip = ColorClip(size=(100, 60), color=0.4, ismask=False)
+
+    with pytest.raises(Exception):
+        clip = ColorClip(size=(100, 60), color="black")
 
 
 def test_setaudio(util):


### PR DESCRIPTION
I added two lines to VideoClip.py that raises an exception if a user passes in a string as the color parameter. This is in reaction to this [Bug](https://github.com/Zulko/moviepy/issues/1920). The problem the original user faced was that it raised a ValueError. The user inputted 'black' as the color in ColorClip, which is not an acceptable parameter for the function. Instead, I just created some code that checks if color is a string, and raises an exception that mentions the wrong user input. In the future, a user should hopefully realize quicker that they passed in incorrect input with the Exception message, instead of not knowing why a ValueError was thrown later on. 

To test_color() in test_VideoClip.py, I added a test that attempts to create a Clip with color = 'black'. The test passes, since an exception should be thrown when color is passed in as a string.

I also checked for PEP8 conventions in both files, and none of the code I added resulted in a style complaint. 

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
