### PR TITLE
Fix pixel_format in FFMPEG_VideoWriter

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -226,6 +226,7 @@ class VideoClip(Clip):
         ffmpeg_params=None,
         logger="bar",
         pixel_format=None,
+        print_cmd=False,
     ):
         """Write the clip to a videofile.
 
@@ -404,6 +405,7 @@ class VideoClip(Clip):
             ffmpeg_params=ffmpeg_params,
             logger=logger,
             pixel_format=pixel_format,
+            print_cmd=print_cmd,
         )
 
         if remove_temp and make_audio:
@@ -1867,7 +1869,8 @@ class TextClip(ImageClip):
             To summarize, the real height of the text is:
               ``initial padding + (lines - 1) * height + end padding``
             or:
-              ``(ascent + stroke_width) + (lines - 1) * height + (descent + stroke_width)``
+              ``(ascent + stroke_width) + (lines - 1) * height
+              + (descent + stroke_width)``
             or:
               ``real_font_size + (stroke_width * 2) + (lines - 1) * height``
         """

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -29,9 +29,11 @@ class FFMPEG_VideoReader:
         target_resolution=None,
         resize_algo="bicubic",
         fps_source="fps",
+        print_cmd=False,
     ):
         self.filename = filename
         self.proc = None
+        self.print_cmd = print_cmd
         infos = ffmpeg_parse_infos(
             filename,
             check_duration=check_duration,
@@ -154,6 +156,8 @@ class FFMPEG_VideoReader:
                 "-",
             ]
         )
+        if self.print_cmd:
+            print(" ".join(cmd))
 
         popen_params = cross_platform_popen_params(
             {

--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -259,6 +259,7 @@ def ffmpeg_write_video(
     ffmpeg_params=None,
     logger="bar",
     pixel_format=None,
+    print_cmd=False,
 ):
     """Write the clip to a videofile. See VideoClip.write_videofile for details
     on the parameters.
@@ -288,6 +289,7 @@ def ffmpeg_write_video(
         threads=threads,
         ffmpeg_params=ffmpeg_params,
         pixel_format=pixel_format,
+        print_cmd=print_cmd,
     ) as writer:
         for t, frame in clip.iter_frames(
             logger=logger, with_times=True, fps=fps, dtype="uint8"


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it

I will be going through the checkpoints above later on.

The main issues that this PR fixes are with the implementation of `FFMPEG_VideoWriter`:
- The current implementation effectively disregards the `pixel_format` argument, and overrides it with either `rgb24` or `rgba`. 
- The FFMPEG option `-pix_fmt` is duplicated in some cases. 
- The FFMPEG option `-vcodec` (or `-c:v`) is systematically duplicated. 

This PR addresses these issues by honoring the `pixel_format` argument when it is not `None` regardless of other arguments. It also introduces an argument `print_cmd` to print the FFMPEG command to the terminal for debugging purposes. 
