### PR TITLE
Add 'decoder' Parameter to VideoFileClip and ffmpeg_reader

### DIFF
--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -52,6 +52,11 @@ class VideoFileClip(VideoClip):
       can be set to 'fps', which may be helpful if importing slow-motion videos
       that get messed up otherwise.
 
+    decoder:
+       The decoder used to decode the video file. FFmpeg's native VPx decoders 
+       don't decode alpha. You have to use the libvpx decoder. Set this to 
+       'libvpx-vp9' if you want to preserve transparency in .webm video.
+
 
     Attributes
     -----------
@@ -79,7 +84,7 @@ class VideoFileClip(VideoClip):
                  audio=True, audio_buffersize=200000,
                  target_resolution=None, resize_algorithm='bicubic',
                  audio_fps=44100, audio_nbytes=2, verbose=False,
-                 fps_source='tbr'):
+                 fps_source='tbr', decoder=None):
 
         VideoClip.__init__(self)
 
@@ -88,7 +93,8 @@ class VideoFileClip(VideoClip):
         self.reader = FFMPEG_VideoReader(filename, pix_fmt=pix_fmt,
                                          target_resolution=target_resolution,
                                          resize_algo=resize_algorithm,
-                                         fps_source=fps_source)
+                                         fps_source=fps_source,
+                                         decoder=decoder)
 
         # Make some of the reader's attributes accessible from the clip
         self.duration = self.reader.duration
@@ -99,6 +105,7 @@ class VideoFileClip(VideoClip):
         self.rotation = self.reader.rotation
 
         self.filename = self.reader.filename
+        self.decoder = self.reader.decoder
 
         if has_mask:
 

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -28,7 +28,7 @@ class FFMPEG_VideoReader:
     def __init__(self, filename, print_infos=False, bufsize = None,
                  pix_fmt="rgb24", check_duration=True,
                  target_resolution=None, resize_algo='bicubic',
-                 fps_source='tbr'):
+                 fps_source='tbr',decoder=None):
 
         self.filename = filename
         self.proc = None
@@ -51,6 +51,7 @@ class FFMPEG_VideoReader:
             else:
                 self.size = target_resolution
         self.resize_algo = resize_algo
+        self.decoder = decoder
 
         self.duration = infos['video_duration']
         self.ffmpeg_duration = infos['duration']
@@ -78,13 +79,20 @@ class FFMPEG_VideoReader:
 
         self.close() # if any
 
+        i_arg = ['-c:v', self.decoder] if self.decoder else []
+
         if starttime != 0 :
             offset = min(1, starttime)
-            i_arg = ['-ss', "%.06f" % (starttime - offset),
+            i_arg = (
+                i_arg 
+                + [
+                    '-ss', "%.06f" % (starttime - offset),
                      '-i', self.filename,
-                     '-ss', "%.06f" % offset]
+                     '-ss', "%.06f" % offset
+                ]
+            )
         else:
-            i_arg = [ '-i', self.filename]
+            i_arg = i_arg + [ '-i', self.filename]
 
         cmd = ([get_setting("FFMPEG_BINARY")] + i_arg +
                ['-loglevel', 'error',


### PR DESCRIPTION
This commit allows users to specify the decoder used to decode the video file.

Fixed bug:
- When importing a .webm video with alpha channel, transparency are not working.

Solved issue:
 - #2008  

References:
 - https://www.reddit.com/r/ffmpeg/comments/fgpyfb/help_with_webm_with_alpha_channel/

"FFmpeg's native VPx decoders don't decode alpha. You have to use the libvpx decoder to preserve transparency in .webm videos. "

Example of use:

VideoFileClip("video.webm", decoder="libvpx-vp9")