### PR TITLE
Fix deprecated PIL resizing

### DIFF
--- a/moviepy/video/fx/resize.py
+++ b/moviepy/video/fx/resize.py
@@ -37,7 +37,7 @@ def _get_PIL_resizer():
         #     newshape = (new_size[0], new_size[1])
 
         pil_img = Image.fromarray(pic)
-        resized_pil = pil_img.resize(new_size[::-1], Image.LANCZOS)
+        resized_pil = pil_img.resize(new_size[::-1], Image.Resampling.LANCZOS)
         # arr = np.fromstring(resized_pil.tostring(), dtype="uint8")
         # arr.reshape(newshape)
         return np.array(resized_pil)


### PR DESCRIPTION
Image.ANTIALIAS is deprecated.
Replacing with the suggested replacement Image.Resampling.LANCZOS

see https://github.com/mpetroff/pannellum/issues/1119

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
