### PR TITLE
Update config.py check() to log correct binary name

### DIFF
--- a/moviepy/config.py
+++ b/moviepy/config.py
@@ -78,9 +78,9 @@ def check():
         print(f"MoviePy: can't find or access ffmpeg in '{FFMPEG_BINARY}'.")
 
     if try_cmd([FFPLAY_BINARY])[0]:
-        print(f"MoviePy: ffmpeg successfully found in '{FFPLAY_BINARY}'.")
+        print(f"MoviePy: ffplay successfully found in '{FFPLAY_BINARY}'.")
     else:  # pragma: no cover
-        print(f"MoviePy: can't find or access ffmpeg in '{FFPLAY_BINARY}'.")
+        print(f"MoviePy: can't find or access ffplay in '{FFPLAY_BINARY}'.")
 
     if DOTENV:
         print(f"\n.env file content at {DOTENV}:\n")


### PR DESCRIPTION
When finding FFMPEG_BINARY, it correctly displays that it found ffmpeg. But when finding FFPLAY_BINARY it again displays ffmpeg. This changes it to display ffplay