### PR TITLE
Fix: change the unit of duration in func `write_gif_with_image_io`

### DIFF
--- a/moviepy/video/io/gif_writers.py
+++ b/moviepy/video/io/gif_writers.py
@@ -439,7 +439,7 @@ def write_gif_with_image_io(
     quantizer = 0 if opt != 0 else "nq"
 
     writer = imageio.save(
-        filename, duration=1.0 / fps, quantizer=quantizer, palettesize=colors, loop=loop
+        filename, duration=1000 * 1 / fps, quantizer=quantizer, palettesize=colors, loop=loop
     )
     logger(message="MoviePy - Building file %s with imageio." % filename)
 


### PR DESCRIPTION
Please refer to the issue https://github.com/Zulko/moviepy/issues/2170.