### PR TITLE
Ensure `last_read` is always set.

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -129,7 +129,7 @@ class FFMPEG_VideoReader:
         # to be read by self.read_frame().
         # Eg when self.pos is 1, the 2nd frame will be read next.
         self.pos = self.get_frame_number(start_time)
-        self.lastread = self.read_frame()
+        self.last_read = self.read_frame()
 
     def skip_frames(self, n=1):
         """Reads and throws away n frames"""
@@ -144,7 +144,7 @@ class FFMPEG_VideoReader:
         """
         Reads the next frame from the file.
         Note that upon (re)initialization, the first frame will already have been read
-        and stored in ``self.lastread``.
+        and stored in ``self.last_read``.
         """
         w, h = self.size
         nbytes = self.depth * w * h
@@ -219,12 +219,17 @@ class FFMPEG_VideoReader:
         elif (pos < self.pos) or (pos > self.pos + 100):
             # We can't just skip forward to `pos` or it would take too long
             self.initialize(t)
-            return self.lastread
+            return self.last_read
         else:
             # If pos == self.pos + 1, this line has no effect
             self.skip_frames(pos - self.pos - 1)
             result = self.read_frame()
             return result
+
+    @property
+    def lastread(self):
+        """Alias of `self.last_read` for backwards compatibility with MoviePy 1.x."""
+        return self.last_read
 
     def get_frame_number(self, t):
         """Helper method to return the frame number at time ``t``"""


### PR DESCRIPTION
The property `lastread` was renamed to `last_read` in #1170 however not all instances were changed. This leads to some cases where only one of the variables is updated.  For example, in the case where one calls `get_frame` with a frame exactly one ahead of the current position.  In this case, only `self.last_read` is updated, but `self.lastread` remains unchanged, leading the two properties to get out of sync.

There are third-party projects which relied on the lastread property as it was never declared as private in previous versions (e.g. no underscore prefix). To avoid breaking projects relying on this, we also provide a property with the old name for backwards compatibility.

This should also help maintain the code, as there is already some confusion over the two similarly named properties (#2044).

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
