### PR TITLE
fix: set default binary to auto-detect

### DIFF
--- a/moviepy/config.py
+++ b/moviepy/config.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     DOTENV = None
 
-FFMPEG_BINARY = os.getenv("FFMPEG_BINARY", "ffmpeg-imageio")
+FFMPEG_BINARY = os.getenv("FFMPEG_BINARY", "auto-detect")
 IMAGEMAGICK_BINARY = os.getenv("IMAGEMAGICK_BINARY", "auto-detect")
 
 IS_POSIX_OS = os.name == "posix"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -145,7 +145,7 @@ def test_download_webfile(static_files_server, util, url, expected_result):
 @pytest.mark.parametrize(
     ("ffmpeg_binary", "ffmpeg_binary_error"),
     (
-        pytest.param("ffmpeg-imageio", None, id="FFMPEG_BINARY=ffmpeg-imageio"),
+        pytest.param("auto-detect", None, id="FFMPEG_BINARY=auto-detect"),
         pytest.param("auto-detect", None, id="FFMPEG_BINARY=auto-detect"),
         pytest.param(
             "foobarbazimpossible",


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- Additional info: this PR is because issue #2189, to fix this I did set the default value of `FFMPEG_BINARY` to `auto-detect` and remade the test