### PR TITLE
make dependency management compatible with uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
+requires-python=">=3.9"
 name = "moviepy"
 version = "2.2.0"
 description = "Video editing with Python"


### PR DESCRIPTION
this is small change  allowing to use [uv](https://docs.astral.sh/uv/) as dependecy manager on this project. With automatic updating of lockfile