### PR TITLE
chore: skip metadata which not satisfied with "key:value"

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -778,8 +778,13 @@ class FFmpegInfosParser:
         """Returns a tuple with a metadata field-value pair given a ffmpeg `-i`
         command output line.
         """
-        raw_field, raw_value = line.split(":", 1)
-        return (raw_field.strip(" "), raw_value.strip(" "))
+        info = line.split(":", 1)
+        
+        if len(info) == 2:
+            raw_field, raw_value = info
+            return (raw_field.strip(" "), raw_value.strip(" "))
+        else:
+            return ("", "")
 
     def video_metadata_type_casting(self, field, value):
         """Cast needed video metadata fields to other types than the default str."""

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -779,7 +779,6 @@ class FFmpegInfosParser:
         command output line.
         """
         info = line.split(":", 1)
-        
         if len(info) == 2:
             raw_field, raw_value = info
             return (raw_field.strip(" "), raw_value.strip(" "))


### PR DESCRIPTION
when i editing video captured by my iphone, throw error while ffmpeg reading, i found out that some video metadata violate the format "key:value", so i adjust some logic in this pr.

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
