### PR TITLE
Fixed_ArchLinux_preview_not_working

### DIFF
--- a/moviepy/video/io/ffmpeg_tools.py
+++ b/moviepy/video/io/ffmpeg_tools.py
@@ -328,5 +328,8 @@ def ffplay_version():
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     # Extract the version number from the first line of output
     full_version = result.stdout.splitlines()[0].split()[2]
+    #On Arch linux ffmpeg versions start with n, then the version number, this makes sure that no errors occur.
+    if full_version.startswith("n"):
+        full_version = full_version[1:]
     numeric_version = re.match(r"^[0-9.]+", full_version).group(0)
     return (full_version, numeric_version)


### PR DESCRIPTION
On Arch linux moviepy.video.io.ffmpeg_tools.tools.ffplay_versions() always returned an error - this made it so that the preview function of clips wasn't working. On arch ffmpeg versions start with an "n" and then the version number. I have fixed this, now it works. This bug only occured on arch linux as far as I can tell.

- [YES ] I have properly explained unusual or unexpected code in the comments around it
