### PR TITLE
Fix version parsing in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ if "build_docs" in sys.argv:
 
     cmdclass["build_docs"] = BuildDoc
 
-__version__ = Path("moviepy/version.py").read_text().strip().split('"')[1][:-1]
+__version__ = Path("moviepy/version.py").read_text().strip().split('"')[1]
 
 
 # Define the requirements for specific execution needs.


### PR DESCRIPTION
The last character of the version is cut out by `[:-1]` in `Path("moviepy/version.py").read_text().strip().split('"')[1][:-1]`.
Eg: `2.0.0.dev2` become `2.0.0.dev`, which Python build reads as `2.0.0.dev0`.

In fact `Path("moviepy/version.py").read_text().strip().split('"')` gives `['__version__ = ', '2.0.0.dev2', '']` so removing the last character isn't needed.
