### PR TITLE
Fix CompositeVideoClip mask [1, 1] unexpected shape - Issue #2247

### DIFF
--- a/moviepy/video/compositing/CompositeVideoClip.py
+++ b/moviepy/video/compositing/CompositeVideoClip.py
@@ -289,7 +289,7 @@ def concatenate_videoclips(
             return clips[i].get_frame(t - timings[i])
 
         def get_mask(clip):
-            mask = clip.mask or ColorClip([1, 1], color=1, is_mask=True)
+            mask = clip.mask or ColorClip(clip.size, color=1, is_mask=True)
             if mask.duration is None:
                 mask.duration = clip.duration
             return mask


### PR DESCRIPTION
Fixes the issue when concatenating videoclips as mask is being considered as [1, 1] so the mask shape is different from the other videos and fails.

I think [1, 1] could be a default mask to avoid divisions by zero or something similar, but here it does not make sense.

Issue here: https://github.com/Zulko/moviepy/issues/2247

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
