### PR TITLE
Fix GPU h264_nvenc encoding not working.

### DIFF
--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -120,7 +120,14 @@ class FFMPEG_VideoWriter:
         ]
         if audiofile is not None:
             cmd.extend(["-i", audiofile, "-acodec", "copy"])
-        cmd.extend(["-vcodec", codec, "-preset", preset])
+
+        if (codec == "h264_nvenc") :
+            cmd.extend(["-c:v", codec])
+        else :
+            cmd.extend(["-vcodec", codec])
+
+        cmd.extend(["-preset", preset])
+
         if ffmpeg_params is not None:
             cmd.extend(ffmpeg_params)
         if bitrate is not None:
@@ -129,8 +136,9 @@ class FFMPEG_VideoWriter:
         if threads is not None:
             cmd.extend(["-threads", str(threads)])
 
-        if (codec == "libx264") and (size[0] % 2 == 0) and (size[1] % 2 == 0):
+        if (codec == "libx264" or codec == "h264_nvenc") and (size[0] % 2 == 0) and (size[1] % 2 == 0):
             cmd.extend(["-pix_fmt", "yuv420p"])
+
         cmd.extend([filename])
 
         popen_params = cross_platform_popen_params(


### PR DESCRIPTION
```
git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
cd nv-codec-headers
make
sudo make install

git clone https://github.com/FFmpeg/FFmpeg.git
./configure --prefix=/usr/local/ffmpeg --enable-shared --disable-static --disable-doc  --enable-gpl --enable-libx264 --enable-cuda --enable-cuvid
make
sudo make install

ffmpeg -decoders | grep cuvid

# Transcoding h264 video with GPU
ffmpeg -hwaccel cuvid -c:v h264_cuvid -i test.mp4 -c:v h264_nvenc  -y test-gpu.mp4

# Transcoding using CPU decoding and GPU encoding.
ffmpeg -i test.mp4 -c:v h264_nvenc -y test-gpu.mp4
```

Reference: https://trac.ffmpeg.org/wiki/HWAccelIntro#NVENC