### PR TITLE
add test that will fail on get_frame(clip.duration) bug

### DIFF
--- a/tests/test_Clip.py
+++ b/tests/test_Clip.py
@@ -254,6 +254,20 @@ def test_clip_memoize():
 
     assert isinstance(memoize_clip.get_frame(1), np.ndarray)
 
+@pytest.mark.parametrize(
+    (
+        "fps",
+    ),
+    (
+        (0.1,1,30),
+    ),
+)
+def test_clip_get_frame(fps):
+    clip = BitmapClip([["RR", "RR"], ["GG", "GG"], ["BB", "BB"]], fps=fps)
+
+    assert clip.get_frame(0) != clip.get_frame(clip.duration)
+    assert clip.get_frame(0) != clip.get_frame(clip.duration - 1./fps)
+    assert clip.get_frame(0) != clip.get_frame(clip.duration - 2./fps)
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
I was going to make an issue, but it was actually easier to add a test case that would fail on the bug I found.

I found that if I pass the duration of the clip to .get_frame() it does not return the last frame, but rather the first frame.  even passing get_frame(clip.duration-1/clip.fps) does not return the last frame.  Only get_frame.duration(clip.duration- 2/clip.fps) will return a frame near the end of the video (I have not confirmed if its actually the last frame).

This is a draft pr as I have not run the code locally yet.  I was hoping the CI would run and fail on this test as a proof of the bug.

- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
