### PR TITLE
Fix issue #2330 audio write wrong fps

### DIFF
--- a/moviepy/audio/AudioClip.py
+++ b/moviepy/audio/AudioClip.py
@@ -240,9 +240,9 @@ class AudioClip(Clip):
         """
         if not fps:
             if hasattr(self, "fps"):
-                fps = 44100
-            else:
                 fps = self.fps
+            else:
+                fps = 44100
 
         if codec is None:
             name, ext = os.path.splitext(os.path.basename(filename))


### PR DESCRIPTION
Fixes a bug that is not setting the instance 'fps' value when it has the attribute, but doing it when it doesn't.

This is the related issue: https://github.com/Zulko/moviepy/issues/2330

If it has the attribute, set it, if not, use a default value.