### PR TITLE
Fix issue #2305: Change stroke_width from float 0.5 to int 1

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1410,7 +1410,7 @@ class TextClip(ImageClip):
       there will be no stroke.
 
     stroke_width
-      Width of the stroke, in pixels. Can be a float, like 1.5.
+      Width of the stroke, in pixels. Must be an int.
 
     method
       Either 'label' (default, the picture will be autosized so as to fit

--- a/moviepy/video/tools/subtitles.py
+++ b/moviepy/video/tools/subtitles.py
@@ -72,6 +72,7 @@ class SubtitlesClip(VideoClip):
             if self.font is None:
                 raise ValueError("Argument font is required if make_textclip is None.")
 
+            # Changed stroke_width from float 0.5 to int 1
             def make_textclip(txt):
                 return TextClip(
                     font=self.font,
@@ -79,7 +80,7 @@ class SubtitlesClip(VideoClip):
                     font_size=24,
                     color="#ffffff",
                     stroke_color="#000000",
-                    stroke_width=0.5,
+                    stroke_width=1,
                 )
 
         self.make_textclip = make_textclip

--- a/moviepy/video/tools/subtitles.py
+++ b/moviepy/video/tools/subtitles.py
@@ -72,7 +72,6 @@ class SubtitlesClip(VideoClip):
             if self.font is None:
                 raise ValueError("Argument font is required if make_textclip is None.")
 
-            # Changed stroke_width from float 0.5 to int 1
             def make_textclip(txt):
                 return TextClip(
                     font=self.font,


### PR DESCRIPTION
Trying to create a SubtitlesClip without make_textclip() causes a TypeError. This TypeError is caused by the default make_textclip() providing a float value of 0.5 for stroke_width when it can only accept int values. Fixed by changing value of stroke_width to 1.
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
