### PR TITLE
Fix bugs that may occur in the file_to_subtitles function

### DIFF
--- a/moviepy/video/tools/subtitles.py
+++ b/moviepy/video/tools/subtitles.py
@@ -195,4 +195,7 @@ def file_to_subtitles(filename, encoding=None):
                 current_times, current_text = None, ""
             elif current_times:
                 current_text += line
+        # Fix the issue where the subtitle is not added to times_texts when it is the last line in an SRT file and the loop ends.
+        if current_times is not None:
+            times_texts.append((current_times, current_text.strip("\n")))
     return times_texts


### PR DESCRIPTION
@convert_path_to_string("filename")
def file_to_subtitles(filename, encoding=None):
    """Converts a srt file into subtitles.

    The returned list is of the form ``[((start_time,end_time),'some text'),...]``
    and can be fed to SubtitlesClip.

    Only works for '.srt' format for the moment.
    """
    times_texts = []
    current_times = None
    current_text = ""
    with open(filename, "r", encoding=encoding) as file:
        for line in file:
            times = re.findall("([0-9]*:[0-9]*:[0-9]*,[0-9]*)", line)
            if times:
                current_times = [convert_to_seconds(t) for t in times]
            elif line.strip() == "":
                times_texts.append((current_times, current_text.strip("\n")))
                current_times, current_text = None, ""
            elif current_times:
                current_text += line
        # Fix the issue where the subtitle is not added to times_texts when it is the last line in an SRT file and the loop ends.
        if current_times is not None:
            times_texts.append((current_times, current_text.strip("\n")))
    return times_texts