### PR TITLE
Fixed typo in audioclips.rst

### DIFF
--- a/docs/getting_started/audioclips.rst
+++ b/docs/getting_started/audioclips.rst
@@ -5,7 +5,7 @@ Audio in MoviePy
 
 This section shows how to use MoviePy to create and edit audio clips.
 
-Note that when you cut, mix or concatenate video clips in MoviePy the audio is automatically handled and you need to worry about it. This section is of interest if you just want to edit audiofiles or you want custom audio clips for your videos.
+Note that when you cut, mix or concatenate video clips in MoviePy the audio is automatically handled and you don't need to worry about it. This section is of interest if you just want to edit audiofiles or you want custom audio clips for your videos.
 
 What audioclips are made of
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/getting_started/effects.rst
+++ b/docs/getting_started/effects.rst
@@ -7,7 +7,7 @@ There are several categories of clip modifications in MoviePy:
 
 - The very common methods to change the attributes of a clip: ``clip.with_duration``, ``clip.with_audio``, ``clip.with_mask``, ``clip.with_start`` etc.
 - The already-implemented effects. Core effects like ``clip.subclip(t1, t2)`` (keep only the cut between t1 and t2), which are very important, are implemented as class methods. More advanced and less common effects like ``loop`` (makes the clip play in a loop) or ``time_mirror`` (makes the clip play backwards) are placed in the special modules ``moviepy.video.fx`` and ``moviepy.audio.fx`` and are applied with the ``clip.fx`` method, for instance ``clip.fx(time_mirror)`` (makes the clip play backwards), ``clip.fx(black_white)`` (turns the clip black and white), etc.
-- The effects that you can create yourself. using 
+- The effects that you can create yourself using  ``clip.fl``.
 
 All these effects have in common that they are **not inplace**: they do NOT modify the original clip, instead they create a new clip that is a version of the former with the changes applied. For instance: ::
 


### PR DESCRIPTION
Fixed typo in audioclips.rst

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
