### PR TITLE
[Feature Request] Proper text breaking by words in TextClip #2501

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1908,6 +1908,7 @@ class TextClip(ImageClip):
         # We try to break on spaces as much as possible
         # if a text dont contain spaces (ex chinese), we will break when possible
         last_space = 0
+        last_break = 0
         for index, char in enumerate(text):
             if char == " ":
                 last_space = index
@@ -1923,23 +1924,26 @@ class TextClip(ImageClip):
             )
             temp_width = temp_right - temp_left
 
-            if temp_width >= width:
+            if temp_width >= width or char == "\n":
                 # If we had a space previously, add everything up to the space
                 # and reset last_space and current_line else add everything up
                 # to previous char
-                if last_space:
-                    lines.append(temp_line[0:last_space])
-                    current_line = temp_line[last_space + 1 : index + 1]
-                    last_space = 0
-                else:
-                    lines.append(current_line[0:index])
+                if last_space==0 or char == "\n":
+                    lines.append(current_line[:index-last_break])
                     current_line = char
-                    last_space = 0
+                    last_break = index
+                else:
+                    lines.append(temp_line[:last_space-last_break])
+                    current_line = temp_line[last_space-last_break:]
+                    last_break = last_space
+                last_space = 0
             else:
                 current_line = temp_line
 
         if current_line:
             lines.append(current_line)
+
+        lines = [line.replace("\n", "").strip() for line in lines]
 
         return lines
 


### PR DESCRIPTION
Fixed a bug where text breaking by words works for first line but not the lines after.

```
import moviepy as mp

text = 'MoviePy (online documentation here) is a Python library for video editing: cuts, concatenations, title insertions, video compositing (a.k.a. non-linear editing), video processing, and creation of custom effects. MoviePy can read and write all the most common audio and video formats, including GIF, and runs on Windows/Mac/Linux, with Python 3.9+.'

text_lines = mp.TextClip(text=text, font_size=20)._TextClip__break_text(width=500, text=text, font=None, font_size=20, stroke_width=0, align="left", spacing=4)
print("\n".join(text_lines))
```

<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix
