### PR TITLE
fix: `Image.putalpha` does not return any value

### DIFF
--- a/moviepy/video/compositing/CompositeVideoClip.py
+++ b/moviepy/video/compositing/CompositeVideoClip.py
@@ -122,7 +122,7 @@ class CompositeVideoClip(VideoClip):
         if self.bg.mask is not None:
             frame_mask = self.bg.mask.get_frame(t)
             im_mask = Image.fromarray(255 * frame_mask).convert("L")
-            im = im.putalpha(im_mask)
+            im.putalpha(im_mask)
 
         for clip in self.playing_clips(t):
             im = clip.blit_on(im, t)


### PR DESCRIPTION
`Image.putalpha` changes the origin object, and does not return a new object.
