### PR TITLE
Remove max line length

### DIFF
--- a/.github/workflows/formatting_linting.yml
+++ b/.github/workflows/formatting_linting.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Show Flake8 version
         run: flake8 --version
       - name: Run Flake8
-        run: flake8 -v --show-source --max-line-length=92 moviepy docs/conf.py examples tests
+        run: flake8 -v --show-source --ignore=E501 moviepy docs/conf.py examples tests
 
   isort:
     name: isort import sorter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,6 @@ repos:
           - flake8-rst-docstrings>=0.3
           - flake8-implicit-str-concat==0.4.0
         args:
-          - --max-line-length=92
+          - --ignore=E501 # Black will force a line length of 88 when possible
         name: flake8-test
         files: \.py$

--- a/docs/_static/code/getting_started/moviepy_10_minutes/trailer.py
+++ b/docs/_static/code/getting_started/moviepy_10_minutes/trailer.py
@@ -1,6 +1,7 @@
 # Lets import moviepy, lets also import numpy we will use it a some point
-from moviepy import *
 import numpy as np
+
+from moviepy import *
 
 
 #################
@@ -199,13 +200,28 @@ bunny_clip = bunny_clip.with_effects(
     [vfx.FadeIn(1), vfx.FadeOut(1), afx.AudioFadeIn(1), afx.AudioFadeOut(1)]
 )
 rodents_clip = rodents_clip.with_effects(
-    [vfx.FadeIn(1), vfx.CrossFadeOut(1.5), afx.AudioFadeIn(1), afx.AudioFadeOut(1.5)]
+    [
+        vfx.FadeIn(1),
+        vfx.CrossFadeOut(1.5),
+        afx.AudioFadeIn(1),
+        afx.AudioFadeOut(1.5),
+    ]
 )  # Just fade in, rambo clip will do the cross fade
 rambo_clip = rambo_clip.with_effects(
-    [vfx.CrossFadeIn(1.5), vfx.FadeOut(1), afx.AudioFadeIn(1.5), afx.AudioFadeOut(1)]
+    [
+        vfx.CrossFadeIn(1.5),
+        vfx.FadeOut(1),
+        afx.AudioFadeIn(1.5),
+        afx.AudioFadeOut(1),
+    ]
 )
 rambo_clip = rambo_clip.with_effects(
-    [vfx.CrossFadeIn(1.5), vfx.FadeOut(1), afx.AudioFadeIn(1.5), afx.AudioFadeOut(1)]
+    [
+        vfx.CrossFadeIn(1.5),
+        vfx.FadeOut(1),
+        afx.AudioFadeIn(1.5),
+        afx.AudioFadeOut(1),
+    ]
 )
 
 # Effects are not only for transition, they can also change a clip timing or appearance

--- a/docs/_static/code/user_guide/compositing/juxtaposing.py
+++ b/docs/_static/code/user_guide/compositing/juxtaposing.py
@@ -2,6 +2,7 @@
 
 from moviepy import VideoFileClip, clips_array, vfx
 
+
 # We will use the same clip and transform it in 3 ways
 clip1 = VideoFileClip("example.mp4").with_effects([vfx.Margin(10)])  # add 10px contour
 clip2 = clip1.with_effects([vfx.MirrorX()])  # Flip horizontaly

--- a/docs/_static/code/user_guide/compositing/with_position.py
+++ b/docs/_static/code/user_guide/compositing/with_position.py
@@ -1,6 +1,7 @@
 """Let's position some text and images on a video."""
 
-from moviepy import TextClip, VideoFileClip, CompositeVideoClip, ImageClip
+from moviepy import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
+
 
 # We load all the clips we want to compose
 background = VideoFileClip("example2.mp4").subclipped(0, 2)

--- a/docs/_static/code/user_guide/loading/UpdatedVideoClip.py
+++ b/docs/_static/code/user_guide/loading/UpdatedVideoClip.py
@@ -1,6 +1,8 @@
-from moviepy import UpdatedVideoClip
-import numpy as np
 import random
+
+import numpy as np
+
+from moviepy import UpdatedVideoClip
 
 
 class CoinFlipWorld:
@@ -9,7 +11,8 @@ class CoinFlipWorld:
     Imagine we want to make a video that become more and more red as we repeat same face
     on coinflip in a row because coinflip are done in real time, we need to wait
     until a winning row is done to be able to make the next frame.
-    This is a world simulating that. Sorry, it's hard to come up with examples..."""
+    This is a world simulating that. Sorry, it's hard to come up with examples...
+    """
 
     def __init__(self, fps):
         """

--- a/docs/_static/code/user_guide/loading/VideoClip.py
+++ b/docs/_static/code/user_guide/loading/VideoClip.py
@@ -1,7 +1,10 @@
-from PIL import Image, ImageDraw
-import numpy as np
-from moviepy import VideoClip
 import math
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+from moviepy import VideoClip
+
 
 WIDTH, HEIGHT = (128, 128)
 RED = (255, 0, 0)

--- a/docs/_static/code/user_guide/loading/VideoFileClip.py
+++ b/docs/_static/code/user_guide/loading/VideoFileClip.py
@@ -1,5 +1,6 @@
 from moviepy import VideoFileClip
 
+
 myclip = VideoFileClip("example.mp4")
 
 # video file clips already have fps and duration

--- a/docs/_static/code/user_guide/loading/loading.py
+++ b/docs/_static/code/user_guide/loading/loading.py
@@ -1,14 +1,16 @@
+import numpy as np
+
 from moviepy import (
+    AudioClip,
+    AudioFileClip,
+    ColorClip,
+    ImageClip,
+    ImageSequenceClip,
+    TextClip,
     VideoClip,
     VideoFileClip,
-    ImageSequenceClip,
-    ImageClip,
-    TextClip,
-    ColorClip,
-    AudioFileClip,
-    AudioClip,
 )
-import numpy as np
+
 
 # Define some constants for later use
 black = (255, 255, 255)  # RGB for black

--- a/docs/_static/code/user_guide/loading/masks.py
+++ b/docs/_static/code/user_guide/loading/masks.py
@@ -1,5 +1,7 @@
-from moviepy import VideoClip, ImageClip, VideoFileClip
 import numpy as np
+
+from moviepy import ImageClip, VideoClip, VideoFileClip
+
 
 # Random RGB noise image of 200x100
 frame_function = lambda t: np.random.rand(100, 200)

--- a/docs/_static/code/user_guide/rendering/preview.py
+++ b/docs/_static/code/user_guide/rendering/preview.py
@@ -1,5 +1,6 @@
 from moviepy import *
 
+
 myclip = VideoFileClip("./example.mp4").subclipped(0, 1)  # Keep only 0 to 1 sec
 
 # We preview our clip as a video, inheriting FPS and audio of the original clip

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,8 +121,8 @@ html_theme_options = {
             "type": "fontawesome",
         }
     ],
