### PR TITLE
Use imageio.v3 when import imread

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -11,7 +11,7 @@ import tempfile
 
 import numpy as np
 import proglog
-from imageio import imread, imsave
+from imageio.v3 import imread, imsave
 from PIL import Image
 
 from moviepy.Clip import Clip

--- a/moviepy/video/io/ImageSequenceClip.py
+++ b/moviepy/video/io/ImageSequenceClip.py
@@ -5,7 +5,7 @@ of image files.
 import os
 
 import numpy as np
-from imageio import imread
+from imageio.v3 import imread
 
 from moviepy.video.VideoClip import VideoClip
 


### PR DESCRIPTION
Using `imageio.v3` instead of `imageio` when import `imread` from `imageio`, which has the advantage that `imageio.v3.imread` support more image format than `imageio.imread` such as `.webp`.
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
