### PR TITLE
Improve performances and fix perfs regressions introduced in v2 and v2.1.2

### DIFF
--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -181,7 +181,12 @@ class FFMPEG_VideoWriter:
     def write_frame(self, img_array):
         """Writes one frame in the file."""
         try:
-            self.proc.stdin.write(img_array.tobytes())
+            # ffmpeg expects the data to be in C order, so we ensure that
+            # the input array is contiguous in memory.
+            if not img_array.flags["C_CONTIGUOUS"]:
+                img_array = img_array.copy(order="C")
+
+            self.proc.stdin.write(img_array)
         except IOError as err:
             _, ffmpeg_error = self.proc.communicate()
             if ffmpeg_error is not None:

--- a/tests/test_compositing.py
+++ b/tests/test_compositing.py
@@ -117,10 +117,12 @@ def test_compositing_masks(util):
     clip3 = ColorClip((25, 25), (0, 0, 255, 76.5)).with_duration(2)
 
     compostite_clip1 = CompositeVideoClip(
-        [clip1, clip2.with_position(("center", "center"))]
+        [clip1, clip2.with_position(("center", "center"))],
+        bg_color=None,
     )
     compostite_clip2 = CompositeVideoClip(
-        [compostite_clip1, clip3.with_position(("center", "center"))]
+        [compostite_clip1, clip3.with_position(("center", "center"))],
+        bg_color=None,
     )
 
     # Load output file and check transparency
@@ -144,10 +146,12 @@ def test_compositing_with_transparency_colors(util):
     clip3 = ColorClip((25, 25), (0, 0, 255, 76.5)).with_duration(2)
 
     compostite_clip1 = CompositeVideoClip(
-        [clip1, clip2.with_position(("center", "center"))]
+        [clip1, clip2.with_position(("center", "center"))],
+        bg_color=None,  # No background color, so it should be transparent
     )
     compostite_clip2 = CompositeVideoClip(
-        [compostite_clip1, clip3.with_position(("center", "center"))]
+        [compostite_clip1, clip3.with_position(("center", "center"))],
+        bg_color=None,
     )
 
     # Load output file and check transparency

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -374,9 +374,13 @@ def test_issue_2269(util):
     ).with_duration(3)
 
     comp1 = CompositeVideoClip(
-        [color_clip, txt_clip_with_margin.with_position(("center", "center"))]
+        [color_clip, txt_clip_with_margin.with_position(("center", "center"))],
+        bg_color=None,  # No background color, so it should be transparent
     )
-    comp2 = CompositeVideoClip([clip, comp1.with_position(("center", "center"))])
+    comp2 = CompositeVideoClip(
+        [clip, comp1.with_position(("center", "center"))],
+        bg_color=None,  # No background color, so it should be transparent
+    )
 
     # If transparency work as expected, this pixel should be pure red at 2 seconds
     frame = comp2.get_frame(2)
@@ -393,10 +397,12 @@ def test_issue_2269_2(util):
     clip3 = ColorClip((50, 50), (0, 0, 255, 76.5)).with_duration(3)
 
     compostite_clip1 = CompositeVideoClip(
-        [clip1, clip2.with_position(("center", "center"))]
+        [clip1, clip2.with_position(("center", "center"))],
+        bg_color=None,
     )
     compostite_clip2 = CompositeVideoClip(
-        [compostite_clip1, clip3.with_position(("center", "center"))]
+        [compostite_clip1, clip3.with_position(("center", "center"))],
+        bg_color=None,
     )
 
     # If transparency work as expected the clip should match thoses colors
@@ -419,10 +425,12 @@ def test_issue_2269_3(util):
     clip3 = ColorClip((50, 50), (0, 0, 255, 76.5)).with_duration(3)
 
     compostite_clip1 = CompositeVideoClip(
-        [clip1, clip2.with_position(("center", "center"))]
+        [clip1, clip2.with_position(("center", "center"))],
+        bg_color=None,
     )
     compostite_clip2 = CompositeVideoClip(
-        [compostite_clip1, clip3.with_position(("center", "center"))]
+        [compostite_clip1, clip3.with_position(("center", "center"))],
+        bg_color=None,
     )
 
     # If transparency work as expected the clip transparency should be between 0.3 and 0.657


### PR DESCRIPTION
When fixig/adding support for video transparency with v2.1.2 some performances issues have been added, on top of some perfs regression in v2.

This PR strongly improve the situation and should give performances on par, or even slightly better than those of v1.

The PR also introduce a small API change in `CompositeVideoClip`, setting default background as black instead of transparent, as this greatly improve perfs and is probably the behaviour expected by the end user. 
 
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [x] I have properly documented new or changed features in the documentation or in the docstrings
- [x] I have properly explained unusual or unexpected code in the comments around it
