### PR TITLE
Fix resize func for https://github.com/Zulko/moviepy/issues/2049

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,18 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.12.1
     hooks:
       - id: black
-        language_version: python3.6
         files: \.py$
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
         args:
           - '--filter-files'
         files: \.py$
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.0.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -43,13 +43,16 @@ class FFMPEG_VideoReader:
         if self.rotation in [90, 270]:
             self.size = [self.size[1], self.size[0]]
 
-        if target_resolution:
+        if target_resolution and target_resolution != (None, None):
             if None in target_resolution:
-                ratio = 1
-                for idx, target in enumerate(target_resolution):
-                    if target:
-                        ratio = target / self.size[idx]
-                self.size = (int(self.size[0] * ratio), int(self.size[1] * ratio))
+                first, second = target_resolution
+                if first:
+                    ratio = first / self.size[0]
+                    second = int(self.size[1] * ratio)
+                else:
+                    ratio = second / self.size[1]
+                    first = int(self.size[0] * ratio)
+                self.size = (first, second)
             else:
                 self.size = target_resolution
         self.resize_algo = resize_algo

--- a/tests/test_ffmpeg_reader.py
+++ b/tests/test_ffmpeg_reader.py
@@ -290,6 +290,22 @@ def test_ffmpeg_parse_video_rotation():
     assert d["video_size"] == [1920, 1080]
 
 
+@pytest.mark.parametrize(
+    "target_resolution,expected_size",
+    [
+        (None, (314, 273)),
+        ((100, None), (100, 86)),
+        ((None, 100), (115, 100)),
+        ((None, None), (314, 273)),
+    ],
+)
+def test_video_target_resolution(target_resolution, expected_size):
+    clip = VideoFileClip(
+        "media/pigs_in_a_polka.gif", target_resolution=target_resolution
+    )
+    assert clip.size == expected_size
+
+
 def test_correct_video_rotation(util):
     """See https://github.com/Zulko/moviepy/pull/577"""
     clip = VideoFileClip("media/rotated-90-degrees.mp4").subclip(0.2, 0.4)


### PR DESCRIPTION
Fixes https://github.com/Zulko/moviepy/issues/2049

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`

Sorry - I couldn't get precommit to work without the first commit in my PR, feel free to drop that if you choose to merge.

From issue:
> I added a little change to fix but it raises a few questions on how should we cater to this case.

> Should we:
1. leave as is - because if you want a specific resolution, you should specify it completely.
2. use the target dimension as specified, calculate the _other_. and/or
3. use proper rounding functions? perhaps use `ceil` or at the very least round even? 

> One could argue that if a result comes to " 12.2 pixels" (or in the example case 223.9999) then it should be `ceil`'d so that we have a pixel to cover that extra little bit that should be there.

> But on the whole, I would expect that if i said "I want target height to be 100" it should come out as 100.