-    "announcement": f"""<p>MoviePy v2.0 have introduced breaking changes, 
-    see <a href="{v2_page}">Updating from v1.X to v2.X</a> for more info.</p>""",
+    "announcement": f"""<p>MoviePy v2.0 have introduced breaking changes, see
+<a href="{v2_page}">Updating from v1.X to v2.X</a> for more info.</p>""",
 }
 
 html_context = {

--- a/docs/developer_guide/developers_install.rst
+++ b/docs/developer_guide/developers_install.rst
@@ -50,7 +50,7 @@ and
 
 .. code:: bash
 
-    $ python3 -m flake8 -v --show-source --max-line-length=92 moviepy docs/conf.py examples tests
+    $ python3 -m flake8 -v --show-source --ignore=E501 moviepy docs/conf.py examples tests
 
 Adding Git pre-commit hooks
 -----------------------------

--- a/moviepy/audio/io/readers.py
+++ b/moviepy/audio/io/readers.py
@@ -61,7 +61,10 @@ class FFMPEG_AudioReader:
         self.format = "s%dle" % (8 * nbytes)
         self.codec = "pcm_s%dle" % (8 * nbytes)
         self.nchannels = nchannels
-        infos = ffmpeg_parse_infos(filename, decode_file=decode_file)
+        infos = ffmpeg_parse_infos(
+            filename, decode_file=decode_file, print_infos=print_infos
+        )
+        print(infos)
         self.duration = infos["duration"]
         self.bitrate = infos["audio_bitrate"]
         self.infos = infos

--- a/moviepy/audio/io/readers.py
+++ b/moviepy/audio/io/readers.py
@@ -64,7 +64,6 @@ class FFMPEG_AudioReader:
         infos = ffmpeg_parse_infos(
             filename, decode_file=decode_file, print_infos=print_infos
         )
-        print(infos)
         self.duration = infos["duration"]
         self.bitrate = infos["audio_bitrate"]
         self.infos = infos

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -327,11 +327,10 @@ def ffmpeg_read_image(filename, with_mask=True, pixel_format=None):
     return im
 
 
-class FFmpegBetterInfosParser:
-    """Finite state ffmpeg `-i` command option file information parser.
-    Is designed to parse the output fast, in one loop. Iterates line by
-    line of the `ffmpeg -i <filename> [-f null -]` command output changing
-    the internal state of the parser.
+class FFmpegInfosParser:
+    """An (hopefully) robuste ffmpeg `-i` command option file information parser.
+    Is designed to parse the output by extracting the different blocks of informations,
+    based on the indentation, in order to create an easy to handle block tree
 
     Parameters
     ----------
@@ -371,7 +370,7 @@ class FFmpegBetterInfosParser:
 
         def __init__(self, block_line, indent_level=0):
             self.type = "unknown"
-            self.childs: List[FFmpegBetterInfosParser.InfoBlock] = []
+            self.childs: List[FFmpegInfosParser.InfoBlock] = []
             self.parent = None
             self.indent_level = indent_level
             self.head_line = block_line
@@ -591,7 +590,7 @@ class FFmpegBetterInfosParser:
                 # size, of the form 460x320 (w x h)
                 block.data["size"] = [int(num) for num in match_video_size.groups()]
         except Exception:
-            raise FFmpegBetterInfosParser.ParseDimensionError()
+            raise FFmpegInfosParser.ParseDimensionError()
 
         match_bitrate = re.search(r"(\d+) k(i?)b/s", block.head_line)
         block.data["bitrate"] = int(match_bitrate.group(1)) if match_bitrate else None
@@ -913,7 +912,7 @@ def ffmpeg_parse_infos(
         print(infos)
 
     try:
-        return FFmpegBetterInfosParser(
+        return FFmpegInfosParser(
             infos,
             filename,
             fps_source=fps_source,

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -327,505 +327,6 @@ def ffmpeg_read_image(filename, with_mask=True, pixel_format=None):
     return im
 
 
-class FFmpegInfosParser:
-    """Finite state ffmpeg `-i` command option file information parser.
-    Is designed to parse the output fast, in one loop. Iterates line by
-    line of the `ffmpeg -i <filename> [-f null -]` command output changing
-    the internal state of the parser.
-
-    Parameters
-    ----------
-
-    filename
-      Name of the file parsed, only used to raise accurate error messages.
-
-    infos
-      Information returned by FFmpeg.
-
-    fps_source
-      Indicates what source data will be preferably used to retrieve fps data.
-
-    check_duration
-      Enable or disable the parsing of the duration of the file. Useful to
-      skip the duration check, for example, for images.
-
-    decode_file
-      Indicates if the whole file has been decoded. The duration parsing strategy
-      will differ depending on this argument.
-    """
-
-    def __init__(
-        self,
-        infos,
-        filename,
-        fps_source="fps",
-        check_duration=True,
-        decode_file=False,
-    ):
-        self.infos = infos
-        self.filename = filename
-        self.check_duration = check_duration
-        self.fps_source = fps_source
-        self.duration_tag_separator = "time=" if decode_file else "Duration: "
-
-        self._reset_state()
-
-    def _reset_state(self):
-        """Reinitializes the state of the parser. Used internally at
-        initialization and at the end of the parsing process.
-        """
-        # could be 2 possible types of metadata:
-        #   - file_metadata: Metadata of the container. Here are the tags set
-        #     by the user using `-metadata` ffmpeg option
-        #   - stream_metadata: Metadata for each stream of the container.
-        self._inside_file_metadata = False
-
-        # this state is needed if `duration_tag_separator == "time="` because
-        # execution of ffmpeg decoding the whole file using `-f null -` appends
-        # to the output the blocks "Stream mapping:" and "Output:", which
-        # should be ignored
-        self._inside_output = False
-
-        # map from stream type to default stream
-        # if a default stream is not indicated, pick the first one available
-        self._default_streams = {}
-
-        # current input file, stream and chapter, which will be built at runtime
-        self._current_input_file = {"streams": []}
-        self._current_stream = None
-        self._current_chapter = None
-
-        # resulting data of the parsing process
-        self.result = {
-            "video_found": False,
-            "audio_found": False,
-            "metadata": {},
-            "inputs": [],
-        }
-
-        # keep the value of latest metadata value parsed so we can build
-        # at next lines a multiline metadata value
-        self._last_metadata_field_added = None
-
-    def parse(self):
-        """Parses the information returned by FFmpeg in stderr executing their binary
-        for a file with ``-i`` option and returns a dictionary with all data needed
-        by MoviePy.
-        """
-        # chapters by input file
-        input_chapters = []
-
-        for line in self.infos.splitlines()[1:]:
-            if (
-                self.duration_tag_separator == "time="
-                and self.check_duration
-                and "time=" in line
-            ):
-                # parse duration using file decodification
-                self.result["duration"] = self.parse_duration(line)
-            elif self._inside_output or line[0] != " ":
-                if self.duration_tag_separator == "time=" and not self._inside_output:
-                    self._inside_output = True
-                # skip lines like "At least one output file must be specified"
-            elif not self._inside_file_metadata and line.startswith("  Metadata:"):
-                # enter "  Metadata:" group
-                self._inside_file_metadata = True
-            elif line.startswith("  Duration:"):
-                # exit "  Metadata:" group
-                self._inside_file_metadata = False
-                if self.check_duration and self.duration_tag_separator == "Duration: ":
-                    self.result["duration"] = self.parse_duration(line)
-
-                # parse global bitrate (in kb/s)
-                bitrate_match = re.search(r"bitrate: (\d+) k(i?)b/s", line)
-                self.result["bitrate"] = (
-                    int(bitrate_match.group(1)) if bitrate_match else None
-                )
-
-                # parse start time (in seconds)
-                start_match = re.search(r"start: (\d+\.?\d+)", line)
-                self.result["start"] = (
-                    float(start_match.group(1)) if start_match else None
-                )
-            elif self._inside_file_metadata:
-                # file metadata line
-                field, value = self.parse_metadata_field_value(line)
-
-                # multiline metadata value parsing
-                if field == "":
-                    field = self._last_metadata_field_added
-                    value = self.result["metadata"][field] + "\n" + value
-                else:
-                    self._last_metadata_field_added = field
-                self.result["metadata"][field] = value
-            elif line.lstrip().startswith("Stream "):
-                # exit stream "    Metadata:"
-                if self._current_stream:
-                    self._current_input_file["streams"].append(self._current_stream)
-
-                # get input number, stream number, language and type
-                main_info_match = re.search(
-                    r"^Stream\s#(\d+):(\d+)(?:\[\w+\])?\(?(\w+)?\)?:\s(\w+):",
-                    line.lstrip(),
-                )
-                (
-                    input_number,
-                    stream_number,
-                    language,
-                    stream_type,
-                ) = main_info_match.groups()
-                input_number = int(input_number)
-                stream_number = int(stream_number)
-                stream_type_lower = stream_type.lower()
-
-                if language == "und":
-                    language = None
-
-                # start builiding the current stream
-                self._current_stream = {
-                    "input_number": input_number,
-                    "stream_number": stream_number,
-                    "stream_type": stream_type_lower,
-                    "language": language,
-                    "default": (stream_type_lower not in self._default_streams)
-                    and line.endswith("(default)"),
-                }
-
-                # for default streams, set their numbers globally, so it's
-                # easy to get without iterating all
-                if self._current_stream["default"]:
-                    self._default_streams[stream_type_lower] = self._current_stream
-
-                # exit chapter
-                if self._current_chapter:
-                    input_chapters[input_number].append(self._current_chapter)
-                    self._current_chapter = None
-
-                if "input_number" not in self._current_input_file:
-                    # first input file
-                    self._current_input_file["input_number"] = input_number
-                elif self._current_input_file["input_number"] != input_number:
-                    # new input file
-
-                    # include their chapters if there are for this input file
-                    if len(input_chapters) >= input_number + 1:
-                        self._current_input_file["chapters"] = input_chapters[
-                            input_number
-                        ]
-
-                    # add new input file to result
-                    self.result["inputs"].append(self._current_input_file)
-                    self._current_input_file = {"input_number": input_number}
-
-                # parse relevant data by stream type
-                try:
-                    stream_data = self.parse_data_by_stream_type(stream_type, line)
-                except NotImplementedError as exc:
-                    warnings.warn(
-                        f"{str(exc)}\nffmpeg output: \n\n{self.infos}", UserWarning
-                    )
-                else:
-                    self._current_stream.update(stream_data)
-            elif line.startswith("    Metadata:"):
-                # enter group "    Metadata:"
-                continue
-            elif self._current_stream:
-                # stream metadata line
-                if "metadata" not in self._current_stream:
-                    self._current_stream["metadata"] = {}
-
-                field, value = self.parse_metadata_field_value(line)
-
-                if self._current_stream["stream_type"] == "video":
-                    field, value = self.video_metadata_type_casting(field, value)
-                    # ffmpeg 7 now use displaymatrix instead of rotate
-                    if field == "rotate":
-                        self.result["video_rotation"] = value
-                    elif field == "displaymatrix":
-                        self.result["video_rotation"] = value
-
-                # multiline metadata value parsing
-                if field == "":
-                    field = self._last_metadata_field_added
-                    value = self._current_stream["metadata"][field] + "\n" + value
-                else:
-                    self._last_metadata_field_added = field
-                self._current_stream["metadata"][field] = value
-            elif line.startswith("    Chapter"):
-                # Chapter data line
-                if self._current_chapter:
-                    # there is a previews chapter?
-                    if len(input_chapters) < self._current_chapter["input_number"] + 1:
-                        input_chapters.append([])
-                    # include in the chapters by input matrix
-                    input_chapters[self._current_chapter["input_number"]].append(
-                        self._current_chapter
-                    )
-
-                # extract chapter data
-                chapter_data_match = re.search(
-                    r"^    Chapter #(\d+):(\d+): start (\d+\.?\d+?), end (\d+\.?\d+?)",
-                    line,
-                )
-                input_number, chapter_number, start, end = chapter_data_match.groups()
-
-                # start building the chapter
-                self._current_chapter = {
-                    "input_number": int(input_number),
-                    "chapter_number": int(chapter_number),
-                    "start": float(start),
-                    "end": float(end),
-                }
-            elif self._current_chapter:
-                # inside chapter metadata
-                if "metadata" not in self._current_chapter:
-                    self._current_chapter["metadata"] = {}
-                field, value = self.parse_metadata_field_value(line)
-
-                # multiline metadata value parsing
-                if field == "":
-                    field = self._last_metadata_field_added
-                    value = self._current_chapter["metadata"][field] + "\n" + value
-                else:
-                    self._last_metadata_field_added = field
-                self._current_chapter["metadata"][field] = value
-
-        # last input file, must be included in the result
-        if self._current_input_file:
-            self._current_input_file["streams"].append(self._current_stream)
-            # include their chapters, if there are any
-            if (
-                "input_number" in self._current_input_file
-                and len(input_chapters) == self._current_input_file["input_number"] + 1
-            ):
-                self._current_input_file["chapters"] = input_chapters[
-                    self._current_input_file["input_number"]
-                ]
-            self.result["inputs"].append(self._current_input_file)
-
-        # set any missing default automatically
-        for stream in self._current_input_file["streams"]:
-            if stream["stream_type"] not in self._default_streams:
-                self._default_streams[stream["stream_type"]] = stream
-                stream["default"] = True
-
-        # set some global info based on the defaults
-        for stream_type_lower, stream_data in self._default_streams.items():
-            self.result[f"default_{stream_type_lower}_input_number"] = stream_data[
-                "input_number"
-            ]
-            self.result[f"default_{stream_type_lower}_stream_number"] = stream_data[
-                "stream_number"
-            ]
-
-            if stream_type_lower == "audio":
-                self.result["audio_found"] = True
-                self.result["audio_fps"] = stream_data["fps"]
-                self.result["audio_bitrate"] = stream_data["bitrate"]
-            elif stream_type_lower == "video":
-                self.result["video_found"] = True
-                self.result["video_size"] = stream_data.get("size", None)
-                self.result["video_bitrate"] = stream_data.get("bitrate", None)
-                self.result["video_fps"] = stream_data["fps"]
-                self.result["video_codec_name"] = stream_data.get("codec_name", None)
-                self.result["video_profile"] = stream_data.get("profile", None)
-
-        # some video duration utilities
-        if self.result["video_found"] and self.check_duration:
-            self.result["video_duration"] = self.result["duration"]
-            self.result["video_n_frames"] = int(
-                self.result["duration"] * self.result.get("video_fps", 0)
-            )
-        else:
-            self.result["video_n_frames"] = 0
-            self.result["video_duration"] = 0.0
-        # We could have also recomputed duration from the number of frames, as follows:
-        # >>> result['video_duration'] = result['video_n_frames'] / result['video_fps']
-
-        # not default audio found, assume first audio stream is the default
-        if self.result["audio_found"] and not self.result.get("audio_bitrate"):
-            self.result["audio_bitrate"] = None
-            for streams_input in self.result["inputs"]:
-                for stream in streams_input["streams"]:
-                    if stream["stream_type"] == "audio" and stream.get("bitrate"):
-                        self.result["audio_bitrate"] = stream["bitrate"]
-                        break
-
-                if self.result["audio_bitrate"] is not None:
-                    break
-
-        result = self.result
-
-        # reset state of the parser
-        self._reset_state()
-
-        return result
-
-    def parse_data_by_stream_type(self, stream_type, line):
-        """Parses data from "Stream ... {stream_type}" line."""
-        try:
-            return {
-                "Audio": self.parse_audio_stream_data,
-                "Video": self.parse_video_stream_data,
-                "Data": lambda _line: {},
-            }[stream_type](line)
-        except KeyError:
-            raise NotImplementedError(
-                f"{stream_type} stream parsing is not supported by moviepy and"
-                " will be ignored"
-            )
-
-    def parse_audio_stream_data(self, line):
-        """Parses data from "Stream ... Audio" line."""
-        stream_data = {}
-        try:
-            stream_data["fps"] = int(re.search(r" (\d+) Hz", line).group(1))
-        except (AttributeError, ValueError):
-            # AttributeError: 'NoneType' object has no attribute 'group'
-            # ValueError: invalid literal for int() with base 10: '<string>'
-            stream_data["fps"] = "unknown"
-        match_audio_bitrate = re.search(r"(\d+) k(i?)b/s", line)
-        stream_data["bitrate"] = (
-            int(match_audio_bitrate.group(1)) if match_audio_bitrate else None
-        )
-        return stream_data
-
-    def parse_video_stream_data(self, line):
-        """Parses data from "Stream ... Video" line."""
-        stream_data = {}
-
-        try:
-            match_video_size = re.search(r" (\d+)x(\d+)[,\s]", line)
-            if match_video_size:
-                # size, of the form 460x320 (w x h)
-                stream_data["size"] = [int(num) for num in match_video_size.groups()]
-        except Exception:
-            raise IOError(
-                (
-                    "MoviePy error: failed to read video dimensions in"
-                    " file '%s'.\nHere are the file infos returned by"
-                    "ffmpeg:\n\n%s"
-                )
-                % (self.filename, self.infos)
-            )
-
-        match_bitrate = re.search(r"(\d+) k(i?)b/s", line)
-        stream_data["bitrate"] = int(match_bitrate.group(1)) if match_bitrate else None
-
-        # Get the frame rate. Sometimes it's 'tbr', sometimes 'fps', sometimes
-        # tbc, and sometimes tbc/2...
-        # Current policy: Trust fps first, then tbr unless fps_source is
-        # specified as 'tbr' in which case try tbr then fps
-
-        # If result is near from x*1000/1001 where x is 23,24,25,50,
-        # replace by x*1000/1001 (very common case for the fps).
-
-        if self.fps_source == "fps":
-            try:
-                fps = self.parse_fps(line)
-            except (AttributeError, ValueError):
-                fps = self.parse_tbr(line)
-        elif self.fps_source == "tbr":
-            try:
-                fps = self.parse_tbr(line)
-            except (AttributeError, ValueError):
-                fps = self.parse_fps(line)
-        else:
-            raise ValueError(
-                ("fps source '%s' not supported parsing the video '%s'")
-                % (self.fps_source, self.filename)
-            )
-
-        # It is known that a fps of 24 is often written as 24000/1001
-        # but then ffmpeg nicely rounds it to 23.98, which we hate.
-        coef = 1000.0 / 1001.0
-        for x in [23, 24, 25, 30, 50]:
-            if (fps != x) and abs(fps - x * coef) < 0.01:
-                fps = x * coef
-        stream_data["fps"] = fps
-
-        # Try to extract video codec and profile
-        main_info_match = re.search(
-            r"Video:\s(\w+)?\s?(\([^)]+\))?",
-            line.lstrip(),
-        )
-        if main_info_match is not None:
-            (codec_name, profile) = main_info_match.groups()
-            stream_data["codec_name"] = codec_name
-            stream_data["profile"] = profile
-
-        return stream_data
-
-    def parse_fps(self, line):
-        """Parses number of FPS from a line of the ``ffmpeg -i`` command output."""
-        return float(re.search(r" (\d+.?\d*) fps", line).group(1))
-
-    def parse_tbr(self, line):
-        """Parses number of TBS from a line of the ``ffmpeg -i`` command output."""
-        s_tbr = re.search(r" (\d+.?\d*k?) tbr", line).group(1)
-
-        # Sometimes comes as e.g. 12k. We need to replace that with 12000.
-        if s_tbr[-1] == "k":
-            tbr = float(s_tbr[:-1]) * 1000
-        else:
-            tbr = float(s_tbr)
-        return tbr
-
-    def parse_duration(self, line):
-        """Parse the duration from the line that outputs the duration of
-        the container.
-        """
-        try:
-            time_raw_string = line.split(self.duration_tag_separator)[-1]
-            match_duration = re.search(
-                r"([0-9][0-9]:[0-9][0-9]:[0-9][0-9].[0-9][0-9])",
-                time_raw_string,
-            )
-            if match_duration is None:
-                raise VideoCorruptedError(
-                    f"Could not parse duration from {time_raw_string!r}"
-                )
-            return convert_to_seconds(match_duration.group(1))
-        except VideoCorruptedError:
-            raise
-        except Exception:
-            raise IOError(
-                (
-                    "MoviePy error: failed to read the duration of file '%s'.\n"
-                    "Here are the file infos returned by ffmpeg:\n\n%s"
-                )
-                % (self.filename, self.infos)
-            )
-
-    def parse_metadata_field_value(
-        self,
-        line,
-    ):
-        """Returns a tuple with a metadata field-value pair given a ffmpeg `-i`
-        command output line.
-        """
-        info = line.split(":", 1)
-        if len(info) == 2:
-            raw_field, raw_value = info
-            return (raw_field.strip(" "), raw_value.strip(" "))
-        else:
-            return ("", "")
-
-    def video_metadata_type_casting(self, field, value):
-        """Cast needed video metadata fields to other types than the default str."""
-        if field == "rotate":
-            return (field, float(value))
-
-        elif field == "displaymatrix":
-            match = re.search(r"[-+]?\d+(\.\d+)?", value)
-            if match:
-                # We must multiply by -1 because displaymatrix return info
-                # about how to rotate to show video, not about video rotation
-                return (field, float(match.group()) * -1)
-
-        return (field, value)
-
-
 class FFmpegBetterInfosParser:
     """Finite state ffmpeg `-i` command option file information parser.
     Is designed to parse the output fast, in one loop. Iterates line by
@@ -903,6 +404,8 @@ class FFmpegBetterInfosParser:
             "video_found": False,
             "audio_found": False,
             "metadata": {},
+            "blocks": None,
+            "inputs": {},
         }
 
     def _extract_block(self, index, start_indent, block: InfoBlock = None):
@@ -942,7 +445,7 @@ class FFmpegBetterInfosParser:
 
                 # New block
                 if line.lstrip().startswith(
-                    ("Metadata", "Stream", "Side data", "Chapter")
+                    ("Metadata", "Stream", "Side data", "Chapter", "Chapters")
                 ):
                     (child_block, index) = self._extract_block(
                         index, indent_level, self.InfoBlock(line.lstrip(), indent_level)
@@ -969,6 +472,8 @@ class FFmpegBetterInfosParser:
             self._parse_stream(block)
         elif line.startswith("Side data:"):
             block.type = "side_data"
+        elif line.startswith("Chapters"):
+            block.type = "chapters"
         elif line.startswith("Chapter"):
             block.type = "chapter"
             self._parse_chapter(block)
@@ -1144,16 +649,16 @@ class FFmpegBetterInfosParser:
             tbr = float(s_tbr)
         return tbr
 
-    def _parse_chapter(self, block):
+    def _parse_chapter(self, block: InfoBlock):
         # extract chapter data
         chapter_data_match = re.search(
             r"^Chapter #(\d+):(\d+): start (\d+\.?\d+?), end (\d+\.?\d+?)",
-            block.head_line.lstrip(),
+            block.head_line.strip(),
         )
         input_number, chapter_number, start, end = chapter_data_match.groups()
 
         # start building the chapter
-        self.data = {
+        block.data = {
             "input_number": int(input_number),
             "chapter_number": int(chapter_number),
             "start": float(start),
@@ -1211,6 +716,40 @@ class FFmpegBetterInfosParser:
             self.result["video_n_frames"] = 0
             self.result["video_duration"] = 0.0
 
+        self._populate_inputs(root=root)
+
+    def _populate_inputs(self, root: InfoBlock):
+        """Forge inputs for compatibility with old versions, not used anywhere though"""
+        for child in root.childs:
+            if child.type == "stream":
+                if "streams" not in self.result["inputs"]:
+                    self.result["inputs"]["streams"] = []
+
+                stream = child.data
+
+                for stream_child in child.childs:
+                    if stream_child.type == "metadata":
+                        stream["metadata"] = stream_child.data
+                    elif stream_child.type == "side_data":
+                        stream["side_data"] = stream_child.data
+
+                self.result["inputs"]["streams"].append(stream)
+
+            elif child.type == "chapters":
+                for chapter in child.childs:
+                    if "chapters" not in self.result["inputs"]:
+                        self.result["inputs"]["chapters"] = []
+
+                    chap = chapter.data
+
+                    for chapter_child in chapter.childs:
+                        if chapter_child.type == "metadata":
+                            chap["metadata"] = chapter_child.data
+                        elif chapter_child.type == "side_data":
+                            chap["side_data"] = chapter_child.data
+
+                    self.result["inputs"]["chapters"].append(chap)
+
     def parse(self):
         """Parses the information returned by FFmpeg in stderr executing their binary
         for a file with ``-i`` option and returns a dictionary with all data needed
@@ -1227,6 +766,7 @@ class FFmpegBetterInfosParser:
             self._extract_block(first_input, 0, root_block)
             self._parse_blocks(root_block)
             self.blocks = root_block
+            self.result["blocks"] = root_block
             return self.result
         except self.ParseDimensionError:
             raise IOError(

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -977,7 +977,11 @@ class FFmpegBetterInfosParser:
         """Parse a standard line to return (field, value) with typecasting
         when needed (rotate, displaymatrix)
         """
-        specials = ("Ambient Viewing Environment,", "Content Light Level Metadata,")
+        specials = (
+            "Ambient Viewing Environment,",
+            "Content Light Level Metadata,",
+            "Mastering Display Metadata,",
+        )
         line = line.strip()
         if line.startswith(specials):
             infos = line.split(",", 1)

--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -4,7 +4,6 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Union
 
 from moviepy.config import FFMPEG_BINARY, FFPLAY_BINARY
 from moviepy.decorators import convert_parameter_to_seconds, convert_path_to_string
@@ -213,7 +212,8 @@ def ffmpeg_stabilize_video(
     subprocess_call(cmd, logger=logger)
 
 
-def ffmpeg_copy(input_file: Union[str, Path], output_file: Union[str, Path]):
+@convert_path_to_string(("inputfile", "outputfile", "output_dir"))
+def ffmpeg_copy(input_file, output_file):
     """
     Re-mix a video file using ffmpeg.
     This may fix issues with corrupted video file.
@@ -234,9 +234,6 @@ def ffmpeg_copy(input_file: Union[str, Path], output_file: Union[str, Path]):
     # Check if the input file exists
     if not input_path.exists():
         raise FileNotFoundError(f"Input file '{input_file}' not found.")
-
-    if output_path.exists():
-        raise FileExistsError(f"Output file '{output_file}' already exists.")
 
     try:
         # Construct the ffmpeg command

--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -242,6 +242,7 @@ def ffmpeg_copy(input_file: Union[str, Path], output_file: Union[str, Path]):
         # Construct the ffmpeg command
         command = [
             FFMPEG_BINARY,
+            "-y",
             "-i",
             str(input_path),
             "-c",

--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -212,7 +212,7 @@ def ffmpeg_stabilize_video(
     subprocess_call(cmd, logger=logger)
 
 
-@convert_path_to_string(("inputfile", "outputfile", "output_dir"))
+@convert_path_to_string(("input_file", "output_file"))
 def ffmpeg_copy(input_file, output_file):
     """
     Re-mix a video file using ffmpeg.

--- a/tests/test_VideoFileClip.py
+++ b/tests/test_VideoFileClip.py
@@ -8,8 +8,8 @@ import pytest
 
 from moviepy.video.compositing.CompositeVideoClip import clips_array
 from moviepy.video.io.errors import VideoCorruptedError
+from moviepy.video.io.ffmpeg_tools import ffmpeg_copy
 from moviepy.video.io.VideoFileClip import VideoFileClip
-from moviepy.video.tools.ffmpeg_copy import ffmpeg_copy
 from moviepy.video.VideoClip import ColorClip
 
 

--- a/tests/test_ffmpeg_reader.py
+++ b/tests/test_ffmpeg_reader.py
@@ -40,7 +40,6 @@ def test_ffmpeg_parse_infos():
     d = ffmpeg_parse_infos("media/crunching.mp3")
     assert d["audio_found"]
     assert d["audio_fps"] == 48000
-    print(d)
     assert d["metadata"]["artist"] == "SoundJay.com Sound Effects"
 
     d = ffmpeg_parse_infos("media/sintel_with_14_chapters.mp4")
@@ -78,7 +77,6 @@ def test_ffmpeg_parse_infos_no_default_stream(util):
         subprocess.check_call(cmd, stderr=stderr)
 
     d = ffmpeg_parse_infos(wmv_filepath)
-    print(d)
 
     for key in (
         "default_video_stream_number",

--- a/tests/test_ffmpeg_reader.py
+++ b/tests/test_ffmpeg_reader.py
@@ -14,7 +14,7 @@ from moviepy.tools import ffmpeg_escape_filename
 from moviepy.video.compositing.CompositeVideoClip import clips_array
 from moviepy.video.io.ffmpeg_reader import (
     FFMPEG_VideoReader,
-    FFmpegInfosParser,
+    FFmpegBetterInfosParser,
     ffmpeg_parse_infos,
 )
 from moviepy.video.io.ffmpeg_tools import ffmpeg_version
@@ -117,7 +117,7 @@ def test_ffmpeg_parse_infos_decode_file(decode_file, expected_duration):
     assert len(d["inputs"]) == 1
 
     # check streams
-    streams = d["inputs"][0]["streams"]
+    streams = d["inputs"]["streams"]
     assert len(streams) == 2
     assert streams[0]["stream_type"] == "video"
     assert streams[0]["stream_number"] == 0
@@ -173,10 +173,10 @@ def test_ffmpeg_parse_infos_multiple_audio_streams(util, mono_wave):
 
     # number of inputs and streams
     assert len(d["inputs"]) == 1
-    assert len(d["inputs"][0]["streams"]) == 2
+    assert len(d["inputs"]["streams"]) == 2
 
-    default_stream = d["inputs"][0]["streams"][0]
-    ignored_stream = d["inputs"][0]["streams"][1]
+    default_stream = d["inputs"]["streams"][0]
+    ignored_stream = d["inputs"]["streams"][1]
 
     # default, only the first
     assert default_stream["default"]
@@ -269,7 +269,7 @@ def test_ffmpeg_parse_infos_metadata(util, mono_wave):
 
     # assert streams metadata
     streams = {"audio": None, "video": None}
-    for stream in d["inputs"][0]["streams"]:
+    for stream in d["inputs"]["streams"]:
         streams[stream["stream_type"]] = stream
 
     for stream_type, stream in streams.items():
@@ -289,7 +289,7 @@ def test_ffmpeg_parse_infos_chapters():
     """Check that `ffmpeg_parse_infos` can parse chapters with their metadata."""
     d = ffmpeg_parse_infos("media/sintel_with_14_chapters.mp4")
 
-    chapters = d["inputs"][0]["chapters"]
+    chapters = d["inputs"]["chapters"]
 
     num_chapters_expected = 14
 
@@ -315,7 +315,7 @@ def test_ffmpeg_parse_infos_metadata_with_attached_pic():
     assert d["audio_fps"] == 44100
 
     assert len(d["inputs"]) == 1
-    streams = d["inputs"][0]["streams"]
+    streams = d["inputs"]["streams"]
     assert len(streams) == 2
     assert streams[0]["stream_type"] == "audio"
     assert streams[1]["stream_type"] == "video"
@@ -408,7 +408,7 @@ def test_ffmpeg_parse_infos_multiline_metadata():
 At least one output file must be specified
 """
 
-    d = FFmpegInfosParser(infos, "foo.mkv").parse()
+    d = FFmpegBetterInfosParser(infos, "foo.mkv").parse()
 
     # container data
     assert d["audio_bitrate"] == 64
@@ -472,7 +472,7 @@ stDim:unit="pixel"/>
     # streams
     assert len(d["inputs"]) == 1
 
-    streams = d["inputs"][0]["streams"]
+    streams = d["inputs"]["streams"]
     assert len(streams) == 3
 
     # video stream
@@ -522,7 +522,7 @@ def test_not_default_audio_stream_audio_bitrate():
     Stream #0:1: Audio: aac (LC) (...), 48000 Hz, stereo, fltp, 139 kb/s
 """
 
-    d = FFmpegInfosParser(infos, "foo.avi").parse()
+    d = FFmpegBetterInfosParser(infos, "foo.avi").parse()
     assert d["audio_bitrate"] == 139
 
 
@@ -544,10 +544,10 @@ def test_stream_deidentation_not_raises_error():
       vendor_id       : [0][0][0][0]
 At least one output file must be specified"""
 
-    d = FFmpegInfosParser(infos, "clip.mp4").parse()
+    d = FFmpegBetterInfosParser(infos, "clip.mp4").parse()
 
     assert d
-    assert len(d["inputs"][0]["streams"]) == 1
+    assert len(d["inputs"]["streams"]) == 1
 
 
 def test_stream_square_brackets():
@@ -558,12 +558,12 @@ Input #0, mpeg, from 'clip.mp4':
     Stream #0:1[0x1c0]: Audio: mp2, 0 channels, s16p
 At least one output file must be specified"""
 
-    d = FFmpegInfosParser(infos, "clip.mp4").parse()
+    d = FFmpegBetterInfosParser(infos, "clip.mp4").parse()
 
     assert d
-    assert len(d["inputs"][0]["streams"]) == 2
-    assert d["inputs"][0]["streams"][0]["language"] is None
-    assert d["inputs"][0]["streams"][1]["language"] is None
+    assert len(d["inputs"]["streams"]) == 2
+    assert d["inputs"]["streams"][0]["language"] is None
+    assert d["inputs"]["streams"][1]["language"] is None
 
 
 def test_stream_square_brackets_and_language():
@@ -574,12 +574,12 @@ Input #0, mpeg, from 'clip.mp4':
     Stream #0:1[0x1c0](und): Audio: mp2, 0 channels, s16p
 At least one output file must be specified"""
 
-    d = FFmpegInfosParser(infos, "clip.mp4").parse()
+    d = FFmpegBetterInfosParser(infos, "clip.mp4").parse()
 
     assert d
-    assert len(d["inputs"][0]["streams"]) == 2
-    assert d["inputs"][0]["streams"][0]["language"] == "eng"
-    assert d["inputs"][0]["streams"][1]["language"] is None
+    assert len(d["inputs"]["streams"]) == 2
+    assert d["inputs"]["streams"][0]["language"] == "eng"
+    assert d["inputs"]["streams"][1]["language"] is None
 
 
 def test_stream_missing_audio_bitrate():
@@ -590,10 +590,10 @@ Input #0, mpeg, from 'clip.mp4':
     Stream #0:1[0x1c0]: Audio: mp2, 0 channels, s16p
 At least one output file must be specified"""
 
-    d = FFmpegInfosParser(infos, "clip.mp4").parse()
+    d = FFmpegBetterInfosParser(infos, "clip.mp4").parse()
 
     assert d
-    assert len(d["inputs"][0]["streams"]) == 2
+    assert len(d["inputs"]["streams"]) == 2
     assert d["audio_found"]
     assert d["audio_bitrate"] is None
 

--- a/tests/test_ffmpeg_reader.py
+++ b/tests/test_ffmpeg_reader.py
@@ -14,7 +14,7 @@ from moviepy.tools import ffmpeg_escape_filename
 from moviepy.video.compositing.CompositeVideoClip import clips_array
 from moviepy.video.io.ffmpeg_reader import (
     FFMPEG_VideoReader,
-    FFmpegBetterInfosParser,
+    FFmpegInfosParser,
     ffmpeg_parse_infos,
 )
 from moviepy.video.io.ffmpeg_tools import ffmpeg_version
@@ -410,7 +410,7 @@ def test_ffmpeg_parse_infos_multiline_metadata():
 At least one output file must be specified
 """
 
-    d = FFmpegBetterInfosParser(infos, "foo.mkv").parse()
+    d = FFmpegInfosParser(infos, "foo.mkv").parse()
 
     # container data
     assert d["audio_bitrate"] == 64
@@ -524,7 +524,7 @@ def test_not_default_audio_stream_audio_bitrate():
     Stream #0:1: Audio: aac (LC) (...), 48000 Hz, stereo, fltp, 139 kb/s
 """
 
-    d = FFmpegBetterInfosParser(infos, "foo.avi").parse()
+    d = FFmpegInfosParser(infos, "foo.avi").parse()
     assert d["audio_bitrate"] == 139
 
 
@@ -546,7 +546,7 @@ def test_stream_deidentation_not_raises_error():
       vendor_id       : [0][0][0][0]
 At least one output file must be specified"""
 
-    d = FFmpegBetterInfosParser(infos, "clip.mp4").parse()
+    d = FFmpegInfosParser(infos, "clip.mp4").parse()
 
     assert d
     assert len(d["inputs"]["streams"]) == 1
@@ -560,7 +560,7 @@ Input #0, mpeg, from 'clip.mp4':
     Stream #0:1[0x1c0]: Audio: mp2, 0 channels, s16p
 At least one output file must be specified"""
 
-    d = FFmpegBetterInfosParser(infos, "clip.mp4").parse()
+    d = FFmpegInfosParser(infos, "clip.mp4").parse()
 
     assert d
     assert len(d["inputs"]["streams"]) == 2
@@ -576,7 +576,7 @@ Input #0, mpeg, from 'clip.mp4':
     Stream #0:1[0x1c0](und): Audio: mp2, 0 channels, s16p
 At least one output file must be specified"""
 
-    d = FFmpegBetterInfosParser(infos, "clip.mp4").parse()
+    d = FFmpegInfosParser(infos, "clip.mp4").parse()
 
     assert d
     assert len(d["inputs"]["streams"]) == 2
@@ -592,7 +592,7 @@ Input #0, mpeg, from 'clip.mp4':
     Stream #0:1[0x1c0]: Audio: mp2, 0 channels, s16p
 At least one output file must be specified"""
 
-    d = FFmpegBetterInfosParser(infos, "clip.mp4").parse()
+    d = FFmpegInfosParser(infos, "clip.mp4").parse()
 
     assert d
     assert len(d["inputs"]["streams"]) == 2

--- a/tests/test_ffmpeg_reader.py
+++ b/tests/test_ffmpeg_reader.py
@@ -40,6 +40,7 @@ def test_ffmpeg_parse_infos():
     d = ffmpeg_parse_infos("media/crunching.mp3")
     assert d["audio_found"]
     assert d["audio_fps"] == 48000
+    print(d)
     assert d["metadata"]["artist"] == "SoundJay.com Sound Effects"
 
     d = ffmpeg_parse_infos("media/sintel_with_14_chapters.mp4")
@@ -77,6 +78,7 @@ def test_ffmpeg_parse_infos_no_default_stream(util):
         subprocess.check_call(cmd, stderr=stderr)
 
     d = ffmpeg_parse_infos(wmv_filepath)
+    print(d)
 
     for key in (
         "default_video_stream_number",
@@ -119,14 +121,14 @@ def test_ffmpeg_parse_infos_decode_file(decode_file, expected_duration):
     # check streams
     streams = d["inputs"]["streams"]
     assert len(streams) == 2
-    assert streams[0]["stream_type"] == "video"
+    assert streams[0]["stream_type_lower"] == "video"
     assert streams[0]["stream_number"] == 0
     assert streams[0]["fps"] == 24
     assert streams[0]["size"] == [1280, 720]
     assert streams[0]["default"] is True
     assert streams[0]["language"] is None
 
-    assert streams[1]["stream_type"] == "audio"
+    assert streams[1]["stream_type_lower"] == "audio"
     assert streams[1]["stream_number"] == 1
     assert streams[1]["fps"] == 44100
     assert streams[1]["default"] is True
@@ -189,8 +191,8 @@ def test_ffmpeg_parse_infos_multiple_audio_streams(util, mono_wave):
     assert ignored_stream["input_number"] == 0
 
     # stream type
-    assert default_stream["stream_type"] == "audio"
-    assert ignored_stream["stream_type"] == "audio"
+    assert default_stream["stream_type_lower"] == "audio"
+    assert ignored_stream["stream_type_lower"] == "audio"
 
     # cleanup
     for filepath in [clip_440_filepath, clip_880_filepath, multiple_streams_filepath]:
@@ -270,7 +272,7 @@ def test_ffmpeg_parse_infos_metadata(util, mono_wave):
     # assert streams metadata
     streams = {"audio": None, "video": None}
     for stream in d["inputs"]["streams"]:
-        streams[stream["stream_type"]] = stream
+        streams[stream["stream_type_lower"]] = stream
 
     for stream_type, stream in streams.items():
         for field, value in metadata[stream_type].items():
@@ -317,8 +319,8 @@ def test_ffmpeg_parse_infos_metadata_with_attached_pic():
     assert len(d["inputs"]) == 1
     streams = d["inputs"]["streams"]
     assert len(streams) == 2
-    assert streams[0]["stream_type"] == "audio"
-    assert streams[1]["stream_type"] == "video"
+    assert streams[0]["stream_type_lower"] == "audio"
+    assert streams[1]["stream_type_lower"] == "video"
 
     assert len(d["metadata"].keys()) == 7
 
@@ -386,20 +388,20 @@ def test_ffmpeg_parse_infos_multiline_metadata():
                     :
                     : <?xpacket end="w"?>
   Duration: 00:02:10.67, start: 0.000000, bitrate: 26287 kb/s
-    Stream #0:0(eng): Video: mjpeg 768x576 26213 kb/s, 24 fps, 24 tbr (default)
+  Stream #0:0(eng): Video: mjpeg 768x576 26213 kb/s, 24 fps, 24 tbr (default)
     Metadata:
       creation_time   : 2015-09-14 14:57:32
       handler_name    : Foo
                       : Bar
       encoder         : Photo - JPEG
       timecode        : 00:00:00:00
-    Stream #0:1(eng): Audio: aac (mp4a / 0x6), 44100 Hz, mono, fltp, 64 kb/s (default)
+  Stream #0:1(eng): Audio: aac (mp4a / 0x6), 44100 Hz, mono, fltp, 64 kb/s (default)
     Metadata:
       creation_time   : 2015-09-14 14:57:33
       handler_name    : Bar
                       : Foo
       timecode        : 00:00:00:00
-    Stream #0:2(eng): Data: none (tmcd / 0x64636D74) (default)
+  Stream #0:2(eng): Data: none (tmcd / 0x64636D74) (default)
     Metadata:
       creation_time   : 2015-09-14 14:58:24
       handler_name    : Baz
@@ -481,7 +483,7 @@ stDim:unit="pixel"/>
     assert streams[0]["input_number"] == 0
     assert streams[0]["language"] == "eng"
     assert streams[0]["stream_number"] == 0
-    assert streams[0]["stream_type"] == "video"
+    assert streams[0]["stream_type_lower"] == "video"
     assert streams[0]["size"] == [768, 576]
 
     assert streams[0]["metadata"]["creation_time"] == "2015-09-14 14:57:32"
@@ -495,7 +497,7 @@ stDim:unit="pixel"/>
     assert streams[1]["input_number"] == 0
     assert streams[1]["language"] == "eng"
     assert streams[1]["stream_number"] == 1
-    assert streams[1]["stream_type"] == "audio"
+    assert streams[1]["stream_type_lower"] == "audio"
 
     assert streams[1]["metadata"]["creation_time"] == "2015-09-14 14:57:33"
     assert streams[1]["metadata"]["timecode"] == "00:00:00:00"
@@ -506,7 +508,7 @@ stDim:unit="pixel"/>
     assert streams[2]["input_number"] == 0
     assert streams[2]["language"] == "eng"
     assert streams[2]["stream_number"] == 2
-    assert streams[2]["stream_type"] == "data"
+    assert streams[2]["stream_type_lower"] == "data"
 
     assert streams[2]["metadata"]["creation_time"] == "2015-09-14 14:58:24"
     assert streams[2]["metadata"]["timecode"] == "00:00:00:00"

--- a/tests/test_ffmpeg_reader.py
+++ b/tests/test_ffmpeg_reader.py
@@ -833,5 +833,65 @@ def test_frame_seek():
     assert not np.array_equal(frame, frame2)
 
 
+def test_side_data():
+    infos = """Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '/home/ajani/Téléchargements/10CAE6A8-1A7A-488F-8DDD-691F0242A5BD_L0_001_1748075354.671342_o_IMG_1977.MOV':
+  Metadata:
+    major_brand     : qt  
+    minor_version   : 0
+    compatible_brands: qt  
+    creation_time   : 2025-05-24T08:27:14.000000Z
+    com.apple.quicktime.location.accuracy.horizontal: 15.257182
+    com.apple.quicktime.full-frame-rate-playback-intent: 0
+    com.apple.quicktime.location.ISO6709: +37.8187+127.0583+097.529/
+    com.apple.quicktime.make: Apple
+    com.apple.quicktime.model: iPhone 14
+    com.apple.quicktime.software: 18.3.2
+    com.apple.quicktime.creationdate: 2025-05-24T17:27:14+0900
+  Duration: 00:00:16.10, start: 0.000000, bitrate: 8764 kb/s
+  Stream #0:0(und): Video: hevc (Main 10) (hvc1 / 0x31637668), yuv420p10le(tv, bt2020nc/bt2020/arib-std-b67), 1920x1080, 8540 kb/s, 30 fps, 30 tbr, 600 tbn, 600 tbc (default)
+    Metadata:
+      rotate          : 90
+      creation_time   : 2025-05-24T08:27:14.000000Z
+      handler_name    : Core Media Video
+      vendor_id       : [0][0][0][0]
+      encoder         : HEVC
+    Side data:
+      DOVI configuration record: version: 1.0, profile: 8, level: 4, rpu flag: 1, el flag: 0, bl flag: 1, compatibility id: 4
+      displaymatrix: rotation of -90.00 degrees
+  Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 157 kb/s (default)
+    Metadata:
+      creation_time   : 2025-05-24T08:27:14.000000Z
+      handler_name    : Core Media Audio
+      vendor_id       : [0][0][0][0]
+  Stream #0:2(und): Data: none (mebx / 0x7862656D), 0 kb/s (default)
+    Metadata:
+      creation_time   : 2025-05-24T08:27:14.000000Z
+      handler_name    : Core Media Metadata
+  Stream #0:3(und): Data: none (mebx / 0x7862656D), 0 kb/s (default)
+    Metadata:
+      creation_time   : 2025-05-24T08:27:14.000000Z
+      handler_name    : Core Media Metadata
+  Stream #0:4(und): Data: none (mebx / 0x7862656D), 42 kb/s (default)
+    Metadata:
+      creation_time   : 2025-05-24T08:27:14.000000Z
+      handler_name    : Core Media Metadata
+  Stream #0:5(und): Data: none (mebx / 0x7862656D), 2 kb/s (default)
+    Metadata:
+      creation_time   : 2025-05-24T08:27:14.000000Z
+      handler_name    : Core Media Metadata
+  Stream #0:6(und): Data: none (mebx / 0x7862656D), 0 kb/s (default)
+    Metadata:
+      creation_time   : 2025-05-24T08:27:14.000000Z
+      handler_name    : Core Media Metadata
+"""
+
+    d = FFmpegInfosParser(infos, "foo.mov").parse()
+    assert d["blocks"].childs[1].childs[1].type == "side_data"
+    assert (
+        d["blocks"].childs[1].childs[1].data["DOVI configuration record"]
+        == "version: 1.0, profile: 8, level: 4, rpu flag: 1, el flag: 0, bl flag: 1, compatibility id: 4"
+    )
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Flake8 max line length settings is redundant with black default behaviour of reformatting to be 88 chars long when possible.
Flake8 blindly forces lines to be 79 chars max, even for comments or strings, leading to cumbersome and mostly useless tricks to pass the test. This does not improve code quality and cost many hours of meaningless works, lets just remove it.

79 chars max should be a metric for code, not for comments or statics strings.