### PR TITLE
replaced "be soon" with "soon be"

### DIFF
--- a/docs/examples/examples.rst
+++ b/docs/examples/examples.rst
@@ -3,7 +3,7 @@
 Example Scripts
 ===============
 
-Here are a few example scripts to get you started. Most are quite old now and will be soon replaced.
+Here are a few example scripts to get you started. Most are quite old now and will soon be replaced.
 
 
 .. toctree::


### PR DESCRIPTION
It is a minior correction on examples.rst documentation which replaceces "be soon" with "soon be". 