### PR TITLE
Try fixing conda for macos

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -15,14 +15,21 @@ jobs:
   # Uses Python Framework build because on macOS, Matplotlib requires it
   macos:
     runs-on: macos-13
+    # Do not ignore bash profile files. From:
+    # https://github.com/marketplace/actions/setup-miniconda
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v4.1.6
-    - uses: s-weigand/setup-conda@v1.2.2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
-        activate-conda: true
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
+        auto-activate-base: true
 
     - name: Install pythonw
       run: conda install python.app


### PR DESCRIPTION
The old conda action seems to no longer with new versions of macos (see https://github.com/s-weigand/setup-conda/issues/432), which in turn break our macos tests, this PR try to solve this issue by migrating to a new conda action, https://github.com/conda-incubator/setup-miniconda.