### PR TITLE
Fix ffmpeg info parser to avoid unexpected metadata lose and type error in certain case.

### DIFF
--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -393,6 +393,9 @@ class FFmpegInfosParser:
         self._current_stream = None
         self._current_chapter = None
 
+        # if stream type is video then has side data
+        self._inside_stream_sidedata = False
+
         # resulting data of the parsing process
         self.result = {
             "video_found": False,
@@ -455,9 +458,12 @@ class FFmpegInfosParser:
                     value = self.result["metadata"][field] + "\n" + value
                 else:
                     self._last_metadata_field_added = field
+
                 self.result["metadata"][field] = value
             elif line.lstrip().startswith("Stream "):
                 # exit stream "    Metadata:"
+                self._inside_stream_sidedata = False
+
                 if self._current_stream:
                     self._current_input_file["streams"].append(self._current_stream)
 
@@ -524,13 +530,19 @@ class FFmpegInfosParser:
                     )
                 else:
                     self._current_stream.update(stream_data)
-            elif line.startswith("    Metadata:"):
+            elif line.startswith('      Metadata:'):
                 # enter group "    Metadata:"
                 continue
             elif self._current_stream:
                 # stream metadata line
                 if "metadata" not in self._current_stream:
                     self._current_stream["metadata"] = {}
+
+                if line.strip().startswith("Side data:"):
+                    self._inside_stream_sidedata = True
+                    if "side_data" not in self._current_stream:
+                        self._current_stream["sidedata"] = {}
+                    continue
 
                 field, value = self.parse_metadata_field_value(line)
 
@@ -548,7 +560,12 @@ class FFmpegInfosParser:
                     value = self._current_stream["metadata"][field] + "\n" + value
                 else:
                     self._last_metadata_field_added = field
-                self._current_stream["metadata"][field] = value
+
+                if not self._inside_stream_sidedata:
+                    self._current_stream["metadata"][field] = value
+                else:
+                    self._current_stream["sidedata"][field] = value
+                
             elif line.startswith("    Chapter"):
                 # Chapter data line
                 if self._current_chapter:

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -543,7 +543,7 @@ class FFmpegInfosParser:
                         self.result["video_rotation"] = value
 
                 # multiline metadata value parsing
-                if field == "":
+                if field == "" and self._last_metadata_field_added not in ['rotate', 'displaymatrix']:
                     field = self._last_metadata_field_added
                     value = self._current_stream["metadata"][field] + "\n" + value
                 else:
@@ -796,6 +796,13 @@ class FFmpegInfosParser:
         """Returns a tuple with a metadata field-value pair given a ffmpeg `-i`
         command output line.
         """
+        if line.startswith("Ambient Viewing Environment, ") or line.startswith(
+            "Content Light Level Metadata, "
+        ) or line.startswith("Mastering Display Metadata, "):
+            field = line.split(",")[0]
+            value = line.split(",")[1:]
+            return (field.strip(" "), ",".join(value).strip(" "))
+
         info = line.split(":", 1)
         if len(info) == 2:
             raw_field, raw_value = info


### PR DESCRIPTION
This is related to [#2311] and [#1860]. 

At first, I got a TypeError from flowing line for `self._last_metadata_field_added` was `"displaymatrix"` which is casted integer, then trying operate int + str. I can easily avoid this TypeError by type conversion or check if the last metadata field was catsted. But fundamentally, why this code try to concat the fields that are not multiple line metadata?
https://github.com/Zulko/moviepy/blob/4dd5fe44b47a4a2f42eebc8b5eadd74a25001853/moviepy/video/io/ffmpeg_reader.py#L545-L548

Then I found [#2311] caused this issue because changed code ignore none "key:value" metadata and return empty string "" as default. So above line is triggered which was intended to multiple line metadata concat.

So I think we need to handle none "key:value" metadata rather than not just ignoring them. Following keys are none "key:value" metadata I've just found in dump.c in ffmpeg original repo. And I want add them on `parse_metadata_field_value()` to parse properly.
- Mastering Display Metadata, 
- Ambient Viewing Environment, 
- Content Light Level Metadata, 

Additionally, I found for video stream there is sidedata besides metadata but currently parsed as metadata. So I separate sidedata from metadata for video stream.