### PR TITLE
ci(workflows): upgrade actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,9 +1,4 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-name: "CodeQL"
+name: Code scanning with CodeQL
 
 on:
   push:
@@ -18,7 +13,6 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     name: Black
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.6
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.1.0
       - name: Black
-        uses: psf/black@22.3.0  # already includes args "--check --diff"
+        uses: psf/black@24.4.2  # already includes args "--check --diff"
   flake8:
     runs-on: ubuntu-latest
     name: Flake8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.6
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: '3.9'
       - name: Install dependencies
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     name: isort
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.6
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: '3.9'
       - name: Install dependencies

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -1,5 +1,7 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# This workflow installs Python dependencies, runs tests and lints
+# using a variety of Python versions.
+# For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Run Test Suite
 
@@ -10,7 +12,7 @@ on:
   pull_request:
 
 jobs:
-  # Uses Python Framework build because on macos matplotlib requires it
+  # Uses Python Framework build because on macOS, Matplotlib requires it
   macos:
     runs-on: macos-latest
     strategy:
@@ -21,8 +23,10 @@ jobs:
     - uses: s-weigand/setup-conda@v1.2.2
       with:
         activate-conda: true
+
     - name: Install pythonw
       run: conda install python.app
+
     - name: Python Version Info
       run: |
         pythonw --version
@@ -30,6 +34,7 @@ jobs:
         pythonw -m site --user-site
         echo $PYTHONPATH
         echo $PYTHONHOME
+
     - name: Install dependencies
       run: |
         brew install imagemagick
@@ -122,6 +127,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4.1.6
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5.1.0
         with:

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
-    - uses: s-weigand/setup-conda@v1
+    - uses: actions/checkout@v4.1.6
+    - uses: s-weigand/setup-conda@v1.2.2
       with:
         activate-conda: true
     - name: Install pythonw
@@ -56,15 +56,15 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Get ImageMagick installer from cache
         id: imagemagick-installer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.0.2
         with:
           path: |
             ImageMagick.exe
@@ -121,9 +121,9 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Upgrade outdated (v3, Node 16) GitHub actions used in workflows to latest versions, which use Node 20.

Closes: #2178
