### PR TITLE
Add exception on outside of boundaries subclip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add background radius to text clips
 
 ### Changed <!-- for changes in existing functionality -->
+- Subclipping outside of clip boundaries now raise an exception
 
 ### Deprecated <!-- for soon-to-be removed features -->
 

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -402,7 +402,6 @@ class Clip:
                 + "should be smaller than the clip's "
                 + "duration (%.02f)." % self.duration
             )
-        
 
         new_clip = self.time_transform(lambda t: t + start_time, apply_to=[])
 
@@ -423,13 +422,14 @@ class Clip:
                 end_time = self.duration + end_time
 
         if end_time is not None:
-            if (self.duration is not None) and (end_time > self.duration):
+            # Allow a slight tolerance to account for rounding errors
+            if (self.duration is not None) and (end_time - self.duration > 0.00000001):
                 raise ValueError(
                     "end_time (%.02f) " % end_time
                     + "should be smaller or equal to the clip's "
                     + "duration (%.02f)." % self.duration
                 )
-        
+
             new_clip.duration = end_time - start_time
             new_clip.end = new_clip.start + new_clip.duration
 

--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -402,6 +402,7 @@ class Clip:
                 + "should be smaller than the clip's "
                 + "duration (%.02f)." % self.duration
             )
+        
 
         new_clip = self.time_transform(lambda t: t + start_time, apply_to=[])
 
@@ -422,6 +423,13 @@ class Clip:
                 end_time = self.duration + end_time
 
         if end_time is not None:
+            if (self.duration is not None) and (end_time > self.duration):
+                raise ValueError(
+                    "end_time (%.02f) " % end_time
+                    + "should be smaller or equal to the clip's "
+                    + "duration (%.02f)." % self.duration
+                )
+        
             new_clip.duration = end_time - start_time
             new_clip.end = new_clip.start + new_clip.duration
 

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -476,12 +476,12 @@ class FFmpegInfosParser:
                 # for default streams, set their numbers globally, so it's
                 # easy to get without iterating all
                 if self._current_stream["default"]:
-                    self.result[f"default_{stream_type_lower}_input_number"] = (
-                        input_number
-                    )
-                    self.result[f"default_{stream_type_lower}_stream_number"] = (
-                        stream_number
-                    )
+                    self.result[
+                        f"default_{stream_type_lower}_input_number"
+                    ] = input_number
+                    self.result[
+                        f"default_{stream_type_lower}_stream_number"
+                    ] = stream_number
 
                 # exit chapter
                 if self._current_chapter:

--- a/tests/test_Clip.py
+++ b/tests/test_Clip.py
@@ -184,6 +184,7 @@ def test_clip_copy(copy_func):
         (3, 3, None, ValueError),  # start_time == duration
         (3, 1, -1, 1),  # negative end_time
         (None, 1, -1, ValueError),  # negative end_time for clip without duration
+        (1, 0, 2, ValueError),  # end_time after video end should raise exception
     ),
 )
 def test_clip_subclip(duration, start_time, end_time, expected_duration):

--- a/tests/test_VideoClip.py
+++ b/tests/test_VideoClip.py
@@ -389,16 +389,17 @@ def test_afterimage(util):
 
 def test_add():
     clip = VideoFileClip("media/fire2.mp4")
-    new_clip = clip[0:1] + clip[2:3.2]
-    assert new_clip.duration == 2.2
-    assert np.array_equal(new_clip[1.1], clip[2.1])
+    print(clip.duration)
+    new_clip = clip[0:1] + clip[1.5:2]
+    assert new_clip.duration == 1.5
+    assert np.array_equal(new_clip[1.1], clip[1.6])
 
 
 def test_slice_tuples():
     clip = VideoFileClip("media/fire2.mp4")
-    new_clip = clip[0:1, 2:3.2]
-    assert new_clip.duration == 2.2
-    assert np.array_equal(new_clip[1.1], clip[2.1])
+    new_clip = clip[0:1, 1.5:2]
+    assert new_clip.duration == 1.5
+    assert np.array_equal(new_clip[1.1], clip[1.6])
 
 
 def test_slice_mirror():

--- a/tests/test_VideoClip.py
+++ b/tests/test_VideoClip.py
@@ -389,7 +389,6 @@ def test_afterimage(util):
 
 def test_add():
     clip = VideoFileClip("media/fire2.mp4")
-    print(clip.duration)
     new_clip = clip[0:1] + clip[1.5:2]
     assert new_clip.duration == 1.5
     assert np.array_equal(new_clip[1.1], clip[1.6])

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -303,9 +303,8 @@ def test_issue_470(util):
     audio_clip = AudioFileClip("media/crunching.mp3")
 
     # end_time is out of bounds
-    subclip = audio_clip.subclipped(start_time=6, end_time=9)
-
-    with pytest.raises(IOError):
+    with pytest.raises(ValueError):
+        subclip = audio_clip.subclipped(start_time=6, end_time=9)
         subclip.write_audiofile(wav_filename, write_logfile=True)
 
     # but this one should work..
@@ -334,7 +333,7 @@ def test_issue_636():
 
 def test_issue_655():
     video_file = "media/fire2.mp4"
-    for subclip in [(0, 2), (1, 2), (2, 3)]:
+    for subclip in [(0, 2), (1, 2), (2, 2.10)]:
         with VideoFileClip(video_file) as v:
             with v.subclipped(1, 2) as _:
                 pass


### PR DESCRIPTION
Fixing issue #2304 by raising an exception if a user try to subclip outside of clip boundaries.
- [x ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ x] I have properly documented new or changed features in the documentation or in the docstrings
- [x ] I have properly explained unusual or unexpected code in the comments around it
