### PR TITLE
Use imageio.v3 when read or write images

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -11,7 +11,7 @@ import tempfile
 
 import numpy as np
 import proglog
-from imageio.v3 import imread, imwrite
+import imageio.v3 as iio
 from PIL import Image
 
 from moviepy.Clip import Clip
@@ -190,7 +190,7 @@ class VideoClip(Clip):
         else:
             im = im.astype("uint8")
 
-        imwrite(filename, im)
+        iio.imwrite(filename, im)
 
     @requires_duration
     @use_clip_fps_by_default
@@ -1040,7 +1040,7 @@ class ImageClip(VideoClip):
 
         if not isinstance(img, np.ndarray):
             # img is a string or path-like object, so read it in from disk
-            img = imread(img, index=0)
+            img = iio.imread(img, index=0)
 
         if len(img.shape) == 3:  # img is (now) a RGB(a) numpy array
             if img.shape[2] == 4:

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1040,7 +1040,7 @@ class ImageClip(VideoClip):
 
         if not isinstance(img, np.ndarray):
             # img is a string or path-like object, so read it in from disk
-            img = imread(img)
+            img = imread(img, index=0)
 
         if len(img.shape) == 3:  # img is (now) a RGB(a) numpy array
             if img.shape[2] == 4:

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -11,7 +11,7 @@ import tempfile
 
 import numpy as np
 import proglog
-from imageio import imread, imsave
+from imageio.v3 import imread, imwrite
 from PIL import Image
 
 from moviepy.Clip import Clip
@@ -190,7 +190,7 @@ class VideoClip(Clip):
         else:
             im = im.astype("uint8")
 
-        imsave(filename, im)
+        imwrite(filename, im)
 
     @requires_duration
     @use_clip_fps_by_default

--- a/moviepy/video/io/ImageSequenceClip.py
+++ b/moviepy/video/io/ImageSequenceClip.py
@@ -5,7 +5,7 @@ of image files.
 import os
 
 import numpy as np
-from imageio import imread
+from imageio.v3 import imread
 
 from moviepy.video.VideoClip import VideoClip
 

--- a/moviepy/video/io/ImageSequenceClip.py
+++ b/moviepy/video/io/ImageSequenceClip.py
@@ -5,7 +5,7 @@ of image files.
 import os
 
 import numpy as np
-from imageio.v3 import imread
+import imageio.v3 as iio
 
 from moviepy.video.VideoClip import VideoClip
 
@@ -62,7 +62,7 @@ class ImageSequenceClip(VideoClip):
         if isinstance(sequence, list):
             if isinstance(sequence[0], str):
                 if load_images:
-                    sequence = [imread(file, index=0) for file in sequence]
+                    sequence = [iio.imread(file, index=0) for file in sequence]
                     fromfiles = False
                 else:
                     fromfiles = True
@@ -78,14 +78,14 @@ class ImageSequenceClip(VideoClip):
 
         # check that all the images are of the same size
         if isinstance(sequence[0], str):
-            size = imread(sequence[0], index=0).shape
+            size = iio.imread(sequence[0], index=0).shape
         else:
             size = sequence[0].shape
 
         for image in sequence:
             image1 = image
             if isinstance(image, str):
-                image1 = imread(image, index=0)
+                image1 = iio.imread(image, index=0)
             if size != image1.shape:
                 raise Exception(
                     "MoviePy: ImageSequenceClip requires all images to be the same size"
@@ -117,12 +117,12 @@ class ImageSequenceClip(VideoClip):
                 index = find_image_index(t)
 
                 if index != self.last_index:
-                    self.last_image = imread(self.sequence[index], index=0)[:, :, :3]
+                    self.last_image = iio.imread(self.sequence[index], index=0)[:, :, :3]
                     self.last_index = index
 
                 return self.last_image
 
-            if with_mask and (imread(self.sequence[0], index=0).shape[2] == 4):
+            if with_mask and (iio.imread(self.sequence[0], index=0).shape[2] == 4):
                 self.mask = VideoClip(is_mask=True)
                 self.mask.last_index = None
                 self.mask.last_image = None
@@ -130,7 +130,7 @@ class ImageSequenceClip(VideoClip):
                 def mask_make_frame(t):
                     index = find_image_index(t)
                     if index != self.mask.last_index:
-                        frame = imread(self.sequence[index], index=0)[:, :, 3]
+                        frame = iio.imread(self.sequence[index], index=0)[:, :, 3]
                         self.mask.last_image = frame.astype(float) / 255
                         self.mask.last_index = index
 

--- a/moviepy/video/io/ImageSequenceClip.py
+++ b/moviepy/video/io/ImageSequenceClip.py
@@ -62,7 +62,7 @@ class ImageSequenceClip(VideoClip):
         if isinstance(sequence, list):
             if isinstance(sequence[0], str):
                 if load_images:
-                    sequence = [imread(file) for file in sequence]
+                    sequence = [imread(file, index=0) for file in sequence]
                     fromfiles = False
                 else:
                     fromfiles = True
@@ -78,14 +78,14 @@ class ImageSequenceClip(VideoClip):
 
         # check that all the images are of the same size
         if isinstance(sequence[0], str):
-            size = imread(sequence[0]).shape
+            size = imread(sequence[0], index=0).shape
         else:
             size = sequence[0].shape
 
         for image in sequence:
             image1 = image
             if isinstance(image, str):
-                image1 = imread(image)
+                image1 = imread(image, index=0)
             if size != image1.shape:
                 raise Exception(
                     "MoviePy: ImageSequenceClip requires all images to be the same size"
@@ -117,12 +117,12 @@ class ImageSequenceClip(VideoClip):
                 index = find_image_index(t)
 
                 if index != self.last_index:
-                    self.last_image = imread(self.sequence[index])[:, :, :3]
+                    self.last_image = imread(self.sequence[index], index=0)[:, :, :3]
                     self.last_index = index
 
                 return self.last_image
 
-            if with_mask and (imread(self.sequence[0]).shape[2] == 4):
+            if with_mask and (imread(self.sequence[0], index=0).shape[2] == 4):
                 self.mask = VideoClip(is_mask=True)
                 self.mask.last_index = None
                 self.mask.last_image = None
@@ -130,7 +130,7 @@ class ImageSequenceClip(VideoClip):
                 def mask_make_frame(t):
                     index = find_image_index(t)
                     if index != self.mask.last_index:
-                        frame = imread(self.sequence[index])[:, :, 3]
+                        frame = imread(self.sequence[index], index=0)[:, :, 3]
                         self.mask.last_image = frame.astype(float) / 255
                         self.mask.last_index = index
 


### PR DESCRIPTION
Using `imageio.v3` instead of `imageio` when read or write images, which has the advantage that `imageio.v3` support more image format than `imageio` such as `.webp`.

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
cumented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it


Fix #1894