### PR TITLE
Fix attribute check

### DIFF
--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -230,7 +230,7 @@ class AudioClip(Clip):
 
         """
         if not fps:
-            if not self.fps:
+            if hasattr(self, "fps"):
                 fps = 44100
             else:
                 fps = self.fps


### PR DESCRIPTION
We want to check if `self` has `fps`, so `hasattr` should be used.
