### PR TITLE
Add bg_radius to text boxes

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1465,7 +1465,7 @@ class TextClip(ImageClip):
         interline=4,
         transparent=True,
         duration=None,
-        bg_radius=0, # TODO : Move this with other bg_param on next breaking release
+        bg_radius=0,  # TODO : Move this with other bg_param on next breaking release
     ):
         def break_text(
             width, text, font, font_size, stroke_width, align, spacing

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1727,13 +1727,14 @@ class TextClip(ImageClip):
 
         if bg_radius is None:
             bg_radius = 0
-        
+
         if bg_radius != 0:
-            
-            img = Image.new(img_mode, (img_width, img_height), color=(0,0,0,0))
+            img = Image.new(img_mode, (img_width, img_height), color=(0, 0, 0, 0))
             pil_font = ImageFont.truetype(font, font_size)
             draw = ImageDraw.Draw(img)
-            draw.rounded_rectangle([0, 0, img_width, img_height], radius=bg_radius, fill=bg_color)
+            draw.rounded_rectangle(
+                [0, 0, img_width, img_height], radius=bg_radius, fill=bg_color
+            )
         else:
             img = Image.new(img_mode, (img_width, img_height), color=bg_color)
             pil_font = ImageFont.truetype(font, font_size)

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1405,12 +1405,6 @@ class TextClip(ImageClip):
       a RGB (or RGBA if transparent = ``True``) ``tuple``, a color name, or an
       hexadecimal notation.
 
-    bg_radius
-     A paramater to round the edges of the text background. Defaults to 0 if there
-     is no background. It will have no effect if there is no bg_colour added.
-     The higher the value, the more rounded the corners will become.
-
-
     stroke_color
       Color of the stroke (=contour line) of the text. If ``None``,
       there will be no stroke.
@@ -1444,6 +1438,11 @@ class TextClip(ImageClip):
 
     duration
         Duration of the clip
+
+    bg_radius
+     A paramater to round the edges of the text background. Defaults to 0 if there
+     is no background. It will have no effect if there is no bg_colour added.
+     The higher the value, the more rounded the corners will become.
     """
 
     @convert_path_to_string("filename")
@@ -1457,7 +1456,6 @@ class TextClip(ImageClip):
         margin=(None, None),
         color="black",
         bg_color=None,
-        bg_radius=0,
         stroke_color=None,
         stroke_width=0,
         method="label",
@@ -1467,6 +1465,7 @@ class TextClip(ImageClip):
         interline=4,
         transparent=True,
         duration=None,
+        bg_radius=0, # TODO : Move this with other bg_param on next breaking release
     ):
         def break_text(
             width, text, font, font_size, stroke_width, align, spacing

--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1405,6 +1405,12 @@ class TextClip(ImageClip):
       a RGB (or RGBA if transparent = ``True``) ``tuple``, a color name, or an
       hexadecimal notation.
 
+    bg_radius
+     A paramater to round the edges of the text background. Defaults to 0 if there
+     is no background. It will have no effect if there is no bg_colour added.
+     The higher the value, the more rounded the corners will become.
+
+
     stroke_color
       Color of the stroke (=contour line) of the text. If ``None``,
       there will be no stroke.
@@ -1451,6 +1457,7 @@ class TextClip(ImageClip):
         margin=(None, None),
         color="black",
         bg_color=None,
+        bg_radius=0,
         stroke_color=None,
         stroke_width=0,
         method="label",
@@ -1719,9 +1726,19 @@ class TextClip(ImageClip):
         if bg_color is None and transparent:
             bg_color = (0, 0, 0, 0)
 
-        img = Image.new(img_mode, (img_width, img_height), color=bg_color)
-        pil_font = ImageFont.truetype(font, font_size)
-        draw = ImageDraw.Draw(img)
+        if bg_radius is None:
+            bg_radius = 0
+        
+        if bg_radius != 0:
+            
+            img = Image.new(img_mode, (img_width, img_height), color=(0,0,0,0))
+            pil_font = ImageFont.truetype(font, font_size)
+            draw = ImageDraw.Draw(img)
+            draw.rounded_rectangle([0, 0, img_width, img_height], radius=bg_radius, fill=bg_color)
+        else:
+            img = Image.new(img_mode, (img_width, img_height), color=bg_color)
+            pil_font = ImageFont.truetype(font, font_size)
+            draw = ImageDraw.Draw(img)
 
         # Dont need allow break here, because we already breaked in caption
         text_width, text_height = find_text_size(

--- a/moviepy/video/fx/Scroll.py
+++ b/moviepy/video/fx/Scroll.py
@@ -30,7 +30,6 @@ class Scroll(Effect):
         y_start=0,
         apply_to="mask",
     ):
-
         self.w = w
         self.h = h
         self.x_speed = x_speed

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -459,12 +459,12 @@ class FFmpegInfosParser:
                 # for default streams, set their numbers globally, so it's
                 # easy to get without iterating all
                 if self._current_stream["default"]:
-                    self.result[f"default_{stream_type_lower}_input_number"] = (
-                        input_number
-                    )
-                    self.result[f"default_{stream_type_lower}_stream_number"] = (
-                        stream_number
-                    )
+                    self.result[
+                        f"default_{stream_type_lower}_input_number"
+                    ] = input_number
+                    self.result[
+                        f"default_{stream_type_lower}_stream_number"
+                    ] = stream_number
 
                 # exit chapter
                 if self._current_chapter:


### PR DESCRIPTION
Adding in a new optional parameter bg_radius. This parameter allows users to round the edges of the background text box so it is not sharp cornered.

This new parameter is optional and utilises the pil libraries rounded_rectangle.

https://pillow.readthedocs.io/en/stable/reference/ImageDraw.html#PIL.ImageDraw.ImageDraw.rounded_rectangle

This has been around since pil 8.2.
Moviepy requires:  "pillow>=9.2.0,<11.0",
Therefore, this is compatible.

Note I have extensively tested on my local computer. I decided to  make the change as it was much simpler than me manually creating this on my end (I have also seen others eg. on reddit with the same issue).

I have not done many PR's before - please let me know if I have not done this correctly. I tried to follow the documentation but as I am newer to this with git I am unsure if I did it in the right place etc.

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->

- [ x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/` (I did this on my local computer but am unsure how to add it for this PR)
- [ x] I have properly documented new or changed features in the documentation or in the docstrings
- [ x] I have properly explained unusual or unexpected code in the comments around it
