### PR TITLE
ImageClip: copy base image. Improves performance in some cases.

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1341,9 +1341,9 @@ class ImageClip(VideoClip):
 
         # if the image was just a 2D mask, it should arrive here
         # unchanged
-        self.frame_function = lambda t: img
+        self.frame_function = lambda t: self.img
         self.size = img.shape[:2][::-1]
-        self.img = img
+        self.img = +img
 
     def transform(self, func, apply_to=None, keep_duration=True):
         """General transformation filter.
@@ -1373,8 +1373,8 @@ class ImageClip(VideoClip):
             apply_to = []
         arr = image_func(self.get_frame(0))
         self.size = arr.shape[:2][::-1]
-        self.frame_function = lambda t: arr
-        self.img = arr
+        self.img = +arr
+        self.frame_function = lambda t: self.img
 
         for attr in apply_to:
             a = getattr(self, attr, None)


### PR DESCRIPTION
Helps with performance in #2395 test to some extent.

If you check the `ndarray.flags` of certain frames, you see that `OWNDATA` and `C_CONTIGUOUS` are sometimes false, which I think is slowing down something in PIL a lot. The copy is improving performance on the #2395 test by about 3x for me, on OS X ARM.