### PR TITLE
 Add 'decoder' parameter to VideoFileClip and ffmpeg_reader - v2 (dev)

### DIFF
--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -56,6 +56,11 @@ class VideoFileClip(VideoClip):
       'rgb24' will be used as the default format unless ``has_mask`` is set
       as ``True``, then 'rgba' will be used.
 
+    decoder:
+       The decoder used to decode the video file. FFmpeg's native VPx decoders 
+       don't decode alpha. You have to use the libvpx decoder. Set this to 
+       'libvpx-vp9' if you want to preserve transparency in .webm video.
+
 
     Attributes
     ----------
@@ -95,6 +100,7 @@ class VideoFileClip(VideoClip):
         audio_nbytes=2,
         fps_source="fps",
         pixel_format=None,
+        decoder=None,
     ):
         VideoClip.__init__(self)
 
@@ -108,6 +114,7 @@ class VideoFileClip(VideoClip):
             target_resolution=target_resolution,
             resize_algo=resize_algorithm,
             fps_source=fps_source,
+            decoder=decoder,
         )
 
         # Make some of the reader's attributes accessible from the clip

--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -126,6 +126,7 @@ class VideoFileClip(VideoClip):
         self.rotation = self.reader.rotation
 
         self.filename = filename
+        self.decoder = decoder
 
         if has_mask:
             self.make_frame = lambda t: self.reader.get_frame(t)[:, :, :3]

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -25,6 +25,7 @@ class FFMPEG_VideoReader:
         target_resolution=None,
         resize_algo="bicubic",
         fps_source="fps",
+        decoder=None,
     ):
         self.filename = filename
         self.proc = None
@@ -54,6 +55,7 @@ class FFMPEG_VideoReader:
             else:
                 self.size = target_resolution
         self.resize_algo = resize_algo
+        self.decoder = decoder
 
         self.duration = infos["video_duration"]
         self.ffmpeg_duration = infos["duration"]
@@ -83,18 +85,23 @@ class FFMPEG_VideoReader:
         """
         self.close(delete_lastread=False)  # if any
 
+        i_arg = ['-c:v', self.decoder] if self.decoder else []
+
         if start_time != 0:
             offset = min(1, start_time)
-            i_arg = [
-                "-ss",
-                "%.06f" % (start_time - offset),
-                "-i",
-                self.filename,
-                "-ss",
-                "%.06f" % offset,
-            ]
+            i_arg = (
+                i_arg 
+                + [
+                    "-ss",
+                    "%.06f" % (start_time - offset),
+                    "-i",
+                    self.filename,
+                    "-ss",
+                    "%.06f" % offset,
+                ]
+            )
         else:
-            i_arg = ["-i", self.filename]
+            i_arg = i_arg + ["-i", self.filename]
 
         cmd = (
             [FFMPEG_BINARY]


### PR DESCRIPTION
Same as #2229 but for v2 (dev)

Fixed bug:
    - When importing a .webm video with alpha channel, transparency are not working.

Solved issue:
    - #2008 
 
References:
    - https://www.reddit.com/r/ffmpeg/comments/fgpyfb/help_with_webm_with_alpha_channel/

"FFmpeg's native VPx decoders don't decode alpha. You have to use the libvpx decoder to preserve transparency in .webm videos. "

To preserve the alpha channel also needs to set has_mask parameter to True.

Example of use:

```py
VideoFileClip("video.webm", has_mask=True, decoder="libvpx-vp9")
```