### PR TITLE
Fix Freeze effect removing original start and end parameters

### DIFF
--- a/moviepy/Clip.py
+++ b/moviepy/Clip.py
@@ -218,6 +218,15 @@ class Clip:
         These changes are also applied to the ``audio`` and ``mask``
         clips of the current clip, if they exist.
 
+        note::
+          The start and end attribute of a clip define when a clip will start
+          playing when used in a composite video clip, not the start time of
+          the clip itself.
+
+          i.e: with_start(10) mean the clip will still start at his first frame,
+          but if used in a composite video clip it will only start to show at
+          10 seconds.
+
         Parameters
         ----------
 
@@ -247,6 +256,15 @@ class Clip:
         which can be expressed in seconds (15.35), in (min, sec), in
         (hour, min, sec), or as a string: '01:03:05.35'. Also sets the duration
         of the mask and audio, if any, of the returned clip.
+
+        note::
+          The start and end attribute of a clip define when a clip will start
+          playing when used in a composite video clip, not the start time of
+          the clip itself.
+
+          i.e: with_start(10) mean the clip will still start at his first frame,
+          but if used in a composite video clip it will only start to show at
+          10 seconds.
 
         Parameters
         ----------

--- a/moviepy/video/fx/Freeze.py
+++ b/moviepy/video/fx/Freeze.py
@@ -15,12 +15,16 @@ class Freeze(Effect):
     With ``total_duration`` you can specify the total duration of
     the clip and the freeze (i.e. the duration of the freeze is
     automatically computed). One of them must be provided.
+
+    With ``update_start_end`` you can define if the effect must preserve
+    and/or update start and end properties of the original clip
     """
 
     t: float = 0
     freeze_duration: float = None
     total_duration: float = None
     padding_end: float = 0
+    update_start_end: bool = True
 
     def apply(self, clip: Clip) -> Clip:
         """Apply the effect to the clip."""
@@ -40,4 +44,12 @@ class Freeze(Effect):
         before = [clip[: self.t]] if (self.t != 0) else []
         freeze = [clip.to_ImageClip(self.t).with_duration(self.freeze_duration)]
         after = [clip[self.t :]] if (self.t != clip.duration) else []
-        return concatenate_videoclips(before + freeze + after)
+
+        new_clip = concatenate_videoclips(before + freeze + after)
+        if self.update_start_end:
+            if clip.start is not None:
+                new_clip = new_clip.with_start(clip.start)
+            if clip.end is not None:
+                new_clip = new_clip.with_end(clip.end + self.freeze_duration)
+
+        return new_clip

--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -240,7 +240,8 @@ def ffmpeg_version():
     cmd = [
         FFMPEG_BINARY,
         "-version",
-        "-v", "quiet",
+        "-v",
+        "quiet",
     ]
 
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)


### PR DESCRIPTION
By default Freeze effect would remove the original clip start and end properties, this PR add a parameter to preserve thoses as much as we can.