### PR TITLE
Passing duration as milliseconds instead of seconds in write_gif_with_image_io. Fixes #2151.

### DIFF
--- a/moviepy/video/io/gif_writers.py
+++ b/moviepy/video/io/gif_writers.py
@@ -439,7 +439,11 @@ def write_gif_with_image_io(
     quantizer = 0 if opt != 0 else "nq"
 
     writer = imageio.save(
-        filename, duration=1.0 / fps, quantizer=quantizer, palettesize=colors, loop=loop
+        filename,
+        duration=1000.0 / fps,
+        quantizer=quantizer,
+        palettesize=colors,
+        loop=loop,
     )
     logger(message="MoviePy - Building file %s with imageio." % filename)
 


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
