### PR TITLE
fix floating point errors in ImageSequenceClip

### DIFF
--- a/moviepy/video/io/ImageSequenceClip.py
+++ b/moviepy/video/io/ImageSequenceClip.py
@@ -94,14 +94,13 @@ class ImageSequenceClip(VideoClip):
 
         self.fps = fps
         if fps is not None:
-            durations = [1.0 / fps for image in sequence]
-            self.images_starts = [
-                1.0 * i / fps - np.finfo(np.float32).eps for i in range(len(sequence))
-            ]
+            self.durations = [1.0 / fps for image in sequence]
+            self.images_starts = [i / fps for i in range(len(sequence))]
+            self.duration = len(sequence) / fps
         else:
-            self.images_starts = [0] + list(np.cumsum(durations))
-        self.durations = durations
-        self.duration = sum(durations)
+            self.durations = durations
+            self.images_starts = [0] + list(np.cumsum(self.durations[:-1]))
+            self.duration = sum(durations)
         self.end = self.duration
         self.sequence = sequence
 

--- a/tests/test_ImageSequenceClip.py
+++ b/tests/test_ImageSequenceClip.py
@@ -2,6 +2,8 @@
 
 import os
 
+import numpy as np
+
 import pytest
 
 from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
@@ -40,3 +42,23 @@ def test_2():
 
 if __name__ == "__main__":
     pytest.main()
+
+
+def test_no_repeat_frames():
+    # set of frames that are all different levels of grey
+    frames = [np.ones((400, 400, 3)) * f for f in np.linspace(0, 1, 20)]
+
+    for frames_per_second in range(1, 31):
+        movie = ImageSequenceClip(frames, fps=frames_per_second)
+        c = np.array([f[0, 0, 0] for f in movie.iter_frames()])
+        assert np.all(c[1:] != c[:-1])
+
+
+def test_correct_number_of_frames():
+    # set of frames that are all different levels of grey
+    frames = [np.ones((400, 400, 3)) * f for f in np.linspace(0, 1, 20)]
+
+    for frames_per_second in range(1, 31):
+        movie = ImageSequenceClip(frames, fps=frames_per_second)
+        c = np.array([f[0, 0, 0] for f in movie.iter_frames()])
+        assert len(c) == 20


### PR DESCRIPTION
Both #2412 and #2507 relate to comparisons that fail due to floating point precision loss.
In #2412 this leads to the frames being included at the wrong timestep.
In #2507 this leads to the last frame not being included.

----

For #2412, `self.images_starts` is calculated in the following way:
```py
            self.images_starts = [
                1.0 * i / fps - np.finfo(np.float32).eps for i in range(len(sequence))
            ]
```
The inclusion of `np.finfo(np.float32).eps` makes the dtype of each element 'float32', and this has lower precision than the number it is compared to. In the cases where there is sufficient precision in a float32 for `np.finfo(np.float32).eps` to impact the numerical value, `self.images_starts[i] <= i/fps` still holds true, but this is only true for numbers close to one. 
Removing  `-np.finfo(np.float32).eps` fixes this error. 
Note: the  `-np.finfo(np.float32).eps`  was introduced to fix the same error (#464, https://github.com/Zulko/moviepy/commit/167db9f9a5bbd08c7070d4e39383f2d355191b93), but the fix was not sufficiently tested

The new test added to test #2412 is inspired by the code in #464

----

#2507 is related to the duration, calculated as:
```py
            durations = [1.0 / fps for image in sequence]
        ...
        self.duration = sum(durations)
```
which is then compared to `len(self.sequences)/self.fps`, which results in a classical floating point error, similar to how `np.sum([1.0/71 for i in range(71)]) == 1` is False.
Changing the calculation of duration to:
```
            self.duration = len(sequence) / fps
```
fixes the error, because then the calculation of the duration, and the check of the duration, is calculated in the same way.  

-----

There are two new tests: 
```py
def test_no_repeat_frames():
    # set of frames that are all different levels of grey
    frames = [np.ones((400, 400, 3)) * f for f in np.linspace(0, 1, 20)]

    for frames_per_second in range(1, 31):
        movie = ImageSequenceClip(frames, fps=frames_per_second)
        c = np.array([f[0, 0, 0] for f in movie.iter_frames()])
        assert np.all(c[1:] != c[:-1])


def test_correct_number_of_frames():
    # set of frames that are all different levels of grey
    frames = [np.ones((400, 400, 3)) * f for f in np.linspace(0, 1, 20)]

    for frames_per_second in range(1, 31):
        movie = ImageSequenceClip(frames, fps=frames_per_second)
        c = np.array([f[0, 0, 0] for f in movie.iter_frames()])
        assert len(c) == 20
```
Which fail on main but pass with this PR.

Note that the details of the failure is system-specific, and different systems will fail at different points (fps), which is why fps values from 1 to 30 are tested.

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
