### PR TITLE
Fix the issue caused by deprecation of `ANTIALIAS` in Pillow version 10.0.0

### DIFF
--- a/moviepy/video/fx/resize.py
+++ b/moviepy/video/fx/resize.py
@@ -37,7 +37,7 @@ def _get_PIL_resizer():
         #     newshape = (new_size[0], new_size[1])
 
         pil_img = Image.fromarray(pic)
-        resized_pil = pil_img.resize(new_size[::-1], Image.ANTIALIAS)
+        resized_pil = pil_img.resize(new_size[::-1], Image.LANCZOS)
         # arr = np.fromstring(resized_pil.tostring(), dtype="uint8")
         # arr.reshape(newshape)
         return np.array(resized_pil)


### PR DESCRIPTION
Fixed Issue #2002.

Reference:
https://stackoverflow.com/a/76616129/4522678

I removed checkboxes because I supposed non of them were applicable.

(Thank you for making this amazing library in open source!😃)