### PR TITLE
Update macOS version to 13 in test_suite.yml

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   # Uses Python Framework build because on macOS, Matplotlib requires it
   macos:
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]


### PR DESCRIPTION
This gets the macOS testing working again. Github will no longer run jobs using the `macOS-12` version. This updates to the next lowest version, `macOS-13`.

I ran into this problem on one of my own repos, and this change fixed it. I came to see if moviepy was being maintained again, and was glad to see it was. Good work y'all! Hopefully getting mac tests passing helps people feel comfortable using this project again.

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
