### PR TITLE
Fix ffmpeg_reader.py failing on non-string metadata values

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -545,7 +545,7 @@ class FFmpegInfosParser:
                 # multiline metadata value parsing
                 if field == "":
                     field = self._last_metadata_field_added
-                    value = self._current_stream["metadata"][field] + "\n" + value
+                    value = str(self._current_stream["metadata"][field]) + "\n" + value
                 else:
                     self._last_metadata_field_added = field
                 self._current_stream["metadata"][field] = value


### PR DESCRIPTION
Fixes #2390 

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ ] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [ ] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ ] I have properly documented new or changed features in the documentation or in the docstrings
- [ ] I have properly explained unusual or unexpected code in the comments around it
