### PR TITLE
Update VideoClip.py

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -362,6 +362,9 @@ class VideoClip(Clip):
                 name + Clip._TEMP_FILES_PREFIX + "wvf_snd.%s" % audio_ext,
             )
 
+        if fps is None:
+            fps = fps.self
+
         # enough cpu for multiprocessing ? USELESS RIGHT NOW, WILL COME AGAIN
         # enough_cpu = (multiprocessing.cpu_count() > 1)
         logger(message="MoviePy - Building video %s." % filename)
@@ -398,7 +401,6 @@ class VideoClip(Clip):
         logger(message="MoviePy - video ready %s" % filename)
 
     @requires_duration
-    @use_clip_fps_by_default
     @convert_masks_to_RGB
     def write_images_sequence(
         self, name_format, fps=None, with_mask=True, logger="bar"


### PR DESCRIPTION
Fixes bug where fps=None due to changes in python decorators
The bug arises when write_video is used. The ffmpeg's write operation fails due to fps=None. 
- [-] I have properly explained unusual or unexpected code in the comments around it
