### PR TITLE
docs: update write_gif docstring to describe logger parameter

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -496,8 +496,8 @@ class VideoClip(Clip):
         loop : int, optional
           Repeat the clip using ``loop`` iterations in the resulting GIF.
 
-        progress_bar
-          If True, displays a progress bar
+        logger
+          Either ``"bar"`` for progress bar or ``None`` or any Proglog logger.
 
 
         Notes


### PR DESCRIPTION
Updated docstring for `VideoClip.write_gif`:

1. Removed outdated `progress_bar` entry 
2. Added the proper `logger` parameter (copied the description from `VideoClip.write_videofile` docstring)

---

Ran tests in docker. No failing tests (as expected for docs-only change).
```
===== 622 passed, 2 skipped, 1 xpassed, 6245 warnings in 274.83s (0:04:34) =====
```

---

- [x ] I have properly documented new or changed features in the documentation or in the docstrings
