### PR TITLE
Fix text without spaces overflowing TextClip boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix GPU h264_nvenc encoding not working.
 - Improve perfs of decorator by pre-computing arguments
 - Fix textclip being cut or of impredictable height (see issues #2325, #2260 and #2268)
+- TextClip now properly breaklines on text without spaces, such as chinese (see #2260)
 - Fix TimeMirror and TimeSymmetrize cutting last second of clip
 - ImageSequenceClip was wrong when calculating fps with duration and no fps (see issue #2351)
 - More consistent frame seek (see issue #2115 and PR #2117)

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -492,12 +492,12 @@ class FFmpegInfosParser:
                 # for default streams, set their numbers globally, so it's
                 # easy to get without iterating all
                 if self._current_stream["default"]:
-                    self.result[f"default_{stream_type_lower}_input_number"] = (
-                        input_number
-                    )
-                    self.result[f"default_{stream_type_lower}_stream_number"] = (
-                        stream_number
-                    )
+                    self.result[
+                        f"default_{stream_type_lower}_input_number"
+                    ] = input_number
+                    self.result[
+                        f"default_{stream_type_lower}_stream_number"
+                    ] = stream_number
 
                 # exit chapter
                 if self._current_chapter:


### PR DESCRIPTION
A text without spaces would never break and end up overflowing TextClip boundaries, this is particularly problematic for languages such as Chinese where the notion of space does not exists (as describe in issue #2260), this PR fix it by breaking on spaces if possible, and force break mid-sentence when not possible.