### PR TITLE
Fix Writing Transparent Video Files

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -218,6 +218,7 @@ class VideoClip(Clip):
         ffmpeg_params=None,
         logger="bar",
         pixel_format=None,
+        with_mask=False,
     ):
         """Write the clip to a videofile.
 
@@ -314,6 +315,9 @@ class VideoClip(Clip):
         pixel_format
           Pixel format for the output video file.
 
+        with_mask
+          Set to ``True`` if there is a mask in the video to be encoded.
+
         Examples
         --------
 
@@ -390,6 +394,7 @@ class VideoClip(Clip):
             ffmpeg_params=ffmpeg_params,
             logger=logger,
             pixel_format=pixel_format,
+            with_mask=with_mask
         )
 
         if remove_temp and make_audio:

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -218,7 +218,6 @@ class VideoClip(Clip):
         ffmpeg_params=None,
         logger="bar",
         pixel_format=None,
-        with_mask=False,
     ):
         """Write the clip to a videofile.
 
@@ -314,9 +313,7 @@ class VideoClip(Clip):
 
         pixel_format
           Pixel format for the output video file.
-
-        with_mask
-          Set to ``True`` if there is a mask in the video to be encoded.
+          Defaults to rgb24. rgba can be used to output transparent files
 
         Examples
         --------
@@ -394,7 +391,6 @@ class VideoClip(Clip):
             ffmpeg_params=ffmpeg_params,
             logger=logger,
             pixel_format=pixel_format,
-            with_mask=with_mask
         )
 
         if remove_temp and make_audio:

--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -226,7 +226,7 @@ def ffmpeg_write_video(
     threads=None,
     ffmpeg_params=None,
     logger="bar",
-    pixel_format=None,
+    pixel_format="rgb24",
 ):
     """Write the clip to a videofile. See VideoClip.write_videofile for details
     on the parameters.
@@ -238,8 +238,6 @@ def ffmpeg_write_video(
     else:
         logfile = None
     logger(message="MoviePy - Writing video %s\n" % filename)
-    if not pixel_format:
-        pixel_format = "rgb24"
     with FFMPEG_VideoWriter(
         filename,
         clip.size,

--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -221,7 +221,6 @@ def ffmpeg_write_video(
     codec="libx264",
     bitrate=None,
     preset="medium",
-    with_mask=False,
     write_logfile=False,
     audiofile=None,
     threads=None,
@@ -240,7 +239,7 @@ def ffmpeg_write_video(
         logfile = None
     logger(message="MoviePy - Writing video %s\n" % filename)
     if not pixel_format:
-        pixel_format = "rgba" if with_mask else "rgb24"
+        pixel_format = "rgb24"
     with FFMPEG_VideoWriter(
         filename,
         clip.size,


### PR DESCRIPTION
This will allow for clips that are loaded with an alpha channel (a .mov file for example) to be writen back out as a .mov file with an alpha layer (transparent background). The code already largely exists for this, the write_videofile function simply needs to be allowed to pass the with_mask arg to the ffmpeg_write_video, which then handles the rest.

For example:
```python
transparentclip = VideoFileClip("1.mov", has_mask=True)
transparentclip.write_videofile("test.mov", codec="png", fps=30, with_mask=True)
```
Longer example:
```python
transparentclip = VideoFileClip("1.mov", has_mask=True)
transparentclip.write_videofile("test.mov", codec="png", fps=30, with_mask=True)

background = VideoFileClip("background.mp4")
overlay = VideoFileClip("test.mov", has_mask=True)
comp = CompositeVideoClip([background, overlay])
comp.write_videofile("final.mp4", fps=30, codec="libx264")
```
Even longer
```python
# Where 1.mov and 2.mov both have an alpha channel
clips = [VideoFileClip("1.mov", has_mask=True), VideoFileClip("2.mov", has_mask=True)]
concat = concatenate_videoclips(clips, method="chain")
concat.write_videofile("test.mov", codec="png", fps=30, with_mask=True)
background = VideoFileClip("background.mp4")
overlay = VideoFileClip("test.mov", has_mask=True)
comp = CompositeVideoClip([background, overlay])
comp.write_videofile("final.mp4", fps=30, codec="libx264")
```


<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have properly documented new or changed features in the documentation or in the docstrings
