### PR TITLE
Fix issue 2539 ffmpeg pixel_format option for libx264 in FFMPEG_VideoWriter class

### DIFF
--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -61,9 +61,11 @@ class FFMPEG_VideoWriter:
       Set to ``True`` if there is a mask in the video to be encoded.
 
     pixel_format : str, optional
-      Optional: Pixel format for the output video file. If is not specified
+      Optional: Pixel format for the output video file. If not specified
       ``"rgb24"`` will be used as the default format unless ``with_mask`` is
-      set as ``True``, then ``"rgba"`` will be used.
+      set as ``True``, then ``"rgba"`` will be used. If the codec is
+      ``libx264`` or ``h264_nvenc``, the pixel format will be set to
+      ``"yuv420p"`` by default, and will only accept other ``yuv`` formats.
 
     logfile : int, optional
       File descriptor for logging output. If not defined, ``subprocess.PIPE``
@@ -160,7 +162,7 @@ class FFMPEG_VideoWriter:
             and (size[1] % 2 == 0)
         ):
             # h264 encoder only supports yuv pixel formats, so allow if requested
-            if pixel_format is None or not pixel_format.startswith('yuv'):
+            if pixel_format is None or not pixel_format.startswith("yuv"):
                 cmd.extend(["-pix_fmt", "yuv420p"])
             else:
                 cmd.extend(["-pix_fmt", pixel_format])

--- a/moviepy/video/io/ffmpeg_writer.py
+++ b/moviepy/video/io/ffmpeg_writer.py
@@ -159,7 +159,11 @@ class FFMPEG_VideoWriter:
             and (size[0] % 2 == 0)
             and (size[1] % 2 == 0)
         ):
-            cmd.extend(["-pix_fmt", "yuva420p"])
+            # h264 encoder only supports yuv pixel formats, so allow if requested
+            if pixel_format is None or not pixel_format.startswith('yuv'):
+                cmd.extend(["-pix_fmt", "yuv420p"])
+            else:
+                cmd.extend(["-pix_fmt", pixel_format])
         else:
             # For all other codecs, we use the pixel format specified by the user
             # or the default one.

--- a/tests/test_ffmpeg_writer.py
+++ b/tests/test_ffmpeg_writer.py
@@ -35,6 +35,11 @@ from moviepy.video.tools.drawing import color_gradient
     ),
 )
 @pytest.mark.parametrize(
+    "pixel_format",
+    (None, "yuv444p", "rgb24"),
+    ids=("pixel_format=None", "pixel_format=yuv444p", "pixel_format=rgb24"),
+)
+@pytest.mark.parametrize(
     "bitrate",
     (None, "5000k"),
     ids=("bitrate=None", "bitrate=5000k"),
@@ -51,6 +56,7 @@ def test_ffmpeg_write_video(
     ext,
     write_logfile,
     with_mask,
+    pixel_format,
     bitrate,
     threads,
 ):
@@ -77,6 +83,8 @@ def test_ffmpeg_write_video(
     )
     if codec is not None:
         kwargs["codec"] = codec
+    if pixel_format is not None:
+        kwargs["pixel_format"] = pixel_format
     if bitrate is not None:
         kwargs["bitrate"] = bitrate
     if threads is not None:


### PR DESCRIPTION
<!--
Please tick when you have done these. They don't need to all be completed before the PR is submitted.
Delete them if they are not appropriate for this pull request.
-->
- [ x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix (repro code is in the issue [here](https://github.com/Zulko/moviepy/issues/2539))
- [ x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/`
- [ x] I have properly documented new or changed features in the documentation or in the docstrings
- [ x] I have properly explained unusual or unexpected code in the comments around it
