### PR TITLE
Correct SubtitlesClip example to not pass the generator lambda as `font`

### DIFF
--- a/moviepy/video/tools/subtitles.py
+++ b/moviepy/video/tools/subtitles.py
@@ -46,8 +46,7 @@ class SubtitlesClip(VideoClip):
         from moviepy.video.io.VideoFileClip import VideoFileClip
         generator = lambda text: TextClip(text, font='Georgia-Regular',
                                         font_size=24, color='white')
-        sub = SubtitlesClip("subtitles.srt", generator)
-        sub = SubtitlesClip("subtitles.srt", generator, encoding='utf-8')
+        sub = SubtitlesClip("subtitles.srt", make_textclip=generator, encoding='utf-8')
         myvideo = VideoFileClip("myvideo.avi")
         final = CompositeVideoClip([clip, subtitles])
         final.write_videofile("final.mp4", fps=myvideo.fps)

--- a/moviepy/video/tools/subtitles.py
+++ b/moviepy/video/tools/subtitles.py
@@ -44,7 +44,7 @@ class SubtitlesClip(VideoClip):
 
         from moviepy.video.tools.subtitles import SubtitlesClip
         from moviepy.video.io.VideoFileClip import VideoFileClip
-        generator = lambda text: TextClip(text, font='Georgia-Regular',
+        generator = lambda text: TextClip(text, font='./path/to/font.ttf',
                                         font_size=24, color='white')
         sub = SubtitlesClip("subtitles.srt", make_textclip=generator, encoding='utf-8')
         myvideo = VideoFileClip("myvideo.avi")


### PR DESCRIPTION
Refs: https://stackoverflow.com/a/79243946/51685

Given the signature for `SubtitlesClip.__init__()` is `__init__(self, subtitles, font=None, make_textclip=None, encoding=None)`, the example would have attempted to pass in the generator function as `font`.