### PR TITLE
[Exp. Overhaul] Faster rendering (more GPU acceleration [CUDA/OpenCV/NVDEC/NVENC], Numba, optimization patches)

### DIFF
--- a/.playwright-mcp/console-2026-02-08T20-17-34-176Z.log
+++ b/.playwright-mcp/console-2026-02-08T20-17-34-176Z.log
@@ -1,0 +1,6 @@
+[    2492ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[    2708ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[  339162ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[  339900ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[  341003ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[  341131ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0

--- a/.playwright-mcp/console-2026-02-08T20-17-34-176Z.log
+++ b/.playwright-mcp/console-2026-02-08T20-17-34-176Z.log
@@ -1,6 +1,0 @@
-[    2492ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[    2708ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[  339162ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[  339900ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[  341003ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[  341131ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0

--- a/.playwright-mcp/console-2026-02-08T20-23-31-719Z.log
+++ b/.playwright-mcp/console-2026-02-08T20-23-31-719Z.log
@@ -1,3 +1,0 @@
-[     975ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[    1086ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[    1431ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0

--- a/.playwright-mcp/console-2026-02-08T20-23-31-719Z.log
+++ b/.playwright-mcp/console-2026-02-08T20-23-31-719Z.log
@@ -1,0 +1,3 @@
+[     975ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[    1086ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[    1431ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0

--- a/.playwright-mcp/console-2026-02-08T20-24-11-035Z.log
+++ b/.playwright-mcp/console-2026-02-08T20-24-11-035Z.log
@@ -1,7 +1,0 @@
-[    1137ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[    1471ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[    1477ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[    1617ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[  856162ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[  857229ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
-[  857336ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0

--- a/.playwright-mcp/console-2026-02-08T20-24-11-035Z.log
+++ b/.playwright-mcp/console-2026-02-08T20-24-11-035Z.log
@@ -1,0 +1,7 @@
+[    1137ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[    1471ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[    1477ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[    1617ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[  856162ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[  857229ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0
+[  857336ms] [ERROR] Failed to load resource: net::ERR_ADDRESS_INVALID @ https://collector.github.com/github/collect:0

--- a/README.md
+++ b/README.md
@@ -54,6 +54,47 @@ This makes MoviePy very flexible and approachable, albeit slower than using ffmp
 
 Intall moviepy with `pip install moviepy`. For additional installation options, such as a custom FFMPEG or for previewing, see [this section](https://zulko.github.io/moviepy/getting_started/install.html). For development, clone that repo locally and install with `pip install -e .`
 
+## Hardware-accelerated decode (optional)
+
+MoviePy can ask ffmpeg to use hardware-accelerated decoding when available. This is best-effort and falls back to software decoding if it fails.
+
+Environment variables:
+
+- `MOVIEPY_FFMPEG_HWACCEL` to force a specific hwaccel (e.g. `cuda`, `qsv`, `d3d11va`) or disable (`none`).
+- `MOVIEPY_GPU_DECODE_E2E=1` to try an end-to-end GPU decode path (decode into GPU surfaces and only then download for the Python pipe).
+- `MOVIEPY_FFMPEG_HWACCEL_OUTPUT_FORMAT=auto` (or a specific pixel format) to enable `-hwaccel_output_format`.
+- `MOVIEPY_FFMPEG_HWACCEL_DEVICE` to pass a `-hwaccel_device` value.
+- `MOVIEPY_GPU_DECODE_SCALE=1` (default) to attempt CUDA scaling via `scale_cuda` when using `cuda` and resizing.
+
+### True GPU-resident decode (optional backend)
+
+If you have a GPU decode library installed, MoviePy can also decode frames directly into GPU memory (no ffmpeg stdout pipe), and feed those GPU frames into the experimental CuPy compositor.
+
+Currently supported (optional):
+
+- `decord` (NVDEC) when available.
+
+Controls:
+
+- `MOVIEPY_GPU_RENDER=1` enables the experimental GPU compositor (required).
+- `MOVIEPY_GPU_DECODE_BACKEND=auto|decord|none` (default: `auto`).
+- `MOVIEPY_DISABLE_GPU_DECODE=1` to disable this path.
+- `MOVIEPY_GPU_DEVICE=0` to pick a GPU index.
+
+Fallbacks are automatic: if the GPU decode backend is unavailable or fails to initialize, MoviePy falls back to the regular OpenCV/ffmpeg readers.
+
+## GPU-native encode (optional backend)
+
+If you have NVIDIA's NVENC Python bindings installed (PyNvCodec), MoviePy can optionally encode the final video stream directly from GPU-resident frames (CuPy) without downloading each frame to the CPU. This is best-effort and always falls back to the regular FFmpeg stdin writer.
+
+Controls:
+
+- `MOVIEPY_GPU_RENDER=1` enables the experimental GPU compositor (required).
+- `MOVIEPY_GPU_ENCODE_BACKEND=auto|pynvcodec|none` (default: `auto`).
+- `MOVIEPY_DISABLE_GPU_ENCODE=1` disables this path.
+- `MOVIEPY_GPU_ENCODE_STRICT=1` makes failures raise instead of falling back.
+- `MOVIEPY_GPU_DEVICE=0` selects the GPU index.
+
 # Documentation
 
 The online documentation ([here](https://zulko.github.io/moviepy/)) is automatically built at every push to the master branch. To build the documentation locally, install the extra dependencies via `pip install "moviepy[doc]"`, then go to the `docs` folder and run `make html`.

--- a/moviepy/audio/fx/AudioFadeIn.py
+++ b/moviepy/audio/fx/AudioFadeIn.py
@@ -39,7 +39,10 @@ class AudioFadeIn(Effect):
     def _stereo_factor_getter(self, nchannels):
         def getter(t, duration):
             factor = np.minimum(t / duration, 1)
-            return np.array([factor for _ in range(nchannels)]).T
+            if np.isscalar(factor):
+                return np.full((nchannels,), factor)
+            factor = np.asarray(factor)
+            return np.broadcast_to(factor[:, None], (factor.shape[0], nchannels))
 
         return getter
 

--- a/moviepy/audio/fx/AudioFadeOut.py
+++ b/moviepy/audio/fx/AudioFadeOut.py
@@ -40,7 +40,10 @@ class AudioFadeOut(Effect):
     def _stereo_factor_getter(self, clip_duration, nchannels):
         def getter(t, duration):
             factor = np.minimum(1.0 * (clip_duration - t) / duration, 1)
-            return np.array([factor for _ in range(nchannels)]).T
+            if np.isscalar(factor):
+                return np.full((nchannels,), factor)
+            factor = np.asarray(factor)
+            return np.broadcast_to(factor[:, None], (factor.shape[0], nchannels))
 
         return getter
 

--- a/moviepy/video/fx/BlackAndWhite.py
+++ b/moviepy/video/fx/BlackAndWhite.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import numpy as np
 
 from moviepy.Effect import Effect
+from moviepy.video.tools import cupy_utils
 
 
 @dataclass
@@ -32,7 +33,11 @@ class BlackAndWhite(Effect):
         )
 
         def filter(im):
+            xp = np
+            if cupy_utils.is_cuda_array(im):
+                xp = cupy_utils.cupy()
+
             im = R * im[:, :, 0] + G * im[:, :, 1] + B * im[:, :, 2]
-            return np.dstack(3 * [im]).astype("uint8")
+            return xp.dstack(3 * [im]).astype(xp.uint8)
 
         return clip.image_transform(filter)

--- a/moviepy/video/fx/GammaCorrection.py
+++ b/moviepy/video/fx/GammaCorrection.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
 
+import numpy as np
+
 from moviepy.Clip import Clip
 from moviepy.Effect import Effect
+from moviepy.video.tools import cupy_utils
 
 
 @dataclass
@@ -13,7 +16,30 @@ class GammaCorrection(Effect):
     def apply(self, clip: Clip) -> Clip:
         """Apply the effect to the clip."""
 
+        # Fast path: precompute a uint8 lookup table for uint8 frames.
+        # Must match: (255 * (1.0 * im / 255) ** gamma).astype(uint8)
+        # for positive values (i.e. truncation toward 0).
+        lut_np = (255 * (np.arange(256, dtype=np.float64) / 255.0) ** self.gamma).astype(
+            np.uint8
+        )
+        lut_cp = None
+
         def filter(im):
+            nonlocal lut_cp
+
+            if cupy_utils.is_cuda_array(im):
+                cp = cupy_utils.cupy()
+                if im.dtype == cp.uint8:
+                    if lut_cp is None:
+                        lut_cp = cp.asarray(lut_np)
+                    return lut_cp[im]
+
+                corrected = 255 * (im.astype(cp.float64) / 255.0) ** self.gamma
+                return corrected.astype(cp.uint8)
+
+            if isinstance(im, np.ndarray) and im.dtype == np.uint8:
+                return lut_np[im]
+
             corrected = 255 * (1.0 * im / 255) ** self.gamma
             return corrected.astype("uint8")
 

--- a/moviepy/video/fx/GammaCorrection.py
+++ b/moviepy/video/fx/GammaCorrection.py
@@ -19,9 +19,10 @@ class GammaCorrection(Effect):
         # Fast path: precompute a uint8 lookup table for uint8 frames.
         # Must match: (255 * (1.0 * im / 255) ** gamma).astype(uint8)
         # for positive values (i.e. truncation toward 0).
-        lut_np = (255 * (np.arange(256, dtype=np.float64) / 255.0) ** self.gamma).astype(
-            np.uint8
-        )
+        lut_np = (
+            255
+            * (np.arange(256, dtype=np.float64) / 255.0) ** self.gamma
+        ).astype(np.uint8)
         lut_cp = None
 
         def filter(im):

--- a/moviepy/video/fx/LumContrast.py
+++ b/moviepy/video/fx/LumContrast.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from moviepy.Clip import Clip
 from moviepy.Effect import Effect
+from moviepy.video.tools import cupy_utils
 
 
 @dataclass
@@ -16,6 +17,15 @@ class LumContrast(Effect):
         """Apply the effect to the clip."""
 
         def image_filter(im):
+            if cupy_utils.is_cuda_array(im):
+                cp = cupy_utils.cupy()
+                im_f = im.astype(cp.float64)
+                corrected = im_f + self.lum + self.contrast * (
+                    im_f - float(self.contrast_threshold)
+                )
+                cp.clip(corrected, 0, 255, out=corrected)
+                return corrected.astype(cp.uint8)
+
             im = 1.0 * im  # float conversion
             corrected = (
                 im + self.lum + self.contrast * (im - float(self.contrast_threshold))

--- a/moviepy/video/fx/Margin.py
+++ b/moviepy/video/fx/Margin.py
@@ -54,14 +54,14 @@ class Margin(Effect):
             self.left = self.right = self.top = self.bottom = self.margin_size
 
         def make_bg(w, h):
-            new_w, new_h = w + self.left + self.right, h + self.top + self.bottom
-            if clip.is_mask:
-                shape = (new_h, new_w)
-                bg = np.tile(self.opacity, (new_h, new_w)).astype(float).reshape(shape)
-            else:
-                shape = (new_h, new_w, 3)
-                bg = np.tile(self.color, (new_h, new_w)).reshape(shape)
-            return bg
+          new_w, new_h = w + self.left + self.right, h + self.top + self.bottom
+          if clip.is_mask:
+            bg = np.empty((new_h, new_w), dtype=float)
+            bg.fill(float(self.opacity))
+          else:
+            bg = np.empty((new_h, new_w, 3), dtype=np.uint8)
+            bg[...] = self.color
+          return bg
 
         if isinstance(clip, ImageClip):
             im = make_bg(clip.w, clip.h)

--- a/moviepy/video/fx/MasksAnd.py
+++ b/moviepy/video/fx/MasksAnd.py
@@ -6,6 +6,7 @@ import numpy as np
 from moviepy.Clip import Clip
 from moviepy.Effect import Effect
 from moviepy.video.VideoClip import ImageClip
+from moviepy.video.tools import cupy_utils
 
 
 @dataclass
@@ -40,13 +41,39 @@ class MasksAnd(Effect):
         if isinstance(self.other_clip, ImageClip):
             self.other_clip = self.other_clip.img
 
+        other_np = self.other_clip if isinstance(self.other_clip, np.ndarray) else None
+        other_cp = None
+
+        def _min(frame, other):
+            if cupy_utils.is_cuda_array(frame) or cupy_utils.is_cuda_array(other):
+                cp = cupy_utils.cupy()
+                a = frame if cupy_utils.is_cuda_array(frame) else cp.asarray(frame)
+                b = other if cupy_utils.is_cuda_array(other) else cp.asarray(other)
+                return cp.minimum(a, b)
+            return np.minimum(frame, other)
+
         if isinstance(self.other_clip, np.ndarray):
-            return clip.image_transform(
-                lambda frame: np.minimum(frame, self.other_clip)
-            )
-        else:
-            return clip.transform(
-                lambda get_frame, t: np.minimum(
-                    get_frame(t), self.other_clip.get_frame(t)
-                )
-            )
+            def flim(frame):
+                nonlocal other_cp
+                if cupy_utils.is_cuda_array(frame):
+                    if other_cp is None:
+                        other_cp = cupy_utils.cupy().asarray(other_np)
+                    return _min(frame, other_cp)
+                return _min(frame, other_np)
+
+            return clip.image_transform(flim)
+
+        def filter(get_frame, t):
+            frame = get_frame(t)
+            if cupy_utils.is_cuda_array(frame):
+                gpu_fn = getattr(self.other_clip, "_gpu_frame_function", None)
+                if gpu_fn is not None:
+                    try:
+                        other = gpu_fn(t)
+                        return _min(frame, other)
+                    except Exception:
+                        pass
+            other = self.other_clip.get_frame(t)
+            return _min(frame, other)
+
+        return clip.transform(filter)

--- a/moviepy/video/fx/MasksOr.py
+++ b/moviepy/video/fx/MasksOr.py
@@ -6,6 +6,7 @@ import numpy as np
 from moviepy.Clip import Clip
 from moviepy.Effect import Effect
 from moviepy.video.VideoClip import ImageClip
+from moviepy.video.tools import cupy_utils
 
 
 @dataclass
@@ -40,13 +41,39 @@ class MasksOr(Effect):
         if isinstance(self.other_clip, ImageClip):
             self.other_clip = self.other_clip.img
 
+        other_np = self.other_clip if isinstance(self.other_clip, np.ndarray) else None
+        other_cp = None
+
+        def _max(frame, other):
+            if cupy_utils.is_cuda_array(frame) or cupy_utils.is_cuda_array(other):
+                cp = cupy_utils.cupy()
+                a = frame if cupy_utils.is_cuda_array(frame) else cp.asarray(frame)
+                b = other if cupy_utils.is_cuda_array(other) else cp.asarray(other)
+                return cp.maximum(a, b)
+            return np.maximum(frame, other)
+
         if isinstance(self.other_clip, np.ndarray):
-            return clip.image_transform(
-                lambda frame: np.maximum(frame, self.other_clip)
-            )
-        else:
-            return clip.transform(
-                lambda get_frame, t: np.maximum(
-                    get_frame(t), self.other_clip.get_frame(t)
-                )
-            )
+            def flim(frame):
+                nonlocal other_cp
+                if cupy_utils.is_cuda_array(frame):
+                    if other_cp is None:
+                        other_cp = cupy_utils.cupy().asarray(other_np)
+                    return _max(frame, other_cp)
+                return _max(frame, other_np)
+
+            return clip.image_transform(flim)
+
+        def filter(get_frame, t):
+            frame = get_frame(t)
+            if cupy_utils.is_cuda_array(frame):
+                gpu_fn = getattr(self.other_clip, "_gpu_frame_function", None)
+                if gpu_fn is not None:
+                    try:
+                        other = gpu_fn(t)
+                        return _max(frame, other)
+                    except Exception:
+                        pass
+            other = self.other_clip.get_frame(t)
+            return _max(frame, other)
+
+        return clip.transform(filter)

--- a/moviepy/video/fx/MultiplyColor.py
+++ b/moviepy/video/fx/MultiplyColor.py
@@ -5,6 +5,7 @@ import numpy as np
 from moviepy.Clip import Clip
 from moviepy.Effect import Effect
 from moviepy.video.tools import scratch
+from moviepy.video.tools import cupy_utils
 
 
 @dataclass
@@ -21,7 +22,14 @@ class MultiplyColor(Effect):
         """Apply the effect to the clip."""
         factor = np.float32(self.factor)
 
-        def _mul(frame: np.ndarray) -> np.ndarray:
+        def _mul(frame):
+            if cupy_utils.is_cuda_array(frame):
+                cp = cupy_utils.cupy()
+                tmp = frame.astype(cp.float32)
+                tmp *= factor
+                cp.minimum(tmp, 255.0, out=tmp)
+                return tmp.astype(cp.uint8)
+
             tmp = scratch.get_float32("multiplycolor_tmp", frame.shape)
             np.multiply(frame, factor, out=tmp, casting="unsafe")
             np.minimum(tmp, 255.0, out=tmp)

--- a/moviepy/video/fx/Painting.py
+++ b/moviepy/video/fx/Painting.py
@@ -5,6 +5,7 @@ from PIL import Image, ImageFilter
 
 from moviepy.Clip import Clip
 from moviepy.Effect import Effect
+from moviepy.video.tools import cupy_utils
 
 
 @dataclass
@@ -30,6 +31,11 @@ class Painting(Effect):
 
         np_image : a numpy image
         """
+        is_cuda = cupy_utils.is_cuda_array(np_image)
+        cp = cupy_utils.cupy() if is_cuda else None
+        if is_cuda:
+            np_image = cp.asnumpy(np_image)
+
         image = Image.fromarray(np_image)
         image = image.filter(ImageFilter.EDGE_ENHANCE_MORE)
 
@@ -54,7 +60,7 @@ class Painting(Effect):
         # Convert the pixel values to unsigned 8-bit integers
         painting = painting.astype("uint8")
 
-        return painting
+        return cp.asarray(painting) if is_cuda else painting
 
     def apply(self, clip: Clip) -> Clip:
         """Apply the effect to the clip."""

--- a/moviepy/video/fx/SuperSample.py
+++ b/moviepy/video/fx/SuperSample.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from moviepy.Clip import Clip
 from moviepy.Effect import Effect
+from moviepy.video.tools import cupy_utils
 
 
 @dataclass
@@ -20,8 +21,18 @@ class SuperSample(Effect):
 
         def filter(get_frame, t):
             timings = np.linspace(t - self.d, t + self.d, self.n_frames)
+            frames = [get_frame(t_) for t_ in timings]
+
+            if frames and cupy_utils.is_cuda_array(frames[0]):
+                cp = cupy_utils.cupy()
+                stack = cp.stack(
+                    [f.astype(cp.uint16, copy=False) for f in frames], axis=0
+                )
+                frame_average = cp.mean(stack, axis=0)
+                return frame_average.astype(cp.uint8)
+
             frame_average = np.mean(
-                1.0 * np.array([get_frame(t_) for t_ in timings], dtype="uint16"),
+                1.0 * np.array(frames, dtype="uint16"),
                 axis=0,
             )
             return frame_average.astype("uint8")

--- a/moviepy/video/fx/_gpu_convert_to_nv12.py
+++ b/moviepy/video/fx/_gpu_convert_to_nv12.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from moviepy.Clip import Clip
+from moviepy.Effect import Effect
+from moviepy.video.tools import cupy_utils
+
+
+@dataclass
+class GPUConvertToNV12(Effect):
+    """Internal helper effect: convert frames to NV12 on GPU.
+
+    This effect is intentionally *GPU-only*: it does not change the CPU
+    `frame_function` output (still RGB). Instead it installs/overrides the
+    internal `_gpu_frame_function` so GPU export/encode pipelines can consume
+    NV12 directly.
+
+    Color settings default to env/config used by the NVENC pipeline.
+
+    Notes
+    -----
+    - Not exported via `moviepy.video.fx` public namespace.
+    - Intended for internal/advanced usage.
+    """
+
+    color_matrix: Optional[str] = None  # "bt601" or "bt709"
+    color_range: Optional[str] = None  # "mpeg" (limited) or "jpeg" (full)
+
+    def apply(self, clip: Clip) -> Clip:
+        new_clip = clip.copy()
+
+        # Import conversion helpers from NVENC writer module to avoid duplicating
+        # kernel code. This module is internal and best-effort.
+        from moviepy.video.io import pynvcodec_writer as _nv
+
+        matrix, crange = _nv._gpu_color_settings_for_clip(clip)
+        if self.color_matrix is not None:
+            matrix = _nv._parse_color_matrix(self.color_matrix)
+        if self.color_range is not None:
+            crange = _nv._parse_color_range(self.color_range)
+
+        new_clip._gpu_frame_format = "nv12"
+        new_clip._gpu_color_matrix = matrix
+        new_clip._gpu_color_range = crange
+
+        def _gpu_frame_function(t):
+            cp = cupy_utils.cupy()
+
+            # If upstream already provides NV12, pass through.
+            src_gpu_fn = getattr(clip, "_gpu_frame_function", None)
+            if src_gpu_fn is not None:
+                try:
+                    v = src_gpu_fn(t)
+                    if callable(getattr(v, "cuda", None)):
+                        return v
+                    if cupy_utils.is_cuda_array(v):
+                        # packed NV12 (H+H/2,W) or planes are accepted downstream
+                        if v.ndim == 2 and v.dtype == cp.uint8:
+                            return v
+                    if isinstance(v, (tuple, list)) and len(v) == 2 and all(
+                        cupy_utils.is_cuda_array(p) for p in v
+                    ):
+                        return v
+                except Exception:
+                    pass
+
+            # Get an RGB frame, best-effort on GPU.
+            if src_gpu_fn is not None:
+                try:
+                    frame = src_gpu_fn(t)
+                except Exception:
+                    frame = clip.get_frame(t)
+            else:
+                frame = clip.get_frame(t)
+
+            if not cupy_utils.is_cuda_array(frame):
+                if not isinstance(frame, np.ndarray):
+                    frame = np.asarray(frame)
+                frame = cp.asarray(frame)
+
+            if frame.ndim != 3 or frame.shape[2] < 3:
+                raise ValueError(
+                    "Expected HxWx3(+) RGB frame for NV12 conversion, got "
+                    f"shape={getattr(frame, 'shape', None)!r}"
+                )
+
+            frame = frame[:, :, :3]
+            if frame.dtype != cp.uint8:
+                frame = frame.astype(cp.uint8)
+            try:
+                if not frame.flags.c_contiguous:
+                    frame = cp.ascontiguousarray(frame)
+            except Exception:
+                frame = cp.ascontiguousarray(frame)
+
+            h = int(frame.shape[0])
+            w = int(frame.shape[1])
+            if (w % 2) or (h % 2):
+                raise ValueError("NV12 requires even frame dimensions")
+
+            nv12 = cp.empty((h + h // 2, w), dtype=cp.uint8)
+            y = nv12[:h, :]
+            uv = nv12[h : h + h // 2, :]
+
+            kernel = _nv._get_rgb_to_nv12_kernel(cp, matrix=matrix, crange=crange)
+
+            threads = (16, 16)
+            grid = (
+                ((w // 2) + threads[0] - 1) // threads[0],
+                ((h // 2) + threads[1] - 1) // threads[1],
+            )
+            kernel(
+                grid,
+                threads,
+                (
+                    frame,
+                    y,
+                    uv,
+                    int(w),
+                    int(h),
+                    int(frame.strides[0]),
+                    int(y.strides[0]),
+                    int(uv.strides[0]),
+                ),
+            )
+
+            return nv12
+
+        new_clip._gpu_frame_function = _gpu_frame_function
+        return new_clip

--- a/moviepy/video/io/ImageSequenceClip.py
+++ b/moviepy/video/io/ImageSequenceClip.py
@@ -11,6 +11,17 @@ from imageio.v2 import imread
 from moviepy.video.VideoClip import VideoClip
 
 
+def _as_numpy_if_cuda_array(arr):
+    if arr is None or not hasattr(arr, "__cuda_array_interface__"):
+        return arr
+    try:
+        import cupy as cp
+
+        return cp.asnumpy(arr)
+    except Exception:
+        return arr
+
+
 class ImageSequenceClip(VideoClip):
     """A VideoClip made from a series of images.
 
@@ -227,6 +238,8 @@ class ImageSequenceClip(VideoClip):
             return self.last_image
         else:
             if self.is_mask:
-                return self.sequence[index][:, :, 3].astype(float) / 255.0
+                img = _as_numpy_if_cuda_array(self.sequence[index])
+                return img[:, :, 3].astype(float) / 255.0
             else:
-                return self.sequence[index][:, :, :3]
+                img = _as_numpy_if_cuda_array(self.sequence[index])
+                return img[:, :, :3]

--- a/moviepy/video/io/decord_gpu_reader.py
+++ b/moviepy/video/io/decord_gpu_reader.py
@@ -1,0 +1,159 @@
+"""Optional GPU video reader backend using `decord`.
+
+This reader is internal-only and is used opportunistically when the experimental
+GPU render path is enabled.
+
+If `decord` is unavailable (or cannot initialize a GPU context), callers must
+fall back to the standard readers.
+
+Design goals:
+- Keep decoded frames GPU-resident (no ffmpeg stdout pipe).
+- Expose a CuPy frame path via `get_frame_gpu(t)`.
+- Preserve MoviePy public semantics: `get_frame(t)` returns a NumPy array.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+class DecordGPUVideoReader:
+    """Best-effort GPU video reader using NVDEC via decord.
+
+    Parameters match the subset needed by `VideoFileClip`.
+
+    Notes
+    -----
+    - Only supports `pixel_format="rgb24"`.
+    - `get_frame(t)` downloads to NumPy for public API compatibility.
+    - `get_frame_gpu(t)` returns a CuPy uint8 RGB array when possible.
+    """
+
+    def __init__(
+        self,
+        filename: str,
+        *,
+        infos: dict,
+        target_resolution=None,
+        pixel_format: str = "rgb24",
+        resize_algo: str | None = None,
+        ctx_id: int = 0,
+    ):
+        if str(pixel_format).lower() != "rgb24":
+            raise ValueError("DecordGPUVideoReader only supports pixel_format=rgb24")
+
+        # Import lazily to keep this backend optional.
+        import decord  # type: ignore
+
+        self.filename = filename
+        self.infos = infos
+
+        self.fps = float(infos.get("video_fps", 1.0) or 1.0)
+        self.duration = float(infos.get("video_duration", 0.0) or 0.0)
+        self.ffmpeg_duration = float(infos.get("duration", 0.0) or 0.0)
+        self.n_frames = int(infos.get("video_n_frames", 0) or 0)
+        self.bitrate = infos.get("video_bitrate", 0)
+
+        self.rotation = abs(infos.get("video_rotation", 0) or 0)
+        self.size = infos.get("video_size", (1, 1))
+        if self.rotation in [90, 270]:
+            self.size = [self.size[1], self.size[0]]
+
+        self.pixel_format = pixel_format
+        self.depth = 3
+        self.resize_algo = resize_algo or "bicubic"
+
+        kwargs: dict[str, Any] = {}
+
+        # Decord supports optional decode-time resizing via (width, height).
+        if target_resolution is not None:
+            if None in target_resolution:
+                raise ValueError(
+                    "DecordGPUVideoReader requires explicit (w, h) target_resolution"
+                )
+            w, h = target_resolution
+            if w and h:
+                kwargs["width"] = int(w)
+                kwargs["height"] = int(h)
+                self.size = (int(w), int(h))
+
+        self._decord = decord
+        self._ctx = decord.gpu(int(ctx_id))
+        self._vr = decord.VideoReader(filename, ctx=self._ctx, **kwargs)
+
+        # Some containers report 0 frames; fall back to len(vr).
+        try:
+            self.n_frames = self.n_frames or int(len(self._vr))
+        except Exception:
+            pass
+
+    def get_frame_number(self, t: float) -> int:
+        # Match MoviePy reader rounding.
+        idx = int(self.fps * t + 0.00001)
+        if idx < 0:
+            return 0
+        if self.n_frames:
+            return min(idx, self.n_frames - 1)
+        return idx
+
+    def get_frame_gpu(self, t: float):
+        """Return a CuPy uint8 RGB frame (H, W, 3) on GPU."""
+        from moviepy.video.tools import cupy_utils
+
+        cp = cupy_utils.cupy()
+
+        idx = self.get_frame_number(t)
+        frame = self._vr[idx]
+
+        # Convert decord NDArray -> CuPy via DLPack (zero-copy on GPU).
+        if hasattr(frame, "to_dlpack"):
+            capsule = frame.to_dlpack()
+            try:
+                out = cp.fromDlpack(capsule)  # CuPy < 13
+            except Exception:
+                out = cp.from_dlpack(capsule)  # CuPy >= 13
+        else:
+            # Fall back (may download to CPU inside decord).
+            out = cp.asarray(frame.asnumpy())
+
+        if out.ndim == 2:
+            out = cp.stack([out, out, out], axis=2)
+        if out.ndim == 3 and out.shape[2] >= 3:
+            out = out[:, :, :3]
+        if out.dtype != cp.uint8:
+            out = out.astype(cp.uint8)
+
+        try:
+            if not out.flags.c_contiguous:
+                out = cp.ascontiguousarray(out)
+        except Exception:
+            pass
+
+        return out
+
+    def get_frame(self, t: float) -> np.ndarray:
+        """Return a NumPy uint8 RGB frame (public API compatibility)."""
+        from moviepy.video.tools import cupy_utils
+
+        cp = cupy_utils.cupy()
+        return cp.asnumpy(self.get_frame_gpu(t))
+
+    @property
+    def lastread(self):
+        # Keep attribute for compatibility; read the first frame.
+        return self.get_frame(0.0)
+
+    def close(self):
+        # Decord doesn't require explicit close, but drop references.
+        try:
+            self._vr = None
+        except Exception:
+            pass
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -298,7 +298,12 @@ class FFMPEG_VideoReader:
             elif codec_name == "vp8":
                 i_arg = ["-c:v", "libvpx"] + i_arg
 
-        def _build_cmd(i_arg_local, *, vf_override: str | None = None, sws_flags: str | None = None):
+        def _build_cmd(
+            i_arg_local,
+            *,
+            vf_override: str | None = None,
+            sws_flags: str | None = None,
+        ):
             cmd_local = [FFMPEG_BINARY] + i_arg_local
             cmd_local += [
                 "-loglevel",
@@ -332,7 +337,11 @@ class FFMPEG_VideoReader:
 
         # Candidate 1: end-to-end hwaccel (hwframes) with explicit download.
         if i_arg_hw_e2e is not None:
-            if hwaccel == "cuda" and self._needs_scaler and _env_flag("MOVIEPY_GPU_DECODE_SCALE", "1"):
+            if (
+                hwaccel == "cuda"
+                and self._needs_scaler
+                and _env_flag("MOVIEPY_GPU_DECODE_SCALE", "1")
+            ):
                 # Scale on GPU when available, then download.
                 vf = "scale_cuda=%d:%d,hwdownload,format=%s" % (
                     self.size[0],
@@ -369,6 +378,7 @@ class FFMPEG_VideoReader:
                 "stdin": sp.DEVNULL,
             }
         )
+
         def _spawn_and_preread(cmd_to_run):
             self.proc = sp.Popen(cmd_to_run, **popen_params)
             self.last_read = self.read_frame()
@@ -522,7 +532,10 @@ class FFMPEG_VideoReader:
                 except Exception:
                     pass
 
-            for stream in (getattr(proc, "stdout", None), getattr(proc, "stderr", None)):
+            for stream in (
+                getattr(proc, "stdout", None),
+                getattr(proc, "stderr", None),
+            ):
                 try:
                     if stream is not None:
                         stream.close()

--- a/moviepy/video/io/ffplay_previewer.py
+++ b/moviepy/video/io/ffplay_previewer.py
@@ -69,7 +69,9 @@ class FFPLAY_VideoPreviewer:
                     pass
 
             # ffplay expects C-contiguous raw bytes.
-            if isinstance(img_array, np.ndarray) and (not img_array.flags["C_CONTIGUOUS"]):
+            if isinstance(img_array, np.ndarray) and (
+                not img_array.flags["C_CONTIGUOUS"]
+            ):
                 img_array = np.ascontiguousarray(img_array)
 
             self.proc.stdin.write(memoryview(img_array))
@@ -145,7 +147,11 @@ def ffplay_preview_video(
 
     with FFPLAY_VideoPreviewer(clip.size, fps, pixel_format) as previewer:
         first_frame = True
-        if (gpu_render is not None) and gpu_render.is_enabled() and gpu_render.is_available():
+        if (
+            (gpu_render is not None)
+            and gpu_render.is_enabled()
+            and gpu_render.is_available()
+        ):
             import numpy as np
 
             n_frames = int(clip.duration * fps)
@@ -163,11 +169,15 @@ def ffplay_preview_video(
                     if audio_flag:
                         audio_flag.wait()
         else:
-            for t, frame in clip.iter_frames(with_times=True, fps=fps, dtype="uint8"):
+            for t, frame in clip.iter_frames(
+                with_times=True,
+                fps=fps,
+                dtype="uint8",
+            ):
                 previewer.show_frame(frame)
 
-                # After first frame is shown, if we have audio/video flag, set video ready
-                # and wait for audio
+                # After first frame is shown, if we have audio/video flag,
+                # set video ready and wait for audio
                 if first_frame:
                     first_frame = False
 

--- a/moviepy/video/io/gif_writers.py
+++ b/moviepy/video/io/gif_writers.py
@@ -22,7 +22,11 @@ def write_gif_with_imageio(clip, filename, fps=None, loop=0, logger="bar"):
 
     with iio.imopen(filename, "w", plugin="pillow") as writer:
         logger(message="MoviePy - Building file %s with imageio." % filename)
-        if (gpu_render is not None) and gpu_render.is_enabled() and gpu_render.is_available():
+        if (
+            (gpu_render is not None)
+            and gpu_render.is_enabled()
+            and gpu_render.is_available()
+        ):
             # Match Clip.iter_frames() time arithmetic for compatibility.
             n_frames = int(clip.duration * fps)
             for frame_index in logger.iter_bar(frame_index=range(n_frames)):

--- a/moviepy/video/io/gif_writers.py
+++ b/moviepy/video/io/gif_writers.py
@@ -1,6 +1,7 @@
 """MoviePy video GIFs writing."""
 
 import imageio.v3 as iio
+import numpy as np
 import proglog
 
 from moviepy.decorators import requires_duration, use_clip_fps_by_default
@@ -12,9 +13,39 @@ def write_gif_with_imageio(clip, filename, fps=None, loop=0, logger="bar"):
     """Writes the gif with the Python library ImageIO (calls FreeImage)."""
     logger = proglog.default_bar_logger(logger)
 
+    # Optional GPU compositor: keep compositing on GPU (CuPy) and download
+    # only at the ImageIO boundary.
+    try:
+        from moviepy.video.tools import gpu_render
+    except Exception:
+        gpu_render = None
+
     with iio.imopen(filename, "w", plugin="pillow") as writer:
         logger(message="MoviePy - Building file %s with imageio." % filename)
-        for frame in clip.iter_frames(fps=fps, logger=logger, dtype="uint8"):
-            writer.write(
-                frame, duration=1000 / fps, loop=loop
-            )  # Duration is in ms not s
+        if (gpu_render is not None) and gpu_render.is_enabled() and gpu_render.is_available():
+            # Match Clip.iter_frames() time arithmetic for compatibility.
+            n_frames = int(clip.duration * fps)
+            for frame_index in logger.iter_bar(frame_index=range(n_frames)):
+                t = np.float64(frame_index) / fps
+                # GIF writing does not support full alpha semantics; keep RGB.
+                frame = gpu_render._composite_rgb_gpu(clip, t)
+                if hasattr(frame, "__cuda_array_interface__"):
+                    try:
+                        import cupy as cp
+
+                        frame = cp.asnumpy(frame)
+                    except Exception:
+                        pass
+                writer.write(frame, duration=1000 / fps, loop=loop)
+        else:
+            for frame in clip.iter_frames(fps=fps, logger=logger, dtype="uint8"):
+                if hasattr(frame, "__cuda_array_interface__"):
+                    try:
+                        import cupy as cp
+
+                        frame = cp.asnumpy(frame)
+                    except Exception:
+                        pass
+                writer.write(
+                    frame, duration=1000 / fps, loop=loop
+                )  # Duration is in ms not s

--- a/moviepy/video/io/opencv_reader.py
+++ b/moviepy/video/io/opencv_reader.py
@@ -1,0 +1,341 @@
+"""Video reader based on OpenCV.
+
+This module provides an internal alternative to the ffmpeg pipe reader.
+
+Public APIs are unchanged; VideoFileClip selects a backend internally and will
+fall back to ffmpeg if OpenCV cannot open/read the file.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+
+import numpy as np
+
+from moviepy.video.io.ffmpeg_reader import ffmpeg_parse_infos
+
+
+class OpenCV_VideoReader:
+    """Class for video reading with OpenCV (cv2.VideoCapture)."""
+
+    def __init__(
+        self,
+        filename,
+        decode_file=True,
+        print_infos=False,
+        bufsize=None,  # kept for signature parity with FFMPEG_VideoReader
+        pixel_format="rgb24",
+        check_duration=True,
+        target_resolution=None,
+        resize_algo="bicubic",
+        fps_source="fps",
+        infos=None,
+        prefer_hwaccel=True,
+    ):
+        if pixel_format and pixel_format.lower().endswith("a"):
+            raise ValueError(
+                "OpenCV_VideoReader does not support alpha (rgba) decoding."
+            )
+
+        self.filename = filename
+        self.cap = None
+
+        if infos is None:
+            infos = ffmpeg_parse_infos(
+                filename,
+                check_duration=check_duration,
+                fps_source=fps_source,
+                decode_file=decode_file,
+                print_infos=print_infos,
+            )
+
+        self.fps = infos.get("video_fps", 1.0) or 1.0
+        self._raw_size = infos.get("video_size", (1, 1))
+        self.size = list(self._raw_size) if isinstance(self._raw_size, (list, tuple)) else self._raw_size
+        self._rotation_tag = infos.get("video_rotation", 0) or 0
+        self._rotation_apply = 0
+
+        # Match ffmpeg's auto-rotation behavior.
+        # Some OpenCV backends already auto-rotate; we detect that at runtime.
+        abs_rotation = abs(self._rotation_tag)
+        self.rotation = abs_rotation
+        if abs_rotation in (90, 270):
+            self.size = [self.size[1], self.size[0]]
+
+        if target_resolution:
+            if None in target_resolution:
+                ratio = 1
+                for idx, target in enumerate(target_resolution):
+                    if target:
+                        ratio = target / self.size[idx]
+                self.size = [int(self.size[0] * ratio), int(self.size[1] * ratio)]
+            else:
+                self.size = list(target_resolution)
+
+        self.resize_algo = resize_algo
+        self.duration = infos.get("video_duration", 0.0)
+        self.ffmpeg_duration = infos.get("duration", 0.0)
+        self.n_frames = infos.get("video_n_frames", 0)
+        self.bitrate = infos.get("video_bitrate", 0)
+        self.infos = infos
+
+        self.pixel_format = pixel_format
+        self.depth = 3
+
+        self._needs_resizer = target_resolution is not None
+
+        self._cv2 = None
+        self._prefer_hwaccel = bool(prefer_hwaccel)
+        self.initialize()
+
+    def _require_cv2(self):
+        if self._cv2 is None:
+            import cv2
+
+            self._cv2 = cv2
+        return self._cv2
+
+    def _postprocess_frame(self, frame):
+        cv2 = self._require_cv2()
+
+        # OpenCV returns BGR; convert to RGB.
+        if frame.ndim == 3 and frame.shape[2] >= 3:
+            frame = np.ascontiguousarray(frame[:, :, ::-1])
+        else:
+            frame = np.ascontiguousarray(frame)
+
+        # Apply rotation to match ffmpeg auto-rotate (only if needed).
+        rot = int(self._rotation_apply) % 360 if self._rotation_apply else 0
+        if rot == 90:
+            frame = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
+        elif rot == 180:
+            frame = cv2.rotate(frame, cv2.ROTATE_180)
+        elif rot == 270:
+            frame = cv2.rotate(frame, cv2.ROTATE_90_COUNTERCLOCKWISE)
+        elif rot not in (0,):
+            # Unknown/odd rotation; ignore to avoid surprising behavior.
+            pass
+
+        if self._needs_resizer and (tuple(frame.shape[1::-1]) != tuple(self.size)):
+            interpolation = cv2.INTER_CUBIC
+            if self.resize_algo in {"bilinear", "fast_bilinear"}:
+                interpolation = cv2.INTER_LINEAR
+            frame = cv2.resize(frame, tuple(self.size), interpolation=interpolation)
+
+        # Ensure uint8 output like ffmpeg rawvideo path.
+        if frame.dtype != np.uint8:
+            frame = frame.astype(np.uint8, copy=False)
+
+        return frame
+
+    def initialize(self, start_time=0):
+        self.close(delete_lastread=False)
+
+        cv2 = self._require_cv2()
+
+        self.cap = None
+
+        def _open_cap(api_preference=None, params=None):
+            # Newer OpenCV supports passing params to select hwaccel.
+            try:
+                if api_preference is None and params is None:
+                    return cv2.VideoCapture(self.filename)
+                if params is None:
+                    return cv2.VideoCapture(self.filename, api_preference)
+                return cv2.VideoCapture(self.filename, api_preference, params)
+            except TypeError:
+                if api_preference is None:
+                    return cv2.VideoCapture(self.filename)
+                return cv2.VideoCapture(self.filename, api_preference)
+
+        def _hw_params_any():
+            if not hasattr(cv2, "CAP_PROP_HW_ACCELERATION"):
+                return None
+            accel_any = getattr(cv2, "VIDEO_ACCELERATION_ANY", 1)
+            return [cv2.CAP_PROP_HW_ACCELERATION, accel_any]
+
+        if self._prefer_hwaccel:
+            params = _hw_params_any()
+            # Prefer FFmpeg backend when present, otherwise use default backend.
+            if hasattr(cv2, "CAP_FFMPEG"):
+                self.cap = _open_cap(cv2.CAP_FFMPEG, params=params)
+            if (self.cap is None) or (not self.cap.isOpened()):
+                self.cap = _open_cap(None, params=params)
+
+        if (self.cap is None) or (not self.cap.isOpened()):
+            if hasattr(cv2, "CAP_FFMPEG"):
+                self.cap = _open_cap(cv2.CAP_FFMPEG)
+            if (self.cap is None) or (not self.cap.isOpened()):
+                self.cap = _open_cap()
+
+        # Some builds only accept hwaccel via set() after opening.
+        if self._prefer_hwaccel and hasattr(cv2, "CAP_PROP_HW_ACCELERATION"):
+            try:
+                accel_any = getattr(cv2, "VIDEO_ACCELERATION_ANY", 1)
+                self.cap.set(cv2.CAP_PROP_HW_ACCELERATION, accel_any)
+            except Exception:
+                pass
+
+        if not self.cap or not self.cap.isOpened():
+            raise IOError(f"Could not open video file with OpenCV: {self.filename}")
+
+        # Reduce internal buffering where supported to lower RAM usage.
+        # Not all backends honor this property.
+        if hasattr(cv2, "CAP_PROP_BUFFERSIZE"):
+            try:
+                self.cap.set(cv2.CAP_PROP_BUFFERSIZE, 1)
+            except Exception:
+                pass
+
+        # If the backend indicates it already auto-rotates, do not rotate again.
+        orientation_auto = None
+        if hasattr(cv2, "CAP_PROP_ORIENTATION_AUTO"):
+            try:
+                orientation_auto = self.cap.get(cv2.CAP_PROP_ORIENTATION_AUTO)
+            except Exception:
+                orientation_auto = None
+
+        rot = int(round(self._rotation_tag)) if self._rotation_tag else 0
+        if rot:
+            rot = rot % 360
+
+        self._rotation_apply = rot
+
+        self.pos = self.get_frame_number(start_time)
+        if self.pos != 0:
+            self.cap.set(cv2.CAP_PROP_POS_FRAMES, float(self.pos))
+
+        ok, frame = self.cap.read()
+        if not ok or frame is None:
+            raise IOError(
+                f"MoviePy error: failed to read the first frame of video file {self.filename}."
+            )
+
+        # Detect OpenCV auto-rotation for 90/270 cases by comparing raw frame shape
+        # with metadata. When auto-rotation is enabled, OpenCV typically swaps the
+        # dimensions already.
+        try:
+            raw_w, raw_h = int(self._raw_size[0]), int(self._raw_size[1])
+        except Exception:
+            raw_w, raw_h = 0, 0
+
+        if orientation_auto not in (None, 0, 0.0):
+            self._rotation_apply = 0
+        elif self._rotation_apply in (90, 270) and raw_w and raw_h:
+            if tuple(frame.shape[:2]) == (raw_w, raw_h):
+                # Frame is already (h,w) == (raw_w, raw_h) => dimensions swapped.
+                self._rotation_apply = 0
+
+        self.last_read = self._postprocess_frame(frame)
+
+        # Trust the processed frame dimensions for downstream writer sizing.
+        self.size = list(self.last_read.shape[1::-1])
+        self.pos += 1
+
+        # EOF/warn state (reset on re-init).
+        self._eof = False
+        self._eof_pos = None
+        self._warned_eof = False
+
+    def skip_frames(self, n=1):
+        cv2 = self._require_cv2()
+        if not self.cap:
+            self.initialize(0)
+
+        # Use grab() to advance without decoding.
+        advanced = 0
+        for _ in range(int(n)):
+            ok = self.cap.grab()
+            if not ok:
+                self._eof = True
+                if self._eof_pos is None:
+                    self._eof_pos = self.pos
+                break
+            advanced += 1
+        self.pos += advanced
+
+    def read_frame(self):
+        if not self.cap:
+            self.initialize(0)
+
+        if getattr(self, "_eof", False):
+            # Do not warn repeatedly: keep returning last frame.
+            self.pos += 1
+            return self.last_read
+
+        ok, frame = self.cap.read()
+        if not ok or frame is None:
+            warn_eof = os.environ.get("MOVIEPY_OPENCV_EOF_WARNING", "0")
+            warn_eof = str(warn_eof).strip().lower() not in {"0", "false", "no", "off", ""}
+
+            if warn_eof and (not getattr(self, "_warned_eof", False)):
+                warnings.warn(
+                    (
+                        "In file %s, failed to read frame index %d. "
+                        "Using the last valid frame instead."
+                    )
+                    % (self.filename, self.pos),
+                    UserWarning,
+                )
+                self._warned_eof = True
+            self._eof = True
+            if self._eof_pos is None:
+                self._eof_pos = self.pos
+            if not hasattr(self, "last_read"):
+                raise IOError(
+                    (
+                        "MoviePy error: failed to read the first frame of "
+                        f"video file {self.filename}. That might mean that the file is "
+                        "corrupted."
+                    )
+                )
+            result = self.last_read
+        else:
+            result = self._postprocess_frame(frame)
+            self.last_read = result
+
+        self.pos += 1
+        return result
+
+    def get_frame(self, t):
+        pos = self.get_frame_number(t) + 1
+
+        if not self.cap:
+            self.initialize(t)
+            return self.last_read
+
+        if pos == self.pos:
+            return self.last_read
+        elif getattr(self, "_eof", False) and (self._eof_pos is not None) and (pos >= self._eof_pos):
+            return self.last_read
+        elif (pos < self.pos) or (pos > self.pos + 100):
+            self.initialize(t)
+            return self.last_read
+        else:
+            self.skip_frames(pos - self.pos - 1)
+            return self.read_frame()
+
+    @property
+    def lastread(self):
+        return self.last_read
+
+    def get_frame_number(self, t):
+        return int(self.fps * t + 0.00001)
+
+    def close(self, delete_lastread=True):
+        if self.cap is not None:
+            try:
+                self.cap.release()
+            except Exception:
+                pass
+            self.cap = None
+
+        if delete_lastread and hasattr(self, "last_read"):
+            del self.last_read
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/moviepy/video/io/pynvcodec_writer.py
+++ b/moviepy/video/io/pynvcodec_writer.py
@@ -1,0 +1,448 @@
+"""Optional GPU-native video encoding via NVIDIA NVENC (PyNvCodec).
+
+This module is internal and best-effort:
+- It is only attempted when the experimental GPU render path is explicitly enabled.
+- It never changes MoviePy's public API.
+- It always falls back to the existing FFmpeg stdin writer on any failure.
+
+The goal is to avoid downloading per-frame RGB data back to the CPU for encoding.
+We still rely on FFmpeg for container muxing and (optionally) audio.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from moviepy.config import FFMPEG_BINARY
+from moviepy.tools import ffmpeg_escape_filename, subprocess_call
+
+
+def _env_flag(name: str, default: str = "0") -> bool:
+    val = os.environ.get(name, default)
+    return str(val).strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def _disabled_value(val: str) -> bool:
+    v = (val or "").strip().lower()
+    return v in {"0", "false", "no", "off", "none", "disable", "disabled"}
+
+
+def gpu_encode_backend() -> str:
+    return (os.getenv("MOVIEPY_GPU_ENCODE_BACKEND") or "auto").strip().lower()
+
+
+def is_enabled() -> bool:
+    """Whether GPU-native encoding should be attempted.
+
+    To avoid surprising behavior, this only turns on when GPU render is
+    *explicitly* enabled (or aggressive mode is set).
+    """
+    if _env_flag("MOVIEPY_DISABLE_GPU", "0"):
+        return False
+    if _env_flag("MOVIEPY_DISABLE_GPU_ENCODE", "0"):
+        return False
+
+    backend = gpu_encode_backend()
+    if _disabled_value(backend):
+        return False
+
+    # Aggressive implies opt-in.
+    if _env_flag("MOVIEPY_GPU_AGGRESSIVE", "0"):
+        return True
+
+    # Only opt-in when user explicitly enabled GPU render.
+    if "MOVIEPY_GPU_RENDER" in os.environ and _env_flag("MOVIEPY_GPU_RENDER", "0"):
+        return True
+
+    return False
+
+
+def _strict() -> bool:
+    return _env_flag("MOVIEPY_GPU_ENCODE_STRICT", "0")
+
+
+def _parse_gpu_id() -> int:
+    try:
+        return int(os.getenv("MOVIEPY_GPU_DEVICE", "0"))
+    except Exception:
+        return 0
+
+
+def _map_codec(codec: str) -> Optional[str]:
+    """Map MoviePy/FFmpeg-ish codec strings to PyNvEncoder codec values."""
+    c = (codec or "").strip().lower()
+    if not c:
+        return None
+    if "hevc" in c or "h265" in c or "libx265" in c or c == "h265_nvenc":
+        return "hevc"
+    if "h264" in c or "x264" in c or "libx264" in c or c == "h264_nvenc":
+        return "h264"
+    return None
+
+
+def _map_nvenc_preset(preset: str) -> str:
+    """Best-effort mapping from FFmpeg preset names to NVENC preset IDs."""
+    p = (preset or "").strip().lower()
+    return {
+        "ultrafast": "P1",
+        "superfast": "P2",
+        "veryfast": "P3",
+        "faster": "P4",
+        "fast": "P4",
+        "medium": "P5",
+        "slow": "P6",
+        "slower": "P7",
+        "veryslow": "P7",
+        "placebo": "P7",
+    }.get(p, "P5")
+
+
+def _import_nvc():
+    """Import NV codec bindings.
+
+    Prefer legacy `PyNvCodec` when available, otherwise fall back to NVIDIA's
+    pip-distributed successor `PyNvVideoCodec`.
+    """
+
+    # Windows: PyNvVideoCodec relies on CUDA/driver DLLs being discoverable.
+    # Notably, current wheels depend on the CUDA 12 runtime DLL `cudart64_12.dll`.
+    # Make a best-effort attempt to add plausible CUDA runtime directories.
+    if os.name == "nt" and hasattr(os, "add_dll_directory"):
+        # 1) If installed via pip, `nvidia-cuda-runtime-cu12` provides cudart64_12.dll
+        # under `.../site-packages/nvidia/cuda_runtime/bin`.
+        try:
+            import site
+
+            roots = []
+            try:
+                roots.append(site.getusersitepackages())
+            except Exception:
+                pass
+            try:
+                roots.extend(site.getsitepackages() or [])
+            except Exception:
+                pass
+
+            for root in roots:
+                if not root:
+                    continue
+                dll_dir = os.path.join(root, "nvidia", "cuda_runtime", "bin")
+                try:
+                    if os.path.isfile(os.path.join(dll_dir, "cudart64_12.dll")):
+                        os.add_dll_directory(dll_dir)
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+        # 2) CUDA Toolkit installs (any version) often provide runtime DLLs under
+        # CUDA_PATH\bin\x64 (or sometimes CUDA_PATH\bin).
+        cuda_roots = []
+        cuda_roots.append(os.environ.get("CUDA_PATH"))
+        for name, value in os.environ.items():
+            if name.startswith("CUDA_PATH_V") and value:
+                cuda_roots.append(value)
+
+        for cuda_root in cuda_roots:
+            if not cuda_root:
+                continue
+            for rel in ("bin", os.path.join("bin", "x64"), os.path.join("lib", "x64")):
+                dll_dir = os.path.join(cuda_root, rel)
+                try:
+                    if os.path.isdir(dll_dir):
+                        os.add_dll_directory(dll_dir)
+                except Exception:
+                    pass
+
+    try:
+        import PyNvCodec as nvc  # type: ignore
+
+        return nvc
+    except Exception:
+        import PyNvVideoCodec as nvc  # type: ignore
+
+        return nvc
+
+
+def _ffmpeg_remux_h26x(
+    *,
+    input_stream: str,
+    output_file: str,
+    fps: float,
+    is_hevc: bool,
+    audiofile: Optional[str],
+    audio_codec: Optional[str],
+    logger,
+) -> None:
+    stream_fmt = "hevc" if is_hevc else "h264"
+    cmd = [
+        FFMPEG_BINARY,
+        "-y",
+        "-loglevel",
+        "error",
+        "-r",
+        f"{fps:.02f}",
+        "-f",
+        stream_fmt,
+        "-i",
+        ffmpeg_escape_filename(input_stream),
+    ]
+
+    if audiofile is not None:
+        cmd.extend(["-i", ffmpeg_escape_filename(audiofile)])
+        cmd.extend(["-c:v", "copy"])
+        cmd.extend(["-c:a", audio_codec or "copy"])
+    else:
+        cmd.extend(["-c:v", "copy", "-an"])
+
+    cmd.append(ffmpeg_escape_filename(output_file))
+    subprocess_call(cmd, logger=logger)
+
+
+@dataclass
+class _EncodeContext:
+    gpu_id: int
+    width: int
+    height: int
+    fps: float
+    codec: str
+    preset: str
+    bitrate: Optional[str]
+
+
+class _SurfaceConverterChain:
+    def __init__(self, nvc, width: int, height: int, gpu_id: int, chain):
+        self._nvc = nvc
+        self._gpu_id = gpu_id
+        self._cc = nvc.ColorspaceConversionContext(nvc.ColorSpace.BT_601, nvc.ColorRange.MPEG)
+        self._chain = [nvc.PySurfaceConverter(width, height, src, dst, gpu_id) for (src, dst) in chain]
+
+    def run(self, surf):
+        out = surf
+        for cvt in self._chain:
+            out = cvt.Execute(out, self._cc)
+            if out.Empty():
+                raise RuntimeError("GPU colorspace conversion failed")
+        return out.Clone(self._gpu_id)
+
+
+class PyNvCodecNVENCWriter:
+    """Write H.264/HEVC using NVENC from CuPy RGB frames."""
+
+    def __init__(
+        self,
+        *,
+        width: int,
+        height: int,
+        fps: float,
+        codec: str,
+        preset: str,
+        bitrate: Optional[str],
+        gpu_id: int,
+        out_stream_path: str,
+    ):
+        import cupy as cp  # lazy
+        nvc = _import_nvc()
+
+        self._cp = cp
+        self._nvc = nvc
+        self._ctx = _EncodeContext(
+            gpu_id=gpu_id,
+            width=width,
+            height=height,
+            fps=fps,
+            codec=codec,
+            preset=preset,
+            bitrate=bitrate,
+        )
+        self._out = open(out_stream_path, "wb")
+        self._out_stream_path = out_stream_path
+        self._packet = np.ndarray(shape=(0,), dtype=np.uint8)
+
+        res = f"{width}x{height}"
+        enc_params = {
+            "codec": codec,
+            "preset": preset,
+            "s": res,
+            "tuning_info": "high_quality",
+        }
+        if bitrate:
+            enc_params["bitrate"] = bitrate
+
+        self._enc = nvc.PyNvEncoder(enc_params, gpu_id)
+
+        # Convert packed RGB to NV12 for NVENC.
+        self._to_nv12 = _SurfaceConverterChain(
+            nvc,
+            width,
+            height,
+            gpu_id,
+            chain=[
+                (nvc.PixelFormat.RGB_PLANAR, nvc.PixelFormat.RGB),
+                (nvc.PixelFormat.RGB, nvc.PixelFormat.YUV420),
+                (nvc.PixelFormat.YUV420, nvc.PixelFormat.NV12),
+            ],
+        )
+
+    def _cupy_rgb_to_surface_rgb_planar(self, frame):
+        cp = self._cp
+        nvc = self._nvc
+        if not hasattr(frame, "__cuda_array_interface__"):
+            raise RuntimeError("Expected a GPU frame (CUDA array)")
+
+        f = frame
+        if f.ndim != 3 or f.shape[2] < 3:
+            raise ValueError(f"Expected HxWx3 frame, got shape={getattr(f, 'shape', None)!r}")
+        f = f[:, :, :3]
+        if f.dtype != cp.uint8:
+            f = f.astype(cp.uint8)
+        try:
+            if not f.flags.c_contiguous:
+                f = cp.ascontiguousarray(f)
+        except Exception:
+            f = cp.ascontiguousarray(f)
+
+        # Packed HWC -> planar CHW, then a device-to-device copy into VPF surface.
+        chw = cp.transpose(f, (2, 0, 1))
+        chw = cp.ascontiguousarray(chw)
+
+        surface = nvc.Surface.Make(nvc.PixelFormat.RGB_PLANAR, self._ctx.width, self._ctx.height, self._ctx.gpu_id)
+        dst_ptr = surface.PlanePtr().GpuMem()
+        dst_pitch = surface.Pitch()
+        width_bytes = surface.Width()
+        height_rows = surface.Height() * 3
+        cp.cuda.runtime.memcpy2DAsync(
+            dst_ptr,
+            dst_pitch,
+            chw.data.ptr,
+            width_bytes,
+            width_bytes,
+            height_rows,
+            cp.cuda.runtime.memcpyDeviceToDevice,
+            0,
+        )
+        return surface
+
+    def write_frame(self, frame_rgb):
+        surface_rgb = self._cupy_rgb_to_surface_rgb_planar(frame_rgb)
+        surface_nv12 = self._to_nv12.run(surface_rgb)
+        success = self._enc.EncodeSingleSurface(surface_nv12, self._packet)
+        if success:
+            self._out.write(bytearray(self._packet))
+
+    def close(self):
+        if getattr(self, "_enc", None) is not None:
+            while self._enc.FlushSinglePacket(self._packet):
+                self._out.write(bytearray(self._packet))
+        if getattr(self, "_out", None) is not None:
+            try:
+                self._out.close()
+            finally:
+                self._out = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+
+def try_write_video_pynvcodec(
+    *,
+    clip,
+    filename: str,
+    fps: float,
+    codec: str,
+    bitrate: Optional[str],
+    preset: str,
+    audiofile: Optional[str],
+    audio_codec: Optional[str],
+    logger,
+    gpu_render,
+    pixel_format: Optional[str],
+) -> bool:
+    """Best-effort: encode via NVENC from GPU frames, then mux via FFmpeg.
+
+    Returns True if the file was written. Returns False to indicate the caller
+    should fall back to the standard FFmpeg stdin writer.
+    """
+    if not is_enabled():
+        return False
+
+    backend = gpu_encode_backend()
+    if backend not in {"auto", "pynvcodec", "pynv", "nvenc"}:
+        # Unknown/unsupported backend: do not attempt.
+        return False
+
+    if clip.mask is not None:
+        # NVENC path doesn't preserve alpha.
+        return False
+
+    if pixel_format is not None:
+        # Respect user request; NVENC path uses NV12 internally.
+        return False
+
+    mapped = _map_codec(codec)
+    if mapped is None:
+        return False
+
+    # NV12 requires even dimensions.
+    if (clip.w % 2) or (clip.h % 2):
+        return False
+
+    gpu_id = _parse_gpu_id()
+    nvenc_preset = _map_nvenc_preset(preset)
+
+    # We encode to an elementary stream, then remux to the requested container.
+    suffix = ".hevc" if mapped == "hevc" else ".h264"
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+    tmp_path = tmp.name
+    tmp.close()
+
+    try:
+        # These imports are intentionally inside the try so missing optional deps
+        # just trigger a fallback.
+        import cupy as _cp  # noqa: F401
+        _import_nvc()
+
+        with PyNvCodecNVENCWriter(
+            width=clip.w,
+            height=clip.h,
+            fps=float(fps),
+            codec=mapped,
+            preset=nvenc_preset,
+            bitrate=bitrate,
+            gpu_id=gpu_id,
+            out_stream_path=tmp_path,
+        ) as writer:
+            n_frames = int(clip.duration * fps)
+            for frame_index in logger.iter_bar(frame_index=range(n_frames)):
+                t = np.float64(frame_index) / fps
+                frame = gpu_render.get_frame_for_export_uint8_gpu(clip, t)
+                writer.write_frame(frame)
+
+        _ffmpeg_remux_h26x(
+            input_stream=tmp_path,
+            output_file=filename,
+            fps=float(fps),
+            is_hevc=(mapped == "hevc"),
+            audiofile=audiofile,
+            audio_codec=audio_codec,
+            logger=logger,
+        )
+        return True
+    except Exception:
+        if _strict() or backend in {"pynvcodec", "pynv", "nvenc"}:
+            raise
+        return False
+    finally:
+        try:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        except Exception:
+            pass

--- a/moviepy/video/io/pynvcodec_writer.py
+++ b/moviepy/video/io/pynvcodec_writer.py
@@ -1,7 +1,8 @@
-"""Optional GPU-native video encoding via NVIDIA NVENC (PyNvCodec).
+"""Optional GPU-native video encoding via NVIDIA NVENC (PyNvCodec/PyNvVideoCodec).
 
 This module is internal and best-effort:
-- It is only attempted when the experimental GPU render path is explicitly enabled.
+- It is attempted when GPU encoding isn't disabled. With backend=auto (default),
+  we try NVENC opportunistically and fall back silently on any failure.
 - It never changes MoviePy's public API.
 - It always falls back to the existing FFmpeg stdin writer on any failure.
 
@@ -13,14 +14,17 @@ from __future__ import annotations
 
 import os
 import subprocess as sp
-import tempfile
 from dataclasses import dataclass
 from typing import Optional
 
 import numpy as np
 
 from moviepy.config import FFMPEG_BINARY
-from moviepy.tools import cross_platform_popen_params, ffmpeg_escape_filename, subprocess_call
+from moviepy.tools import (
+    cross_platform_popen_params,
+    ffmpeg_escape_filename,
+    subprocess_call,
+)
 
 
 def _env_flag(name: str, default: str = "0") -> bool:
@@ -40,8 +44,8 @@ def gpu_encode_backend() -> str:
 def is_enabled() -> bool:
     """Whether GPU-native encoding should be attempted.
 
-    To avoid surprising behavior, this only turns on when GPU render is
-    *explicitly* enabled (or aggressive mode is set).
+    GPU encoding can be disabled via env vars. Otherwise, NVENC is attempted
+    opportunistically (backend=auto) or explicitly (backend=nvenc/pynv/pynvcodec).
     """
     if _env_flag("MOVIEPY_DISABLE_GPU", "0"):
         return False
@@ -52,15 +56,16 @@ def is_enabled() -> bool:
     if _disabled_value(backend):
         return False
 
-    # Aggressive implies opt-in.
-    if _env_flag("MOVIEPY_GPU_AGGRESSIVE", "0"):
+    if backend not in {"auto", "pynvcodec", "pynv", "nvenc"}:
+        return False
+
+    # If the user explicitly requested an NVENC backend, treat that as opt-in
+    # even when GPU render isn't enabled. We'll still fall back safely if any
+    # required pieces aren't available.
+    if backend in {"pynvcodec", "pynv", "nvenc"}:
         return True
 
-    # Only opt-in when user explicitly enabled GPU render.
-    if "MOVIEPY_GPU_RENDER" in os.environ and _env_flag("MOVIEPY_GPU_RENDER", "0"):
-        return True
-
-    return False
+    return True
 
 
 def _strict() -> bool:
@@ -101,6 +106,142 @@ def _map_nvenc_preset(preset: str) -> str:
         "veryslow": "P7",
         "placebo": "P7",
     }.get(p, "P5")
+
+
+def _parse_color_matrix(val: Optional[str]) -> str:
+    v = (val or "").strip().lower()
+    if v in {"bt709", "709"}:
+        return "bt709"
+    return "bt601"
+
+
+def _parse_color_range(val: Optional[str]) -> str:
+    v = (val or "").strip().lower()
+    if v in {"jpeg", "full", "pc", "fullrange"}:
+        return "jpeg"
+    return "mpeg"
+
+
+def _gpu_color_settings_for_clip(clip) -> tuple[str, str]:
+    # Clip-level overrides (internal attrs) take precedence.
+    matrix = getattr(clip, "_gpu_color_matrix", None)
+    crange = getattr(clip, "_gpu_color_range", None)
+    if matrix is None:
+        matrix = os.getenv("MOVIEPY_GPU_COLOR_MATRIX")
+    if crange is None:
+        crange = os.getenv("MOVIEPY_GPU_COLOR_RANGE")
+    return _parse_color_matrix(matrix), _parse_color_range(crange)
+
+
+_RGB_TO_NV12_KERNEL_CACHE = {}
+
+
+def _get_rgb_to_nv12_kernel(cp, *, matrix: str, crange: str):
+    key = (matrix, crange)
+    k = _RGB_TO_NV12_KERNEL_CACHE.get(key)
+    if k is not None:
+        return k
+
+    # Integer coefficient sets.
+    # Limited (MPEG): Y has +16 offset, coefficients scaled for 219/255 range.
+    # Full (JPEG): Y has no offset, coefficients are full-range.
+    if matrix == "bt709" and crange == "mpeg":
+        y_r, y_g, y_b, y_off = 47, 157, 16, 16
+        u_r, u_g, u_b, u_off = -26, -87, 112, 128
+        v_r, v_g, v_b, v_off = 112, -102, -10, 128
+    elif matrix == "bt709" and crange == "jpeg":
+        y_r, y_g, y_b, y_off = 54, 183, 18, 0
+        u_r, u_g, u_b, u_off = -29, -99, 128, 128
+        v_r, v_g, v_b, v_off = 128, -116, -12, 128
+    elif matrix == "bt601" and crange == "jpeg":
+        y_r, y_g, y_b, y_off = 77, 150, 29, 0
+        u_r, u_g, u_b, u_off = -43, -85, 128, 128
+        v_r, v_g, v_b, v_off = 128, -107, -21, 128
+    else:
+        # Default: BT.601 limited/MPEG.
+        y_r, y_g, y_b, y_off = 66, 129, 25, 16
+        u_r, u_g, u_b, u_off = -38, -74, 112, 128
+        v_r, v_g, v_b, v_off = 112, -94, -18, 128
+
+    src = rf'''
+    extern "C" __device__ __forceinline__ unsigned char clamp_u8(int v) {{
+        return (unsigned char)(v < 0 ? 0 : (v > 255 ? 255 : v));
+    }}
+
+    extern "C" __global__ void rgb_to_nv12_u8(
+        const unsigned char* __restrict__ src,
+        unsigned char* __restrict__ y_plane,
+        unsigned char* __restrict__ uv_plane,
+        const int w,
+        const int h,
+        const int src_pitch,
+        const int y_pitch,
+        const int uv_pitch
+    ) {{
+        int bx = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+        int by = (int)(blockIdx.y * blockDim.y + threadIdx.y);
+        int x = bx * 2;
+        int y = by * 2;
+        if (x + 1 >= w || y + 1 >= h) return;
+
+        const unsigned char* row0 = src + y * src_pitch;
+        const unsigned char* row1 = src + (y + 1) * src_pitch;
+
+        int idx00 = x * 3;
+        int idx01 = (x + 1) * 3;
+        int idx10 = x * 3;
+        int idx11 = (x + 1) * 3;
+
+        int r00 = (int)row0[idx00 + 0];
+        int g00 = (int)row0[idx00 + 1];
+        int b00 = (int)row0[idx00 + 2];
+
+        int r01 = (int)row0[idx01 + 0];
+        int g01 = (int)row0[idx01 + 1];
+        int b01 = (int)row0[idx01 + 2];
+
+        int r10 = (int)row1[idx10 + 0];
+        int g10 = (int)row1[idx10 + 1];
+        int b10 = (int)row1[idx10 + 2];
+
+        int r11 = (int)row1[idx11 + 0];
+        int g11 = (int)row1[idx11 + 1];
+        int b11 = (int)row1[idx11 + 2];
+
+        int y00 = (({y_r} * r00 + {y_g} * g00 + {y_b} * b00 + 128) >> 8) + {y_off};
+        int y01 = (({y_r} * r01 + {y_g} * g01 + {y_b} * b01 + 128) >> 8) + {y_off};
+        int y10 = (({y_r} * r10 + {y_g} * g10 + {y_b} * b10 + 128) >> 8) + {y_off};
+        int y11 = (({y_r} * r11 + {y_g} * g11 + {y_b} * b11 + 128) >> 8) + {y_off};
+
+        unsigned char* y_row0 = y_plane + y * y_pitch;
+        unsigned char* y_row1 = y_plane + (y + 1) * y_pitch;
+        y_row0[x] = clamp_u8(y00);
+        y_row0[x + 1] = clamp_u8(y01);
+        y_row1[x] = clamp_u8(y10);
+        y_row1[x + 1] = clamp_u8(y11);
+
+        int u00 = (({u_r} * r00 + {u_g} * g00 + {u_b} * b00 + 128) >> 8) + {u_off};
+        int u01 = (({u_r} * r01 + {u_g} * g01 + {u_b} * b01 + 128) >> 8) + {u_off};
+        int u10 = (({u_r} * r10 + {u_g} * g10 + {u_b} * b10 + 128) >> 8) + {u_off};
+        int u11 = (({u_r} * r11 + {u_g} * g11 + {u_b} * b11 + 128) >> 8) + {u_off};
+
+        int v00 = (({v_r} * r00 + {v_g} * g00 + {v_b} * b00 + 128) >> 8) + {v_off};
+        int v01 = (({v_r} * r01 + {v_g} * g01 + {v_b} * b01 + 128) >> 8) + {v_off};
+        int v10 = (({v_r} * r10 + {v_g} * g10 + {v_b} * b10 + 128) >> 8) + {v_off};
+        int v11 = (({v_r} * r11 + {v_g} * g11 + {v_b} * b11 + 128) >> 8) + {v_off};
+
+        int u = (u00 + u01 + u10 + u11 + 2) >> 2;
+        int v = (v00 + v01 + v10 + v11 + 2) >> 2;
+
+        unsigned char* uv_row = uv_plane + by * uv_pitch;
+        uv_row[x] = clamp_u8(u);
+        uv_row[x + 1] = clamp_u8(v);
+    }}
+    '''
+
+    k = cp.RawKernel(src, "rgb_to_nv12_u8")
+    _RGB_TO_NV12_KERNEL_CACHE[key] = k
+    return k
 
 
 def _import_nvc():
@@ -165,7 +306,18 @@ def _import_nvc():
 
         return nvc
     except Exception:
-        import PyNvVideoCodec as nvc  # type: ignore
+        # PyNvVideoCodec currently triggers a DeprecationWarning on Python 3.13+
+        # due to internal use of deprecated ast nodes. Silence it here so users
+        # don't see noise during normal operation.
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                module=r"^PyNvVideoCodec(\\..*)?$",
+            )
+            import PyNvVideoCodec as nvc  # type: ignore
 
         return nvc
 
@@ -251,7 +403,9 @@ class _FFmpegH26xPipeMuxer:
         if logger is not None:
             logger(message="MoviePy - Running:\n>>> " + " ".join(self._cmd))
 
-        popen_params = cross_platform_popen_params({"stdout": sp.DEVNULL, "stderr": sp.PIPE, "stdin": sp.PIPE})
+        popen_params = cross_platform_popen_params(
+            {"stdout": sp.DEVNULL, "stderr": sp.PIPE, "stdin": sp.PIPE}
+        )
         self._proc = sp.Popen(self._cmd, **popen_params)
         assert self._proc.stdin is not None
         return self._proc.stdin
@@ -305,8 +459,13 @@ class _SurfaceConverterChain:
     def __init__(self, nvc, width: int, height: int, gpu_id: int, chain):
         self._nvc = nvc
         self._gpu_id = gpu_id
-        self._cc = nvc.ColorspaceConversionContext(nvc.ColorSpace.BT_601, nvc.ColorRange.MPEG)
-        self._chain = [nvc.PySurfaceConverter(width, height, src, dst, gpu_id) for (src, dst) in chain]
+        self._cc = nvc.ColorspaceConversionContext(
+            nvc.ColorSpace.BT_601, nvc.ColorRange.MPEG
+        )
+        self._chain = [
+            nvc.PySurfaceConverter(width, height, src, dst, gpu_id)
+            for (src, dst) in chain
+        ]
 
     def run(self, surf):
         out = surf
@@ -318,8 +477,486 @@ class _SurfaceConverterChain:
         return out
 
 
+def _parse_bitrate_to_bps(bitrate: Optional[str]) -> Optional[int]:
+    if not bitrate:
+        return None
+    if isinstance(bitrate, (int, float)):
+        try:
+            return int(bitrate)
+        except Exception:
+            return None
+
+    s = str(bitrate).strip()
+    if not s:
+        return None
+
+    # Common MoviePy/FFmpeg-style forms: "5000k", "5M", "8000000".
+    mult = 1
+    last = s[-1].lower()
+    if last in {"k", "m", "g"}:
+        s_num = s[:-1].strip()
+        mult = {"k": 1000, "m": 1000_000, "g": 1000_000_000}[last]
+    else:
+        s_num = s
+
+    try:
+        return int(float(s_num) * mult)
+    except Exception:
+        return None
+
+
+class _NV12CudaFrame:
+    """PyNvVideoCodec GPU-buffer input frame helper.
+
+    For GPU buffer mode, PyNvVideoCodec expects an object with a `cuda()` method
+    that returns CUDA Array Interface dictionaries for each plane.
+    """
+
+    def __init__(self, y_plane, uv_plane):
+        self._y = y_plane
+        self._uv = uv_plane
+
+    def cuda(self):
+        return [self._y.__cuda_array_interface__, self._uv.__cuda_array_interface__]
+
+
+class PyNvVideoCodecNVENCWriter:
+    """Write H.264/HEVC using NVENC from CuPy RGB frames (PyNvVideoCodec)."""
+
+    class _Slot:
+        __slots__ = ("nv12", "y", "uv", "frame", "conv_done", "encode_done")
+
+        def __init__(self, nv12, y, uv, frame, conv_done, encode_done):
+            self.nv12 = nv12
+            self.y = y
+            self.uv = uv
+            self.frame = frame
+            self.conv_done = conv_done
+            self.encode_done = encode_done
+
+    @staticmethod
+    def _create_encoder_best_effort(nvc, width: int, height: int, params: dict):
+        """Create a PyNvVideoCodec encoder.
+
+        Tolerates API differences across versions.
+        """
+
+        attempts = [
+            dict(params),
+            {k: v for k, v in params.items() if k != "gpuid"},
+            {k: v for k, v in params.items() if k not in {"gpuid", "repeatspspps"}},
+            {
+                k: v
+                for k, v in params.items()
+                if k not in {"gpuid", "repeatspspps", "tuning_info"}
+            },
+            {k: v for k, v in params.items() if k in {"codec", "preset", "fps"}},
+            {k: v for k, v in params.items() if k in {"codec", "preset"}},
+            {k: v for k, v in params.items() if k in {"codec"}},
+        ]
+
+        last_exc = None
+        for p in attempts:
+            try:
+                return nvc.CreateEncoder(width, height, "NV12", False, **p)
+            except Exception as exc:  # best-effort; retry with fewer args
+                last_exc = exc
+                continue
+
+        raise last_exc
+
+    @staticmethod
+    def _iter_packets(payload):
+        if not payload:
+            return
+        if isinstance(payload, (bytes, bytearray, memoryview)):
+            yield payload
+            return
+        # Some bindings return a list of packets.
+        if isinstance(payload, (list, tuple)):
+            for p in payload:
+                if p:
+                    yield p
+            return
+        yield payload
+
+    def __init__(
+        self,
+        *,
+        width: int,
+        height: int,
+        fps: float,
+        codec: str,
+        preset: str,
+        bitrate: Optional[str],
+        gpu_id: int,
+        color_matrix: str = "bt601",
+        color_range: str = "mpeg",
+        out,
+    ):
+        import cupy as cp  # lazy
+
+        nvc = _import_nvc()
+
+        self._cp = cp
+        self._nvc = nvc
+        self._ctx = _EncodeContext(
+            gpu_id=gpu_id,
+            width=width,
+            height=height,
+            fps=fps,
+            codec=codec,
+            preset=preset,
+            bitrate=bitrate,
+        )
+        self._out = out
+
+        # Explicit streams for conversion/encoding.
+        # We keep conversion on a dedicated stream; encode is assumed to run on the
+        # default stream (or an internal stream), so we order with CUDA events.
+        self._conv_stream = cp.cuda.Stream(non_blocking=True)
+        self._pending = []
+
+        # Surface/buffer pool to avoid overwriting an input buffer while NVENC is still
+        # consuming it, and to enable overlap between conversion and encode.
+        self._pool_size = max(2, int(os.getenv("MOVIEPY_GPU_ENCODE_POOL", "3")))
+        self._slots = []
+        for _ in range(self._pool_size):
+            nv12 = cp.empty((height + height // 2, width), dtype=cp.uint8)
+            y = nv12[:height, :]
+            uv = nv12[height : height + height // 2, :]
+            frame = _NV12CudaFrame(y, uv)
+            self._slots.append(
+                self._Slot(
+                    nv12,
+                    y,
+                    uv,
+                    frame,
+                    cp.cuda.Event(),
+                    cp.cuda.Event(),
+                )
+            )
+        self._slot_index = 0
+
+        # Kernel: packed HWC RGB -> NV12 (BT.601 limited/MPEG range).
+        self._color_matrix = _parse_color_matrix(color_matrix)
+        self._color_range = _parse_color_range(color_range)
+        self._rgb_to_nv12 = _get_rgb_to_nv12_kernel(
+            cp,
+            matrix=self._color_matrix,
+            crange=self._color_range,
+        )
+
+        enc_params = {
+            "codec": codec,
+            "preset": preset,
+            "fps": float(fps),
+            "tuning_info": "high_quality",
+            # Ensure elementary stream contains headers suitable for muxing.
+            "repeatspspps": 1,
+        }
+
+        # Try to honor MoviePy's bitrate strings ("5000k", "5M", ...).
+        bps = _parse_bitrate_to_bps(bitrate)
+        if bps:
+            enc_params["bitrate"] = int(bps)
+
+        # Some PyNvVideoCodec APIs use `gpuid` naming (not `gpu_id`).
+        enc_params["gpuid"] = int(gpu_id)
+
+        self._enc = self._create_encoder_best_effort(nvc, width, height, enc_params)
+
+    def _as_nv12_frame_best_effort(self, f):
+        cp = self._cp
+
+        # 1) If the user provided a PyNvVideoCodec-style object, accept it.
+        if callable(getattr(f, "cuda", None)):
+            return f
+
+        # 2) Tuple/list of planes.
+        if isinstance(f, (tuple, list)) and len(f) == 2:
+            y, uv = f
+            if hasattr(y, "__cuda_array_interface__") and hasattr(
+                uv, "__cuda_array_interface__"
+            ):
+                return _NV12CudaFrame(y, uv)
+
+        # 3) Packed NV12 (H+H/2, W) uint8.
+        if hasattr(f, "__cuda_array_interface__"):
+            if getattr(f, "dtype", None) == cp.uint8 and getattr(f, "ndim", None) == 2:
+                h = int(self._ctx.height)
+                w = int(self._ctx.width)
+                if int(f.shape[0]) == (h + h // 2) and int(f.shape[1]) == w:
+                    y = f[:h, :]
+                    uv = f[h : h + h // 2, :]
+                    return _NV12CudaFrame(y, uv)
+
+        return None
+
+    def _write_payload(self, payload) -> None:
+        for pkt in self._iter_packets(payload):
+            self._out.write(pkt)
+
+    def write_frame(self, frame_rgb):
+        cp = self._cp
+
+        # Direct NV12 acceptance (GPU-native color management / preconversion).
+        nv12_obj = self._as_nv12_frame_best_effort(frame_rgb)
+
+        slot = self._slots[self._slot_index]
+        self._slot_index = (self._slot_index + 1) % self._pool_size
+
+        # Ensure we don't overwrite a slot that the encoder may still be consuming.
+        try:
+            cp.cuda.runtime.streamWaitEvent(
+                int(self._conv_stream.ptr),
+                int(slot.encode_done.ptr),
+                0,
+            )
+        except Exception:
+            slot.encode_done.synchronize()
+
+        if nv12_obj is not None:
+            # If user provided NV12 planes, we can encode immediately.
+            # Use the pipeline queue to preserve overlap semantics.
+            self._pending.append((nv12_obj, slot))
+            if len(self._pending) <= 1:
+                return
+            encode_item = self._pending.pop(0)
+            frame_obj, enc_slot = encode_item
+            self._write_payload(self._enc.Encode(frame_obj))
+            try:
+                enc_slot.encode_done.record(cp.cuda.Stream.null)
+            except Exception:
+                enc_slot.encode_done.synchronize()
+            return
+
+        f = frame_rgb
+        if not hasattr(f, "__cuda_array_interface__"):
+            # Best-effort: upload CPU frame to GPU so encoding can still be GPU.
+            if isinstance(f, np.ndarray):
+                f = cp.asarray(f)
+            else:
+                raise RuntimeError(
+                    "Expected a GPU frame (CUDA array) or a NumPy ndarray"
+                )
+        if f.ndim != 3 or f.shape[2] < 3:
+            raise ValueError(
+                "Expected HxWx3 frame, got shape="
+                f"{getattr(f, 'shape', None)!r}"
+            )
+        f = f[:, :, :3]
+
+        with self._conv_stream:
+            if f.dtype != cp.uint8:
+                f = f.astype(cp.uint8)
+            try:
+                if not f.flags.c_contiguous:
+                    f = cp.ascontiguousarray(f)
+            except Exception:
+                f = cp.ascontiguousarray(f)
+
+            threads = (16, 16)
+            grid = (
+                ((self._ctx.width // 2) + threads[0] - 1) // threads[0],
+                ((self._ctx.height // 2) + threads[1] - 1) // threads[1],
+            )
+            self._rgb_to_nv12(
+                grid,
+                threads,
+                (
+                    f,
+                    slot.y,
+                    slot.uv,
+                    int(self._ctx.width),
+                    int(self._ctx.height),
+                    int(f.strides[0]),
+                    int(slot.y.strides[0]),
+                    int(slot.uv.strides[0]),
+                ),
+            )
+            slot.conv_done.record(self._conv_stream)
+
+        # Queue this slot for encoding; we encode one frame behind to allow
+        # conversion and encode to overlap.
+        self._pending.append(slot)
+
+        if len(self._pending) <= 1:
+            return
+
+        encode_slot = self._pending.pop(0)
+
+        # Ensure conversion finished before giving the buffer to NVENC.
+        encode_slot.conv_done.synchronize()
+
+        self._write_payload(self._enc.Encode(encode_slot.frame))
+
+        # Record an event after Encode so we can safely reuse this slot later.
+        try:
+            encode_slot.encode_done.record(cp.cuda.Stream.null)
+        except Exception:
+            encode_slot.encode_done.synchronize()
+
+    def write_frames(self, frames):
+        """Best-effort batched encode to reduce host syncs.
+
+        Accepts:
+        - iterable of frames
+        - a CuPy array shaped (N,H,W,3)
+        """
+        cp = self._cp
+
+        # Normalize iterator.
+        if hasattr(frames, "__cuda_array_interface__") and getattr(
+            frames, "ndim", None
+        ) == 4:
+            n = int(frames.shape[0])
+            it = (frames[i] for i in range(n))
+        elif isinstance(frames, (list, tuple)):
+            it = iter(frames)
+        else:
+            it = iter([frames])
+
+        slots_to_encode = []
+        frames_to_encode_direct = []
+
+        # Stage conversions on the conversion stream.
+        for f_in in it:
+            nv12_obj = self._as_nv12_frame_best_effort(f_in)
+            if nv12_obj is not None:
+                frames_to_encode_direct.append(nv12_obj)
+                continue
+
+            f = f_in
+            if not hasattr(f, "__cuda_array_interface__"):
+                if isinstance(f, np.ndarray):
+                    f = cp.asarray(f)
+                else:
+                    raise RuntimeError(
+                        "Expected a GPU frame (CUDA array) or a NumPy ndarray"
+                    )
+            if f.ndim != 3 or f.shape[2] < 3:
+                raise ValueError(
+                    "Expected HxWx3 frame, got shape="
+                    f"{getattr(f, 'shape', None)!r}"
+                )
+            f = f[:, :, :3]
+
+            slot = self._slots[self._slot_index]
+            self._slot_index = (self._slot_index + 1) % self._pool_size
+
+            # Ensure slot is not reused while NVENC might still consume it.
+            try:
+                cp.cuda.runtime.streamWaitEvent(
+                    int(self._conv_stream.ptr),
+                    int(slot.encode_done.ptr),
+                    0,
+                )
+            except Exception:
+                slot.encode_done.synchronize()
+
+            with self._conv_stream:
+                if f.dtype != cp.uint8:
+                    f = f.astype(cp.uint8)
+                try:
+                    if not f.flags.c_contiguous:
+                        f = cp.ascontiguousarray(f)
+                except Exception:
+                    f = cp.ascontiguousarray(f)
+
+                threads = (16, 16)
+                grid = (
+                    ((self._ctx.width // 2) + threads[0] - 1) // threads[0],
+                    ((self._ctx.height // 2) + threads[1] - 1) // threads[1],
+                )
+                self._rgb_to_nv12(
+                    grid,
+                    threads,
+                    (
+                        f,
+                        slot.y,
+                        slot.uv,
+                        int(self._ctx.width),
+                        int(self._ctx.height),
+                        int(f.strides[0]),
+                        int(slot.y.strides[0]),
+                        int(slot.uv.strides[0]),
+                    ),
+                )
+
+            slots_to_encode.append(slot)
+
+        # Encode any direct NV12 inputs first.
+        for nv12_obj in frames_to_encode_direct:
+            self._write_payload(self._enc.Encode(nv12_obj))
+
+        if not slots_to_encode:
+            return
+
+        # Single sync per batch instead of per-frame conv_done.synchronize().
+        try:
+            self._conv_stream.synchronize()
+        except Exception:
+            cp.cuda.runtime.deviceSynchronize()
+
+        for slot in slots_to_encode:
+            self._write_payload(self._enc.Encode(slot.frame))
+            try:
+                slot.encode_done.record(cp.cuda.Stream.null)
+            except Exception:
+                slot.encode_done.synchronize()
+
+    def close(self):
+        # Drain any queued frames.
+        if getattr(self, "_pending", None):
+            while self._pending:
+                item = self._pending.pop(0)
+                if isinstance(item, tuple):
+                    frame_obj, slot = item
+                    self._write_payload(self._enc.Encode(frame_obj))
+                    try:
+                        slot.encode_done.record(self._cp.cuda.Stream.null)
+                    except Exception:
+                        pass
+                else:
+                    slot = item
+                    try:
+                        slot.conv_done.synchronize()
+                    except Exception:
+                        pass
+                    self._write_payload(self._enc.Encode(slot.frame))
+                    try:
+                        slot.encode_done.record(self._cp.cuda.Stream.null)
+                    except Exception:
+                        pass
+
+        if getattr(self, "_enc", None) is not None:
+            self._write_payload(self._enc.EndEncode())
+        if getattr(self, "_out", None) is not None:
+            try:
+                self._out.close()
+            finally:
+                self._out = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+
 class PyNvCodecNVENCWriter:
     """Write H.264/HEVC using NVENC from CuPy RGB frames."""
+
+    class _Slot:
+        __slots__ = ("surface", "y", "uv", "conv_done", "encode_done")
+
+        def __init__(self, surface, y, uv, conv_done, encode_done):
+            self.surface = surface
+            self.y = y
+            self.uv = uv
+            self.conv_done = conv_done
+            self.encode_done = encode_done
 
     def __init__(
         self,
@@ -350,47 +987,156 @@ class PyNvCodecNVENCWriter:
         self._out = out
         self._packet = np.ndarray(shape=(0,), dtype=np.uint8)
 
-        # Preallocate the input RGB_PLANAR surface once and write into it per-frame.
-        self._surface_rgb_planar = nvc.Surface.Make(nvc.PixelFormat.RGB_PLANAR, width, height, gpu_id)
-        self._surface_rgb_planar_pitch = int(self._surface_rgb_planar.Pitch())
-        # Create a CuPy view onto the surface's device memory to let kernels write into it.
-        dst_ptr = int(self._surface_rgb_planar.PlanePtr().GpuMem())
-        buf_bytes = self._surface_rgb_planar_pitch * (height * 3)
-        unowned = cp.cuda.UnownedMemory(dst_ptr, buf_bytes, self._surface_rgb_planar)
-        memptr = cp.cuda.MemoryPointer(unowned, 0)
-        self._surface_rgb_planar_view = cp.ndarray(
-            (height * 3, self._surface_rgb_planar_pitch),
-            dtype=cp.uint8,
-            memptr=memptr,
-            strides=(self._surface_rgb_planar_pitch, 1),
-        )
+        self._conv_stream = cp.cuda.Stream(non_blocking=True)
+        self._pending = []
 
-        # Kernel: packed HWC RGB -> planar RGB in the VPF surface memory.
-        self._hwc_to_planar = cp.RawKernel(
+        self._pool_size = max(2, int(os.getenv("MOVIEPY_GPU_ENCODE_POOL", "3")))
+        self._slots = []
+        self._slot_index = 0
+
+        def _map_nv12_surface(surface):
+            pitch = int(surface.Pitch())
+            y_ptr = None
+            uv_ptr = None
+            try:
+                y_ptr = int(surface.PlanePtr(0).GpuMem())
+                uv_ptr = int(surface.PlanePtr(1).GpuMem())
+            except Exception:
+                pass
+
+            if y_ptr is not None and uv_ptr is not None:
+                y_bytes = pitch * height
+                uv_bytes = pitch * (height // 2)
+                y_unowned = cp.cuda.UnownedMemory(int(y_ptr), int(y_bytes), surface)
+                uv_unowned = cp.cuda.UnownedMemory(int(uv_ptr), int(uv_bytes), surface)
+                y_memptr = cp.cuda.MemoryPointer(y_unowned, 0)
+                uv_memptr = cp.cuda.MemoryPointer(uv_unowned, 0)
+                y = cp.ndarray(
+                    (height, pitch),
+                    dtype=cp.uint8,
+                    memptr=y_memptr,
+                    strides=(pitch, 1),
+                )
+                uv = cp.ndarray(
+                    (height // 2, pitch),
+                    dtype=cp.uint8,
+                    memptr=uv_memptr,
+                    strides=(pitch, 1),
+                )
+                return pitch, y, uv
+
+            dst_ptr = int(surface.PlanePtr().GpuMem())
+            buf_bytes = pitch * (height + height // 2)
+            unowned = cp.cuda.UnownedMemory(dst_ptr, buf_bytes, surface)
+            memptr = cp.cuda.MemoryPointer(unowned, 0)
+            view = cp.ndarray(
+                (height + height // 2, pitch),
+                dtype=cp.uint8,
+                memptr=memptr,
+                strides=(pitch, 1),
+            )
+            return (
+                pitch,
+                view[:height, :],
+                view[height : height + height // 2, :],
+            )
+
+        for _ in range(self._pool_size):
+            surface = nvc.Surface.Make(nvc.PixelFormat.NV12, width, height, gpu_id)
+            self._surface_nv12_pitch, y, uv = _map_nv12_surface(surface)
+            self._slots.append(
+                self._Slot(
+                    surface,
+                    y,
+                    uv,
+                    cp.cuda.Event(),
+                    cp.cuda.Event(),
+                )
+            )
+
+        # Kernel: packed HWC RGB -> NV12 (BT.601 limited/MPEG range).
+        self._rgb_to_nv12 = cp.RawKernel(
             r'''
-            extern "C" __global__ void hwc_to_planar_u8(
+            extern "C" __device__ __forceinline__ unsigned char clamp_u8(int v) {
+                return (unsigned char)(v < 0 ? 0 : (v > 255 ? 255 : v));
+            }
+
+            extern "C" __global__ void rgb_to_nv12_bt601_mpeg_u8(
                 const unsigned char* __restrict__ src,
-                unsigned char* __restrict__ dst,
+                unsigned char* __restrict__ y_plane,
+                unsigned char* __restrict__ uv_plane,
                 const int w,
                 const int h,
-                const int dst_pitch
+                const int src_pitch,
+                const int y_pitch,
+                const int uv_pitch
             ) {
-                int x = (int)(blockIdx.x * blockDim.x + threadIdx.x);
-                int y = (int)(blockIdx.y * blockDim.y + threadIdx.y);
-                if (x >= w || y >= h) return;
-                int src_idx = (y * w + x) * 3;
-                unsigned char r = src[src_idx + 0];
-                unsigned char g = src[src_idx + 1];
-                unsigned char b = src[src_idx + 2];
-                int plane0 = y;
-                int plane1 = y + h;
-                int plane2 = y + 2 * h;
-                dst[plane0 * dst_pitch + x] = r;
-                dst[plane1 * dst_pitch + x] = g;
-                dst[plane2 * dst_pitch + x] = b;
+                int bx = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+                int by = (int)(blockIdx.y * blockDim.y + threadIdx.y);
+                int x = bx * 2;
+                int y = by * 2;
+                if (x + 1 >= w || y + 1 >= h) return;
+
+                const unsigned char* row0 = src + y * src_pitch;
+                const unsigned char* row1 = src + (y + 1) * src_pitch;
+
+                int idx00 = x * 3;
+                int idx01 = (x + 1) * 3;
+                int idx10 = x * 3;
+                int idx11 = (x + 1) * 3;
+
+                int r00 = (int)row0[idx00 + 0];
+                int g00 = (int)row0[idx00 + 1];
+                int b00 = (int)row0[idx00 + 2];
+
+                int r01 = (int)row0[idx01 + 0];
+                int g01 = (int)row0[idx01 + 1];
+                int b01 = (int)row0[idx01 + 2];
+
+                int r10 = (int)row1[idx10 + 0];
+                int g10 = (int)row1[idx10 + 1];
+                int b10 = (int)row1[idx10 + 2];
+
+                int r11 = (int)row1[idx11 + 0];
+                int g11 = (int)row1[idx11 + 1];
+                int b11 = (int)row1[idx11 + 2];
+
+                // BT.601 limited range (MPEG):
+                // Y  = (( 66R +129G + 25B +128) >> 8) + 16
+                // U  = ((-38R - 74G +112B +128) >> 8) +128
+                // V  = ((112R - 94G - 18B +128) >> 8) +128
+                int y00 = ((66 * r00 + 129 * g00 + 25 * b00 + 128) >> 8) + 16;
+                int y01 = ((66 * r01 + 129 * g01 + 25 * b01 + 128) >> 8) + 16;
+                int y10 = ((66 * r10 + 129 * g10 + 25 * b10 + 128) >> 8) + 16;
+                int y11 = ((66 * r11 + 129 * g11 + 25 * b11 + 128) >> 8) + 16;
+
+                unsigned char* y_row0 = y_plane + y * y_pitch;
+                unsigned char* y_row1 = y_plane + (y + 1) * y_pitch;
+                y_row0[x] = clamp_u8(y00);
+                y_row0[x + 1] = clamp_u8(y01);
+                y_row1[x] = clamp_u8(y10);
+                y_row1[x + 1] = clamp_u8(y11);
+
+                int u00 = ((-38 * r00 - 74 * g00 + 112 * b00 + 128) >> 8) + 128;
+                int u01 = ((-38 * r01 - 74 * g01 + 112 * b01 + 128) >> 8) + 128;
+                int u10 = ((-38 * r10 - 74 * g10 + 112 * b10 + 128) >> 8) + 128;
+                int u11 = ((-38 * r11 - 74 * g11 + 112 * b11 + 128) >> 8) + 128;
+
+                int v00 = ((112 * r00 - 94 * g00 - 18 * b00 + 128) >> 8) + 128;
+                int v01 = ((112 * r01 - 94 * g01 - 18 * b01 + 128) >> 8) + 128;
+                int v10 = ((112 * r10 - 94 * g10 - 18 * b10 + 128) >> 8) + 128;
+                int v11 = ((112 * r11 - 94 * g11 - 18 * b11 + 128) >> 8) + 128;
+
+                // Average chroma over 2x2 block with rounding.
+                int u = (u00 + u01 + u10 + u11 + 2) >> 2;
+                int v = (v00 + v01 + v10 + v11 + 2) >> 2;
+
+                unsigned char* uv_row = uv_plane + by * uv_pitch;
+                uv_row[x] = clamp_u8(u);
+                uv_row[x + 1] = clamp_u8(v);
             }
             ''',
-            "hwc_to_planar_u8",
+            "rgb_to_nv12_bt601_mpeg_u8",
         )
 
         res = f"{width}x{height}"
@@ -405,28 +1151,23 @@ class PyNvCodecNVENCWriter:
 
         self._enc = nvc.PyNvEncoder(enc_params, gpu_id)
 
-        # Convert packed RGB to NV12 for NVENC.
-        self._to_nv12 = _SurfaceConverterChain(
-            nvc,
-            width,
-            height,
-            gpu_id,
-            chain=[
-                (nvc.PixelFormat.RGB_PLANAR, nvc.PixelFormat.RGB),
-                (nvc.PixelFormat.RGB, nvc.PixelFormat.YUV420),
-                (nvc.PixelFormat.YUV420, nvc.PixelFormat.NV12),
-            ],
-        )
-
-    def _cupy_rgb_to_surface_rgb_planar(self, frame):
+    def _cupy_rgb_to_surface_nv12(self, frame):
         cp = self._cp
-        nvc = self._nvc
-        if not hasattr(frame, "__cuda_array_interface__"):
-            raise RuntimeError("Expected a GPU frame (CUDA array)")
+        f_in = frame
+        if not hasattr(f_in, "__cuda_array_interface__"):
+            if isinstance(f_in, np.ndarray):
+                f_in = cp.asarray(f_in)
+            else:
+                raise RuntimeError(
+                    "Expected a GPU frame (CUDA array) or a NumPy ndarray"
+                )
 
-        f = frame
+        f = f_in
         if f.ndim != 3 or f.shape[2] < 3:
-            raise ValueError(f"Expected HxWx3 frame, got shape={getattr(f, 'shape', None)!r}")
+            raise ValueError(
+                "Expected HxWx3 frame, got shape="
+                f"{getattr(f, 'shape', None)!r}"
+            )
         f = f[:, :, :3]
         if f.dtype != cp.uint8:
             f = f.astype(cp.uint8)
@@ -436,28 +1177,118 @@ class PyNvCodecNVENCWriter:
         except Exception:
             f = cp.ascontiguousarray(f)
 
-        # Packed HWC -> planar surface, without allocating a CHW temporary.
-        threads = (16, 16)
-        grid = ((self._ctx.width + threads[0] - 1) // threads[0], (self._ctx.height + threads[1] - 1) // threads[1])
-        self._hwc_to_planar(
-            grid,
-            threads,
-            (f, self._surface_rgb_planar_view, int(self._ctx.width), int(self._ctx.height), int(self._surface_rgb_planar_pitch)),
-        )
-        return self._surface_rgb_planar
+        slot = self._slots[self._slot_index]
+        self._slot_index = (self._slot_index + 1) % self._pool_size
+
+        try:
+            cp.cuda.runtime.streamWaitEvent(
+                int(self._conv_stream.ptr),
+                int(slot.encode_done.ptr),
+                0,
+            )
+        except Exception:
+            slot.encode_done.synchronize()
+
+        with self._conv_stream:
+            threads = (16, 16)
+            grid = (
+                ((self._ctx.width // 2) + threads[0] - 1) // threads[0],
+                ((self._ctx.height // 2) + threads[1] - 1) // threads[1],
+            )
+            self._rgb_to_nv12(
+                grid,
+                threads,
+                (
+                    f,
+                    slot.y,
+                    slot.uv,
+                    int(self._ctx.width),
+                    int(self._ctx.height),
+                    int(f.strides[0]),
+                    int(slot.y.strides[0]),
+                    int(slot.uv.strides[0]),
+                ),
+            )
+            slot.conv_done.record(self._conv_stream)
+
+        return slot.surface, slot
 
     def _write_packet(self):
         if self._packet.size:
             self._out.write(memoryview(self._packet))
 
     def write_frame(self, frame_rgb):
-        surface_rgb = self._cupy_rgb_to_surface_rgb_planar(frame_rgb)
-        surface_nv12 = self._to_nv12.run(surface_rgb)
-        success = self._enc.EncodeSingleSurface(surface_nv12, self._packet)
+        surface_nv12, slot = self._cupy_rgb_to_surface_nv12(frame_rgb)
+        self._pending.append((surface_nv12, slot))
+
+        if len(self._pending) <= 1:
+            return
+
+        surface_to_encode, encode_slot = self._pending.pop(0)
+        encode_slot.conv_done.synchronize()
+        success = self._enc.EncodeSingleSurface(surface_to_encode, self._packet)
         if success:
             self._write_packet()
 
+        # Mark slot reusable.
+        try:
+            encode_slot.encode_done.record(self._cp.cuda.Stream.null)
+        except Exception:
+            pass
+
+    def write_frames(self, frames):
+        """Best-effort batched encode to reduce host syncs."""
+        cp = self._cp
+
+        if hasattr(frames, "__cuda_array_interface__") and getattr(
+            frames, "ndim", None
+        ) == 4:
+            n = int(frames.shape[0])
+            it = (frames[i] for i in range(n))
+        elif isinstance(frames, (list, tuple)):
+            it = iter(frames)
+        else:
+            it = iter([frames])
+
+        pending_local = []
+        for f in it:
+            surface_nv12, slot = self._cupy_rgb_to_surface_nv12(f)
+            pending_local.append((surface_nv12, slot))
+
+        if not pending_local:
+            return
+
+        # One sync per batch.
+        try:
+            self._conv_stream.synchronize()
+        except Exception:
+            cp.cuda.runtime.deviceSynchronize()
+
+        for surface_nv12, slot in pending_local:
+            success = self._enc.EncodeSingleSurface(surface_nv12, self._packet)
+            if success:
+                self._write_packet()
+            try:
+                slot.encode_done.record(cp.cuda.Stream.null)
+            except Exception:
+                pass
+
     def close(self):
+        if getattr(self, "_pending", None):
+            while self._pending:
+                surface_to_encode, slot = self._pending.pop(0)
+                try:
+                    slot.conv_done.synchronize()
+                except Exception:
+                    pass
+                success = self._enc.EncodeSingleSurface(surface_to_encode, self._packet)
+                if success:
+                    self._write_packet()
+                try:
+                    slot.encode_done.record(self._cp.cuda.Stream.null)
+                except Exception:
+                    pass
+
         if getattr(self, "_enc", None) is not None:
             while self._enc.FlushSinglePacket(self._packet):
                 self._write_packet()
@@ -485,7 +1316,7 @@ def try_write_video_pynvcodec(
     audiofile: Optional[str],
     audio_codec: Optional[str],
     logger,
-    gpu_render,
+    gpu_render=None,
     pixel_format: Optional[str],
 ) -> bool:
     """Best-effort: encode via NVENC from GPU frames, then mux via FFmpeg.
@@ -519,12 +1350,13 @@ def try_write_video_pynvcodec(
 
     gpu_id = _parse_gpu_id()
     nvenc_preset = _map_nvenc_preset(preset)
+    color_matrix, color_range = _gpu_color_settings_for_clip(clip)
 
     try:
         # These imports are intentionally inside the try so missing optional deps
         # just trigger a fallback.
         import cupy as _cp  # noqa: F401
-        _import_nvc()
+        nvc = _import_nvc()
 
         with _FFmpegH26xPipeMuxer(
             output_file=filename,
@@ -534,7 +1366,13 @@ def try_write_video_pynvcodec(
             audio_codec=audio_codec,
             logger=logger,
         ) as mux_stdin:
-            with PyNvCodecNVENCWriter(
+            writer_cls = (
+                PyNvCodecNVENCWriter
+                if hasattr(nvc, "Surface")
+                else PyNvVideoCodecNVENCWriter
+            )
+
+            with writer_cls(
                 width=clip.w,
                 height=clip.h,
                 fps=float(fps),
@@ -542,13 +1380,126 @@ def try_write_video_pynvcodec(
                 preset=nvenc_preset,
                 bitrate=bitrate,
                 gpu_id=gpu_id,
+                color_matrix=color_matrix,
+                color_range=color_range,
                 out=mux_stdin,
             ) as writer:
                 n_frames = int(clip.duration * fps)
-                for frame_index in logger.iter_bar(frame_index=range(n_frames)):
-                    t = np.float64(frame_index) / fps
-                    frame = gpu_render.get_frame_for_export_uint8_gpu(clip, t)
-                    writer.write_frame(frame)
+                iter_bar = logger.iter_bar
+                gpu_fn = getattr(clip, "_gpu_frame_function", None)
+                wants_nv12 = (getattr(clip, "_gpu_frame_format", None) == "nv12")
+
+                batch = 0
+                try:
+                    batch = int(os.getenv("MOVIEPY_GPU_ENCODE_BATCH", "0") or "0")
+                except Exception:
+                    batch = 0
+
+                # Auto default: use pool size (keeps batching modest and aligned
+                # with buffer reuse). User can always force 1 to disable.
+                if batch <= 0:
+                    try:
+                        batch = int(os.getenv("MOVIEPY_GPU_ENCODE_POOL", "3") or "3")
+                    except Exception:
+                        batch = 3
+                batch = max(1, int(batch))
+
+                batch_safe = bool(getattr(clip, "_gpu_batch_safe", False))
+                batch_decode = getattr(clip, "_gpu_frame_function_batch_by_index", None)
+                can_batch_decode = (
+                    batch_safe and callable(batch_decode) and (not wants_nv12)
+                )
+
+                decode_batch = 0
+                try:
+                    decode_batch = int(
+                        os.getenv("MOVIEPY_GPU_DECODE_BATCH", "0") or "0"
+                    )
+                except Exception:
+                    decode_batch = 0
+                if decode_batch <= 0:
+                    # Auto default: if batch decode is available, use a small
+                    # chunk (pool-aligned) even if encode batching is disabled.
+                    if can_batch_decode:
+                        try:
+                            decode_batch = int(
+                                os.getenv("MOVIEPY_GPU_ENCODE_POOL", "3")
+                                or "3"
+                            )
+                        except Exception:
+                            decode_batch = 3
+                    else:
+                        decode_batch = 1
+                decode_batch = max(1, int(decode_batch))
+
+                def _get_frame_for_nvenc(t):
+                    # If the clip explicitly provides a GPU frame function and
+                    # is tagged as NV12, prefer that output (which may be an
+                    # NV12 carrier object, NV12 planes, or packed NV12).
+                    if wants_nv12 and (gpu_fn is not None):
+                        return gpu_fn(t)
+
+                    # Otherwise, still prefer the GPU frame function if it
+                    # returns a CUDA array (decode/process on GPU) to avoid
+                    # CPU downloads between stages.
+                    if gpu_fn is not None:
+                        try:
+                            v = gpu_fn(t)
+                            if hasattr(v, "__cuda_array_interface__") or callable(
+                                getattr(v, "cuda", None)
+                            ):
+                                return v
+                        except Exception:
+                            pass
+
+                    if gpu_render is not None:
+                        return gpu_render.get_frame_for_export_uint8_gpu(clip, t)
+
+                    return clip.get_frame(t)
+
+                fps_f = float(fps)
+
+                if (batch <= 1) and (
+                    not (can_batch_decode and (decode_batch > 1))
+                ):
+                    for frame_index in iter_bar(frame_index=range(n_frames)):
+                        t = np.float64(frame_index) / fps_f
+                        frame = _get_frame_for_nvenc(t)
+                        writer.write_frame(frame)
+                else:
+                    # Iterate in chunks to reduce per-frame host syncs.
+                    chunk = batch
+                    if (batch <= 1) and can_batch_decode and (decode_batch > 1):
+                        # Decode in batches but still encode per-frame.
+                        chunk = decode_batch
+
+                    for start in iter_bar(frame_index=range(0, n_frames, chunk)):
+                        end = min(n_frames, int(start) + chunk)
+                        idxs = list(range(int(start), int(end)))
+
+                        if can_batch_decode:
+                            frames = batch_decode(idxs)
+                            if (batch > 1) and hasattr(
+                                writer, "write_frames"
+                            ):
+                                writer.write_frames(frames)
+                            else:
+                                for i in range(int(frames.shape[0])):
+                                    writer.write_frame(frames[i])
+                            continue
+
+                        frames = []
+                        for fi in idxs:
+                            t = np.float64(fi) / fps_f
+                            frames.append(_get_frame_for_nvenc(t))
+
+                        if (batch > 1) and hasattr(
+                            writer, "write_frames"
+                        ):
+                            writer.write_frames(frames)
+                        else:
+                            for fr in frames:
+                                writer.write_frame(fr)
 
         return True
     except Exception:

--- a/moviepy/video/tools/cupy_utils.py
+++ b/moviepy/video/tools/cupy_utils.py
@@ -1,0 +1,127 @@
+"""Internal CuPy/CUDA helpers.
+
+This module centralizes best-effort CUDA DLL setup (Windows) and CuPy
+availability/usability checks. It is intentionally conservative:
+
+- Never requires CuPy as an import-time dependency.
+- Never raises on failure; callers should fall back to CPU paths.
+"""
+
+from __future__ import annotations
+
+import os
+import site
+from typing import Any
+
+
+_CUPY_USABLE: bool | None = None
+
+
+def is_cuda_array(x: Any) -> bool:
+    return hasattr(x, "__cuda_array_interface__")
+
+
+def _windows_cuda_dll_setup() -> None:
+    """Best-effort CUDA DLL setup for Windows.
+
+    CuPy can import successfully but fail later when it needs NVRTC/NVJIT
+    DLLs. Adding CUDA Toolkit and pip runtime DLL directories helps.
+    """
+    if os.name != "nt":
+        return
+
+    cuda_root = os.environ.get("CUDA_PATH") or os.environ.get("CUDA_HOME")
+    if not cuda_root:
+        versioned = [
+            (k, v)
+            for k, v in os.environ.items()
+            if k.startswith("CUDA_PATH_V") and v
+        ]
+        if versioned:
+            cuda_root = sorted(versioned, key=lambda kv: kv[0])[-1][1]
+            os.environ.setdefault("CUDA_PATH", cuda_root)
+
+    candidates: list[str] = []
+    if cuda_root:
+        candidates.extend(
+            [
+                os.path.join(cuda_root, "bin"),
+                os.path.join(cuda_root, "bin", "x64"),
+                os.path.join(cuda_root, "bin", "x86_64"),
+            ]
+        )
+
+    # Pip-installed NVIDIA runtime layout (if present).
+    for sp in site.getsitepackages():
+        candidates.extend(
+            [
+                os.path.join(sp, "nvidia", "cu13", "bin"),
+                os.path.join(sp, "nvidia", "cu13", "bin", "x86_64"),
+                os.path.join(sp, "nvidia", "cu12", "bin"),
+                os.path.join(sp, "nvidia", "cu12", "bin", "x86_64"),
+            ]
+        )
+
+    for d in candidates:
+        try:
+            if d and os.path.isdir(d):
+                os.add_dll_directory(d)
+        except Exception:
+            pass
+
+
+def try_import_cupy() -> Any:
+    """Return the imported cupy module, or None if unavailable."""
+    try:
+        _windows_cuda_dll_setup()
+        import cupy as cp
+
+        return cp
+    except Exception:
+        return None
+
+
+def _cupy_is_usable(cp: Any) -> bool:
+    """Return True if CuPy can actually execute kernels."""
+    try:
+        try:
+            if int(cp.cuda.runtime.getDeviceCount()) <= 0:
+                return False
+        except Exception:
+            # Some setups fail here but still work; rely on kernel test.
+            pass
+
+        a = cp.zeros((1,), dtype=cp.uint8)
+        b = a.astype(cp.float32)
+        b += 1.0
+        cp.cuda.runtime.deviceSynchronize()
+        return True
+    except Exception:
+        return False
+
+
+def is_cupy_usable() -> bool:
+    """Cached CuPy runtime usability check."""
+    global _CUPY_USABLE
+    if _CUPY_USABLE is not None:
+        return bool(_CUPY_USABLE)
+
+    if os.environ.get("MOVIEPY_DISABLE_GPU"):
+        _CUPY_USABLE = False
+        return False
+
+    cp = try_import_cupy()
+    if cp is None:
+        _CUPY_USABLE = False
+        return False
+
+    _CUPY_USABLE = bool(_cupy_is_usable(cp))
+    return bool(_CUPY_USABLE)
+
+
+def cupy() -> Any:
+    """Return cupy module if usable, else raise ImportError."""
+    cp = try_import_cupy()
+    if cp is None:
+        raise ImportError("cupy is not available")
+    return cp

--- a/moviepy/video/tools/cuts.py
+++ b/moviepy/video/tools/cuts.py
@@ -8,14 +8,14 @@ from moviepy.decorators import convert_parameter_to_seconds, use_clip_fps_by_def
 
 
 def _as_numpy_if_cuda_array(arr):
-  if arr is None or not hasattr(arr, "__cuda_array_interface__"):
-    return arr
-  try:
-    import cupy as cp
+    if arr is None or not hasattr(arr, "__cuda_array_interface__"):
+        return arr
+    try:
+        import cupy as cp
 
-    return cp.asnumpy(arr)
-  except Exception:
-    return arr
+        return cp.asnumpy(arr)
+    except Exception:
+        return arr
 
 
 @use_clip_fps_by_default
@@ -50,7 +50,7 @@ def find_video_period(clip, fps=None, start_time=0.3):
     """
 
     def frame(t):
-      return _as_numpy_if_cuda_array(clip.get_frame(t)).flatten()
+        return _as_numpy_if_cuda_array(clip.get_frame(t)).flatten()
 
     timings = np.arange(start_time, clip.duration, 1 / fps)[1:]
     ref = frame(0)
@@ -516,8 +516,8 @@ def detect_scenes(
     """
     if luminosities is None:
         luminosities = [
-        float(_as_numpy_if_cuda_array(f).sum())
-        for f in clip.iter_frames(fps=fps, dtype="uint32", logger=logger)
+            float(_as_numpy_if_cuda_array(f).sum())
+            for f in clip.iter_frames(fps=fps, dtype="uint32", logger=logger)
         ]
 
     luminosities = np.array(luminosities, dtype=float)

--- a/moviepy/video/tools/drawing.py
+++ b/moviepy/video/tools/drawing.py
@@ -5,6 +5,17 @@ methods that are difficult to do with the existing Python libraries.
 import numpy as np
 
 
+def _as_numpy_if_cuda_array(obj):
+    if hasattr(obj, "__cuda_array_interface__"):
+        try:
+            import cupy as cp
+
+            return cp.asnumpy(obj)
+        except Exception:
+            return obj
+    return obj
+
+
 def color_gradient(
     size,
     p1,
@@ -109,6 +120,12 @@ def color_gradient(
     """
     # np-arrayize and change x,y coordinates to y,x
     w, h = size
+
+    color_1 = _as_numpy_if_cuda_array(color_1)
+    color_2 = _as_numpy_if_cuda_array(color_2)
+    p1 = _as_numpy_if_cuda_array(p1)
+    p2 = _as_numpy_if_cuda_array(p2)
+    vector = _as_numpy_if_cuda_array(vector)
 
     color_1 = np.array(color_1).astype(float)
     color_2 = np.array(color_2).astype(float)
@@ -239,6 +256,12 @@ def color_split(
         # An image split along an arbitrary line (see below)
         color_split(size, p1=[20, 50], p2=[25, 70], color_1=0, color_2=1)
     """
+    color_1 = _as_numpy_if_cuda_array(color_1)
+    color_2 = _as_numpy_if_cuda_array(color_2)
+    p1 = _as_numpy_if_cuda_array(p1)
+    p2 = _as_numpy_if_cuda_array(p2)
+    vector = _as_numpy_if_cuda_array(vector)
+
     if gradient_width or ((x is None) and (y is None)):
         if p2 is not None:
             vector = np.array(p2) - np.array(p1)

--- a/moviepy/video/tools/gpu_blend.py
+++ b/moviepy/video/tools/gpu_blend.py
@@ -419,10 +419,18 @@ def _blend_over_with_masks_u8_opencv_cuda(
     if h <= 0 or w <= 0:
         return True
 
-    bg_gpu = cv2.cuda_GpuMat(); bg_gpu.upload(bg_region)
-    fr_gpu = cv2.cuda_GpuMat(); fr_gpu.upload(fr_region)
-    ac_gpu = cv2.cuda_GpuMat(); ac_gpu.upload(a_clip_region.astype(np.float32, copy=False))
-    ab_gpu = cv2.cuda_GpuMat(); ab_gpu.upload(a_bg_region.astype(np.float32, copy=False))
+    bg_gpu = cv2.cuda_GpuMat()
+    bg_gpu.upload(bg_region)
+    fr_gpu = cv2.cuda_GpuMat()
+    fr_gpu.upload(fr_region)
+
+    a_clip_f32 = a_clip_region.astype(np.float32, copy=False)
+    ac_gpu = cv2.cuda_GpuMat()
+    ac_gpu.upload(a_clip_f32)
+
+    a_bg_f32 = a_bg_region.astype(np.float32, copy=False)
+    ab_gpu = cv2.cuda_GpuMat()
+    ab_gpu.upload(a_bg_f32)
 
     bg_f = bg_gpu.convertTo(cv2.CV_32F)
     fr_f = fr_gpu.convertTo(cv2.CV_32F)

--- a/moviepy/video/tools/gpu_blend.py
+++ b/moviepy/video/tools/gpu_blend.py
@@ -1,0 +1,531 @@
+"""Optional GPU blending helpers (internal).
+
+These helpers are best-effort and must never change MoviePy public APIs.
+They attempt to use CuPy (CUDA) when available and fall back silently to
+CPU paths on any error or OOM.
+
+We intentionally operate on *regions* and copy results back to NumPy arrays.
+Keeping whole-frame state on the GPU would require broader architectural changes.
+"""
+
+from __future__ import annotations
+
+import os
+import site
+from typing import Any
+
+
+_CUPY_USABLE: bool | None = None
+
+
+def _windows_cuda_dll_setup() -> None:
+    """Best-effort CUDA DLL setup for Windows."""
+    if os.name != "nt":
+        return
+
+    cuda_root = os.environ.get("CUDA_PATH") or os.environ.get("CUDA_HOME")
+    if not cuda_root:
+        versioned = [(k, v) for k, v in os.environ.items() if k.startswith("CUDA_PATH_V") and v]
+        if versioned:
+            cuda_root = sorted(versioned, key=lambda kv: kv[0])[-1][1]
+            os.environ.setdefault("CUDA_PATH", cuda_root)
+
+    candidates: list[str] = []
+    if cuda_root:
+        candidates.extend(
+            [
+                os.path.join(cuda_root, "bin"),
+                os.path.join(cuda_root, "bin", "x64"),
+                os.path.join(cuda_root, "bin", "x86_64"),
+            ]
+        )
+
+    for sp in site.getsitepackages():
+        candidates.extend(
+            [
+                os.path.join(sp, "nvidia", "cu13", "bin"),
+                os.path.join(sp, "nvidia", "cu13", "bin", "x86_64"),
+                os.path.join(sp, "nvidia", "cu12", "bin"),
+                os.path.join(sp, "nvidia", "cu12", "bin", "x86_64"),
+            ]
+        )
+
+    for d in candidates:
+        try:
+            if d and os.path.isdir(d):
+                os.add_dll_directory(d)
+        except Exception:
+            pass
+
+
+def _env_flag(name: str, default: str = "0") -> bool:
+    val = os.environ.get(name, default)
+    return str(val).strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def is_available() -> bool:
+    if _env_flag("MOVIEPY_DISABLE_GPU", "0"):
+        return False
+    if _has_cupy():
+        return True
+    if _has_opencv_cuda():
+        return True
+    return False
+
+
+def _has_cupy() -> bool:
+    global _CUPY_USABLE
+    if _CUPY_USABLE is not None:
+        return bool(_CUPY_USABLE)
+
+    try:
+        _windows_cuda_dll_setup()
+        import cupy as cp
+
+        try:
+            if int(cp.cuda.runtime.getDeviceCount()) <= 0:
+                return False
+        except Exception:
+            # Be permissive; we'll validate by running a tiny op.
+            pass
+
+        try:
+            a = cp.zeros((1,), dtype=cp.uint8)
+            b = a.astype(cp.float32)
+            b += 1.0
+            cp.cuda.runtime.deviceSynchronize()
+        except Exception:
+            _CUPY_USABLE = False
+            return False
+
+        _CUPY_USABLE = True
+        return True
+    except Exception:
+        _CUPY_USABLE = False
+        return False
+
+
+def _has_opencv_cuda() -> bool:
+    try:
+        import cv2
+
+        if not hasattr(cv2, "cuda"):
+            return False
+        if not hasattr(cv2.cuda, "getCudaEnabledDeviceCount"):
+            return False
+        return int(cv2.cuda.getCudaEnabledDeviceCount()) > 0
+    except Exception:
+        return False
+
+
+def _min_pixels() -> int:
+    # Heuristic gate to avoid GPU upload/download overhead on small regions.
+    # Set MOVIEPY_GPU_AGGRESSIVE=1 to default to always-on.
+    if _env_flag("MOVIEPY_GPU_AGGRESSIVE", "0"):
+        return 0
+
+    # Default to always-on when a GPU backend is present.
+    val = os.environ.get("MOVIEPY_GPU_MIN_PIXELS", "0")
+    try:
+        return max(0, int(val))
+    except Exception:
+        return 0
+
+
+def should_use_gpu(h: int, w: int) -> bool:
+    return (h * w) >= _min_pixels()
+
+
+def _cp() -> Any:
+    _windows_cuda_dll_setup()
+    import cupy as cp
+
+    return cp
+
+
+def _try_run_opencv_cuda(fn):
+    def _wrapped(*args, **kwargs) -> bool:
+        try:
+            import cv2
+
+            return bool(fn(cv2, *args, **kwargs))
+        except Exception:
+            return False
+
+    return _wrapped
+
+
+def _has_enough_vram(cp: Any, bytes_needed: int) -> bool:
+    try:
+        free_bytes, total_bytes = cp.cuda.runtime.memGetInfo()
+    except Exception:
+        return True
+
+    # Be conservative: require a safety margin.
+    # In aggressive mode, use a smaller margin and rely on OOM fallback.
+    margin = 1.1 if _env_flag("MOVIEPY_GPU_AGGRESSIVE", "0") else 1.5
+    return free_bytes > int(bytes_needed * margin)
+
+
+def _on_oom(cp: Any) -> None:
+    try:
+        cp.get_default_memory_pool().free_all_blocks()
+    except Exception:
+        pass
+
+
+def _try_run(fn):
+    """Decorator-like helper to convert GPU errors into a boolean result."""
+
+    def _wrapped(*args, **kwargs) -> bool:
+        cp = _cp()
+        try:
+            return bool(fn(cp, *args, **kwargs))
+        except Exception as exc:
+            # CuPy raises different errors depending on version/driver.
+            oom_types = []
+            try:
+                oom_types.append(cp.cuda.memory.OutOfMemoryError)
+            except Exception:
+                pass
+
+            if any(isinstance(exc, t) for t in oom_types):
+                _on_oom(cp)
+                return False
+
+            # Generic runtime / driver errors: fall back.
+            return False
+
+    return _wrapped
+
+
+def blend_over_opaque_u8(
+    bg_copy,
+    clip_frame,
+    alpha2d,
+    y1_bg: int,
+    y2_bg: int,
+    x1_bg: int,
+    x2_bg: int,
+    y1_clip: int,
+    y2_clip: int,
+    x1_clip: int,
+    x2_clip: int,
+) -> bool:
+    """Dispatch to the best available GPU backend.
+
+    Preference order: CuPy (CUDA) > OpenCV CUDA.
+    """
+    if _has_cupy():
+        return _blend_over_opaque_u8_cupy(
+            bg_copy,
+            clip_frame,
+            alpha2d,
+            y1_bg,
+            y2_bg,
+            x1_bg,
+            x2_bg,
+            y1_clip,
+            y2_clip,
+            x1_clip,
+            x2_clip,
+        )
+    if _has_opencv_cuda():
+        return _blend_over_opaque_u8_opencv_cuda(
+            bg_copy,
+            clip_frame,
+            alpha2d,
+            y1_bg,
+            y2_bg,
+            x1_bg,
+            x2_bg,
+            y1_clip,
+            y2_clip,
+            x1_clip,
+            x2_clip,
+        )
+    return False
+
+
+@_try_run
+def _blend_over_opaque_u8_cupy(
+    cp: Any,
+    bg_copy,
+    clip_frame,
+    alpha2d,
+    y1_bg: int,
+    y2_bg: int,
+    x1_bg: int,
+    x2_bg: int,
+    y1_clip: int,
+    y2_clip: int,
+    x1_clip: int,
+    x2_clip: int,
+) -> bool:
+    """Blend clip over an opaque background (uint8 RGB), in-place into bg_copy.
+
+    Returns True if GPU path succeeded.
+    """
+    bg_region = bg_copy[y1_bg:y2_bg, x1_bg:x2_bg]
+    fr_region = clip_frame[y1_clip:y2_clip, x1_clip:x2_clip]
+    a_region = alpha2d[y1_clip:y2_clip, x1_clip:x2_clip]
+
+    h, w = bg_region.shape[:2]
+    if h <= 0 or w <= 0:
+        return True
+
+    # Rough VRAM estimate: two float32 RGB + one float32 alpha.
+    bytes_needed = h * w * (3 * 4 * 2 + 4)
+    if not _has_enough_vram(cp, bytes_needed):
+        return False
+
+    bg = cp.asarray(bg_region, dtype=cp.float32)
+    fr = cp.asarray(fr_region, dtype=cp.float32)
+    a = cp.asarray(a_region, dtype=cp.float32)
+
+    # result = bg + a * (fr - bg) (minimize temporaries)
+    cp.subtract(fr, bg, out=fr)
+    fr *= a[:, :, None]
+    fr += bg
+    cp.rint(fr, out=fr)
+    cp.clip(fr, 0, 255, out=fr)
+    out_u8 = fr.astype(cp.uint8)
+
+    bg_region[...] = cp.asnumpy(out_u8)
+    return True
+
+
+@_try_run_opencv_cuda
+def _blend_over_opaque_u8_opencv_cuda(
+    cv2: Any,
+    bg_copy,
+    clip_frame,
+    alpha2d,
+    y1_bg: int,
+    y2_bg: int,
+    x1_bg: int,
+    x2_bg: int,
+    y1_clip: int,
+    y2_clip: int,
+    x1_clip: int,
+    x2_clip: int,
+) -> bool:
+    # Keep this conservative: compute on GPU, but do rounding/clipping on CPU
+    # to better match NumPy semantics.
+    bg_region = bg_copy[y1_bg:y2_bg, x1_bg:x2_bg]
+    fr_region = clip_frame[y1_clip:y2_clip, x1_clip:x2_clip]
+    a_region = alpha2d[y1_clip:y2_clip, x1_clip:x2_clip]
+
+    h, w = bg_region.shape[:2]
+    if h <= 0 or w <= 0:
+        return True
+
+    bg_gpu = cv2.cuda_GpuMat()
+    fr_gpu = cv2.cuda_GpuMat()
+    a_gpu = cv2.cuda_GpuMat()
+    bg_gpu.upload(bg_region)
+    fr_gpu.upload(fr_region)
+    a_gpu.upload(a_region)
+
+    bg_f = bg_gpu.convertTo(cv2.CV_32F)
+    fr_f = fr_gpu.convertTo(cv2.CV_32F)
+    a_f = a_gpu.convertTo(cv2.CV_32F)
+
+    # Expand alpha to 3 channels.
+    a3 = cv2.cuda.merge([a_f, a_f, a_f])
+
+    diff = cv2.cuda.subtract(fr_f, bg_f)
+    diff = cv2.cuda.multiply(diff, a3)
+    out_f = cv2.cuda.add(bg_f, diff)
+
+    out = out_f.download()
+    # CPU rounding/clipping for stable semantics.
+    import numpy as np
+
+    np.rint(out, out=out)
+    out = np.clip(out, 0, 255).astype(np.uint8)
+    bg_region[...] = out
+    return True
+
+
+def blend_over_with_masks_u8(
+    bg_copy,
+    bg_mask_copy,
+    clip_frame,
+    alpha2d,
+    y1_bg: int,
+    y2_bg: int,
+    x1_bg: int,
+    x2_bg: int,
+    y1_clip: int,
+    y2_clip: int,
+    x1_clip: int,
+    x2_clip: int,
+) -> bool:
+    if _has_cupy():
+        return _blend_over_with_masks_u8_cupy(
+            bg_copy,
+            bg_mask_copy,
+            clip_frame,
+            alpha2d,
+            y1_bg,
+            y2_bg,
+            x1_bg,
+            x2_bg,
+            y1_clip,
+            y2_clip,
+            x1_clip,
+            x2_clip,
+        )
+    if _has_opencv_cuda():
+        return _blend_over_with_masks_u8_opencv_cuda(
+            bg_copy,
+            bg_mask_copy,
+            clip_frame,
+            alpha2d,
+            y1_bg,
+            y2_bg,
+            x1_bg,
+            x2_bg,
+            y1_clip,
+            y2_clip,
+            x1_clip,
+            x2_clip,
+        )
+    return False
+
+
+@_try_run
+def _blend_over_with_masks_u8_cupy(
+    cp: Any,
+    bg_copy,
+    bg_mask_copy,
+    clip_frame,
+    alpha2d,
+    y1_bg: int,
+    y2_bg: int,
+    x1_bg: int,
+    x2_bg: int,
+    y1_clip: int,
+    y2_clip: int,
+    x1_clip: int,
+    x2_clip: int,
+) -> bool:
+    """Blend clip over background where both have masks.
+
+    Updates bg_copy (uint8 RGB) and bg_mask_copy (float mask) in-place.
+    Returns True if GPU path succeeded.
+    """
+    bg_region = bg_copy[y1_bg:y2_bg, x1_bg:x2_bg]
+    fr_region = clip_frame[y1_clip:y2_clip, x1_clip:x2_clip]
+    a_clip_region = alpha2d[y1_clip:y2_clip, x1_clip:x2_clip]
+    a_bg_region = bg_mask_copy[y1_bg:y2_bg, x1_bg:x2_bg]
+
+    h, w = bg_region.shape[:2]
+    if h <= 0 or w <= 0:
+        return True
+
+    # Rough VRAM estimate: two float32 RGB + three float32 masks.
+    bytes_needed = h * w * (3 * 4 * 2 + 4 * 3)
+    if not _has_enough_vram(cp, bytes_needed):
+        return False
+
+    bg = cp.asarray(bg_region, dtype=cp.float32)
+    fr = cp.asarray(fr_region, dtype=cp.float32)
+    a_clip = cp.asarray(a_clip_region, dtype=cp.float32)
+    a_bg = cp.asarray(a_bg_region, dtype=cp.float32)
+
+    # tmp = (1 - a_clip)
+    tmp = 1.0 - a_clip
+    final_a = a_clip + a_bg * tmp
+    safe_a = cp.where(final_a == 0, 1.0, final_a)
+
+    # fr <- fr * a_clip
+    fr *= a_clip[:, :, None]
+
+    # a_bg <- a_bg * (1 - a_clip)
+    a_bg *= tmp
+
+    # bg <- bg * a_bg
+    bg *= a_bg[:, :, None]
+
+    # fr <- fr + bg
+    fr += bg
+
+    # fr <- fr / safe_a
+    fr /= safe_a[:, :, None]
+
+    cp.rint(fr, out=fr)
+    cp.clip(fr, 0, 255, out=fr)
+    out_u8 = fr.astype(cp.uint8)
+
+    bg_region[...] = cp.asnumpy(out_u8)
+    bg_mask_copy[y1_bg:y2_bg, x1_bg:x2_bg] = cp.asnumpy(final_a)
+    return True
+
+
+@_try_run_opencv_cuda
+def _blend_over_with_masks_u8_opencv_cuda(
+    cv2: Any,
+    bg_copy,
+    bg_mask_copy,
+    clip_frame,
+    alpha2d,
+    y1_bg: int,
+    y2_bg: int,
+    x1_bg: int,
+    x2_bg: int,
+    y1_clip: int,
+    y2_clip: int,
+    x1_clip: int,
+    x2_clip: int,
+) -> bool:
+    # Conservative implementation: compute float output on GPU, round on CPU.
+    import numpy as np
+
+    bg_region = bg_copy[y1_bg:y2_bg, x1_bg:x2_bg]
+    fr_region = clip_frame[y1_clip:y2_clip, x1_clip:x2_clip]
+    a_clip_region = alpha2d[y1_clip:y2_clip, x1_clip:x2_clip]
+    a_bg_region = bg_mask_copy[y1_bg:y2_bg, x1_bg:x2_bg]
+
+    h, w = bg_region.shape[:2]
+    if h <= 0 or w <= 0:
+        return True
+
+    bg_gpu = cv2.cuda_GpuMat(); bg_gpu.upload(bg_region)
+    fr_gpu = cv2.cuda_GpuMat(); fr_gpu.upload(fr_region)
+    ac_gpu = cv2.cuda_GpuMat(); ac_gpu.upload(a_clip_region.astype(np.float32, copy=False))
+    ab_gpu = cv2.cuda_GpuMat(); ab_gpu.upload(a_bg_region.astype(np.float32, copy=False))
+
+    bg_f = bg_gpu.convertTo(cv2.CV_32F)
+    fr_f = fr_gpu.convertTo(cv2.CV_32F)
+    ac_f = ac_gpu.convertTo(cv2.CV_32F)
+    ab_f = ab_gpu.convertTo(cv2.CV_32F)
+
+    one = cv2.cuda_GpuMat()
+    one.upload(np.ones((h, w), dtype=np.float32))
+    one_minus_ac = cv2.cuda.subtract(one, ac_f)
+    final_a = cv2.cuda.add(ac_f, cv2.cuda.multiply(ab_f, one_minus_ac))
+
+    ac3 = cv2.cuda.merge([ac_f, ac_f, ac_f])
+    bw = cv2.cuda.multiply(ab_f, one_minus_ac)
+    bw3 = cv2.cuda.merge([bw, bw, bw])
+
+    num = cv2.cuda.add(cv2.cuda.multiply(fr_f, ac3), cv2.cuda.multiply(bg_f, bw3))
+
+    # Match CPU semantics: safe_alpha = where(final_a == 0, 1.0, final_a)
+    final_a_cpu = final_a.download()
+    safe_a_cpu = final_a_cpu.copy()
+    safe_a_cpu[safe_a_cpu == 0] = 1.0
+    safe_a = cv2.cuda_GpuMat()
+    safe_a.upload(safe_a_cpu)
+    safe_a3 = cv2.cuda.merge([safe_a, safe_a, safe_a])
+
+    out_f = cv2.cuda.divide(num, safe_a3)
+
+    out = out_f.download()
+    np.rint(out, out=out)
+    out = np.clip(out, 0, 255).astype(np.uint8)
+    bg_region[...] = out
+    bg_mask_copy[y1_bg:y2_bg, x1_bg:x2_bg] = final_a_cpu
+    return True

--- a/moviepy/video/tools/gpu_render.py
+++ b/moviepy/video/tools/gpu_render.py
@@ -1,0 +1,456 @@
+"""Experimental GPU render path.
+
+Goal: keep intermediate compositing math on the GPU (CuPy) during export,
+and only download once per output frame for feeding FFmpeg.
+
+This does NOT change MoviePy's public API by default.
+It is used opportunistically by ffmpeg_write_video when enabled.
+"""
+
+from __future__ import annotations
+
+import os
+import site
+from typing import Tuple
+
+import numpy as np
+
+from moviepy.tools import compute_position
+
+
+def _env_flag(name: str, default: str = "0") -> bool:
+    val = os.environ.get(name, default)
+    return str(val).strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def _strict() -> bool:
+    return _env_flag("MOVIEPY_GPU_RENDER_STRICT", "0")
+
+
+_CUPY_USABLE: bool | None = None
+
+
+def _windows_cuda_dll_setup() -> None:
+    """Best-effort CUDA DLL setup for Windows.
+
+    CuPy may import successfully but fail later when it needs NVRTC DLLs.
+    Adding CUDA Toolkit / pip-runtime DLL directories helps DLL resolution.
+    """
+    if os.name != "nt":
+        return
+
+    # Prefer explicit CUDA_PATH.
+    cuda_root = os.environ.get("CUDA_PATH") or os.environ.get("CUDA_HOME")
+
+    # Some installations set versioned variables (e.g. CUDA_PATH_V13_0).
+    if not cuda_root:
+        versioned = [(k, v) for k, v in os.environ.items() if k.startswith("CUDA_PATH_V") and v]
+        if versioned:
+            # Pick the highest lexicographic key (good enough for V<major>_<minor>).
+            cuda_root = sorted(versioned, key=lambda kv: kv[0])[-1][1]
+            os.environ.setdefault("CUDA_PATH", cuda_root)
+
+    candidates: list[str] = []
+    if cuda_root:
+        candidates.extend(
+            [
+                os.path.join(cuda_root, "bin"),
+                os.path.join(cuda_root, "bin", "x64"),
+                os.path.join(cuda_root, "bin", "x86_64"),
+            ]
+        )
+
+    # Also consider pip-installed NVIDIA runtime layout (if present).
+    for sp in site.getsitepackages():
+        candidates.extend(
+            [
+                os.path.join(sp, "nvidia", "cu13", "bin"),
+                os.path.join(sp, "nvidia", "cu13", "bin", "x86_64"),
+                os.path.join(sp, "nvidia", "cu12", "bin"),
+                os.path.join(sp, "nvidia", "cu12", "bin", "x86_64"),
+            ]
+        )
+
+    for d in candidates:
+        try:
+            if d and os.path.isdir(d):
+                os.add_dll_directory(d)
+        except Exception:
+            pass
+
+
+def _cp():
+    _windows_cuda_dll_setup()
+    import cupy as cp
+
+    return cp
+
+
+def _cupy_is_usable(cp) -> bool:
+    """Return True if CuPy can actually execute kernels.
+
+    Some installations can import CuPy and even see a device, but fail at runtime
+    due to missing CUDA/NVRTC DLLs (common on Windows if PATH isn't set up).
+    """
+    try:
+        # Device query
+        try:
+            if int(cp.cuda.runtime.getDeviceCount()) <= 0:
+                return False
+        except Exception:
+            # Be permissive; the real check is executing a kernel.
+            pass
+
+        # Minimal kernel compile/launch check.
+        a = cp.zeros((1,), dtype=cp.uint8)
+        b = a.astype(cp.float32)
+        b += 1.0
+        cp.cuda.runtime.deviceSynchronize()
+        return True
+    except Exception:
+        return False
+
+
+def is_available() -> bool:
+    global _CUPY_USABLE
+    if _CUPY_USABLE is not None:
+        return bool(_CUPY_USABLE)
+    if _env_flag("MOVIEPY_DISABLE_GPU", "0"):
+        _CUPY_USABLE = False
+        return False
+    try:
+        cp = _cp()
+        _CUPY_USABLE = bool(_cupy_is_usable(cp))
+        return bool(_CUPY_USABLE)
+    except Exception:
+        _CUPY_USABLE = False
+        return False
+
+
+def is_enabled() -> bool:
+    """Whether the experimental GPU export path should be attempted.
+
+    Default: enabled (auto) when available.
+    Opt-out: set MOVIEPY_GPU_RENDER=0 or MOVIEPY_DISABLE_GPU=1.
+    """
+    if _env_flag("MOVIEPY_DISABLE_GPU", "0"):
+        return False
+
+    # Aggressive implies enabled.
+    if _env_flag("MOVIEPY_GPU_AGGRESSIVE", "0"):
+        return True
+
+    # If user explicitly sets the flag, honor it.
+    if "MOVIEPY_GPU_RENDER" in os.environ:
+        return _env_flag("MOVIEPY_GPU_RENDER", "0")
+
+    # Auto by default.
+    return True
+
+
+def _is_gpu_array(x) -> bool:
+    # CuPy (and many CUDA array libs) expose this.
+    return hasattr(x, "__cuda_array_interface__")
+
+
+def _to_cp_u8_rgb(frame):
+    cp = _cp()
+    f = frame if _is_gpu_array(frame) else cp.asarray(frame)
+    if f.ndim == 2:
+        f = cp.stack([f, f, f], axis=2)
+    if f.ndim == 3 and f.shape[2] >= 3:
+        f = f[:, :, :3]
+    if f.dtype != cp.uint8:
+        f = f.astype(cp.uint8)
+    return f
+
+
+def _to_cp_f32_mask(mask):
+    cp = _cp()
+    m = mask if _is_gpu_array(mask) else cp.asarray(mask)
+    if m.ndim == 3:
+        m = m[:, :, 0]
+    if m.dtype != cp.float32:
+        m = m.astype(cp.float32)
+    return m
+
+
+def _as_u8_rgb(frame: np.ndarray) -> np.ndarray:
+    if frame.ndim == 2:
+        frame = np.dstack([frame, frame, frame])
+    if frame.ndim == 3 and frame.shape[2] >= 3:
+        frame = frame[:, :, :3]
+    if frame.dtype != np.uint8:
+        frame = frame.astype(np.uint8)
+    return frame
+
+
+def _as_f32_mask(mask: np.ndarray) -> np.ndarray:
+    if mask.ndim == 3:
+        mask = mask[:, :, 0]
+    if mask.dtype != np.float32:
+        mask = mask.astype(np.float32)
+    return mask
+
+
+def _coords_for_layer(
+    background_size: Tuple[int, int],
+    clip_size: Tuple[int, int],
+    x_start: int,
+    y_start: int,
+):
+    background_width, background_height = background_size
+    clip_width, clip_height = clip_size
+
+    y1_bg = max(y_start, 0)
+    y2_bg = min(y_start + clip_height, background_height)
+    x1_bg = max(x_start, 0)
+    x2_bg = min(x_start + clip_width, background_width)
+
+    y1_clip = max(-y_start, 0)
+    y2_clip = y1_clip + (y2_bg - y1_bg)
+    x1_clip = max(-x_start, 0)
+    x2_clip = x1_clip + (x2_bg - x1_bg)
+
+    return y1_bg, y2_bg, x1_bg, x2_bg, y1_clip, y2_clip, x1_clip, x2_clip
+
+
+def _composite_rgb_gpu(clip, t):
+    """Return a CuPy uint8 RGB frame for a (possibly composite) clip."""
+    cp = _cp()
+
+    # CompositeVideoClip path
+    from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
+
+    if isinstance(clip, CompositeVideoClip):
+        playing = clip.playing_clips(t)
+
+        bg_t = t - clip.bg.start
+        bg_u8 = _to_cp_u8_rgb(clip.bg.get_frame(bg_t))
+        bg_f = bg_u8.astype(cp.float32)
+
+        bg_mask_f = None
+        if clip.bg.mask:
+            bgm_t = t - clip.bg.mask.start
+            bg_mask_f = _to_cp_f32_mask(clip.bg.mask.get_frame(bgm_t))
+
+        bg_h, bg_w = int(bg_u8.shape[0]), int(bg_u8.shape[1])
+
+        for layer in playing:
+            ct = t - layer.start
+            fr_u8 = _to_cp_u8_rgb(layer.get_frame(ct))
+            fr_f = fr_u8.astype(cp.float32)
+
+            layer_mask_f = None
+            if layer.mask is not None:
+                layer_mask_f = _to_cp_f32_mask(layer.mask.get_frame(ct))
+
+            pos = layer.pos(ct)
+            x_start, y_start = compute_position(
+                (int(fr_u8.shape[1]), int(fr_u8.shape[0])),
+                (bg_w, bg_h),
+                pos,
+                layer.relative_pos,
+            )
+
+            (
+                y1_bg,
+                y2_bg,
+                x1_bg,
+                x2_bg,
+                y1_clip,
+                y2_clip,
+                x1_clip,
+                x2_clip,
+            ) = _coords_for_layer((bg_w, bg_h), (int(fr_u8.shape[1]), int(fr_u8.shape[0])), x_start, y_start)
+
+            if (y2_bg <= y1_bg) or (x2_bg <= x1_bg):
+                continue
+
+            bg_region = bg_f[y1_bg:y2_bg, x1_bg:x2_bg]
+            fr_region = fr_f[y1_clip:y2_clip, x1_clip:x2_clip]
+
+            if layer_mask_f is None:
+                bg_region[...] = fr_region
+                if bg_mask_f is not None:
+                    bg_mask_f[y1_bg:y2_bg, x1_bg:x2_bg] = 1.0
+                continue
+
+            a = layer_mask_f[y1_clip:y2_clip, x1_clip:x2_clip]
+
+            if bg_mask_f is None:
+                # bg = bg + a*(fr - bg)
+                cp.subtract(fr_region, bg_region, out=fr_region)
+                fr_region *= a[:, :, None]
+                bg_region += fr_region
+            else:
+                # final_a = a + bg_a*(1-a)
+                bg_a = bg_mask_f[y1_bg:y2_bg, x1_bg:x2_bg]
+                one_minus_a = 1.0 - a
+                final_a = a + bg_a * one_minus_a
+                safe_a = cp.where(final_a == 0, 1.0, final_a)
+
+                # numerator = fr*a + bg*bg_a*(1-a)
+                # reuse fr_region as temp: fr*a
+                fr_region *= a[:, :, None]
+                bg_region *= (bg_a * one_minus_a)[:, :, None]
+                bg_region += fr_region
+                bg_region /= safe_a[:, :, None]
+
+                bg_a[...] = final_a
+
+        cp.rint(bg_f, out=bg_f)
+        cp.clip(bg_f, 0, 255, out=bg_f)
+        return bg_f.astype(cp.uint8)
+
+    # Non-composite: upload current frame.
+    return _to_cp_u8_rgb(clip.get_frame(t))
+
+
+def _composite_mask_gpu(mask_clip, t):
+    """Return a CuPy float32 mask frame."""
+    cp = _cp()
+
+    from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
+
+    if isinstance(mask_clip, CompositeVideoClip) and mask_clip.is_mask:
+        # Background mask is zeros
+        h, w = mask_clip.size[1], mask_clip.size[0]
+        b = cp.zeros((h, w), dtype=cp.float32)
+
+        for layer in mask_clip.playing_clips(t):
+            ct = t - layer.start
+            m = _to_cp_f32_mask(layer.get_frame(ct))
+
+            pos = layer.pos(ct)
+            x_start, y_start = compute_position(
+                (int(m.shape[1]), int(m.shape[0])),
+                (w, h),
+                pos,
+                layer.relative_pos,
+            )
+
+            (
+                y1_bg,
+                y2_bg,
+                x1_bg,
+                x2_bg,
+                y1_clip,
+                y2_clip,
+                x1_clip,
+                x2_clip,
+            ) = _coords_for_layer((w, h), (int(m.shape[1]), int(m.shape[0])), x_start, y_start)
+
+            if (y2_bg <= y1_bg) or (x2_bg <= x1_bg):
+                continue
+
+            b_region = b[y1_bg:y2_bg, x1_bg:x2_bg]
+            m_region = m[y1_clip:y2_clip, x1_clip:x2_clip]
+
+            # b = m + b*(1-m)
+            b_region *= (1.0 - m_region)
+            b_region += m_region
+
+        return b
+
+    # Non-composite mask: upload.
+    return _to_cp_f32_mask(mask_clip.get_frame(t))
+
+
+def get_frame_for_export_uint8(clip, t: float):
+    """Return a NumPy uint8 frame ready for ffmpeg_writer.
+
+    If clip has a mask, returns RGBA uint8; otherwise RGB uint8.
+
+    Falls back to CPU path on any error.
+    """
+    if not (is_enabled() and is_available()):
+        frame = clip.get_frame(t)
+        if frame.dtype != np.uint8:
+            frame = frame.astype(np.uint8)
+        return frame
+
+    cp = _cp()
+
+    try:
+        rgb_u8 = _composite_rgb_gpu(clip, t)
+        if clip.mask is None:
+            return cp.asnumpy(rgb_u8)
+
+        # Match CPU export path semantics exactly:
+        # mask_u8 = (255 * mask_frame).astype(uint8) with NumPy/CuPy overflow
+        # behavior for uint8 masks, and stack via dstack semantics.
+        mask_frame = clip.mask.get_frame(t)
+        m = mask_frame if _is_gpu_array(mask_frame) else cp.asarray(mask_frame)
+        m_u8 = m * 255
+        if m_u8.dtype != cp.uint8:
+            m_u8 = m_u8.astype(cp.uint8)
+        if m_u8.ndim == 2:
+            m_u8 = m_u8[:, :, None]
+        rgba = cp.concatenate([rgb_u8, m_u8], axis=2)
+        return cp.asnumpy(rgba)
+    except Exception:
+        if _strict():
+            raise
+        # Best-effort: never fail export.
+        frame = clip.get_frame(t)
+        if frame.dtype != np.uint8:
+            frame = frame.astype(np.uint8)
+        if clip.mask is not None:
+            mask = 255 * clip.mask.get_frame(t)
+            if mask.dtype != np.uint8:
+                mask = mask.astype(np.uint8)
+            frame = np.dstack([frame, mask])
+        return frame
+
+
+def get_frame_for_export_uint8_gpu(clip, t: float):
+    """Return a CuPy uint8 frame (RGB or RGBA) for ffmpeg export.
+
+    This is the "CuPy-native" experimental export pipeline: all compositing
+    work happens on the GPU and the returned frame is a CuPy array. The only
+    CPU conversion happens at the final FFmpeg write.
+
+    On any error, returns a NumPy uint8 frame as a safe fallback.
+    """
+    if not (is_enabled() and is_available()):
+        frame = clip.get_frame(t)
+        if frame.dtype != np.uint8:
+            frame = frame.astype(np.uint8)
+        if clip.mask is not None:
+            mask = 255 * clip.mask.get_frame(t)
+            if mask.dtype != np.uint8:
+                mask = mask.astype(np.uint8)
+            frame = np.dstack([frame, mask])
+        return frame
+
+    cp = _cp()
+    try:
+        rgb_u8 = _composite_rgb_gpu(clip, t)
+        if clip.mask is None:
+            return rgb_u8
+
+        # Match CPU export path semantics exactly:
+        # mask_u8 = (255 * mask_frame).astype(uint8) with CuPy overflow
+        # behavior for uint8 masks, and stack via dstack semantics.
+        mask_frame = clip.mask.get_frame(t)
+        m = mask_frame if _is_gpu_array(mask_frame) else cp.asarray(mask_frame)
+        m_u8 = m * 255
+        if m_u8.dtype != cp.uint8:
+            m_u8 = m_u8.astype(cp.uint8)
+        if m_u8.ndim == 2:
+            m_u8 = m_u8[:, :, None]
+        rgba = cp.concatenate([rgb_u8, m_u8], axis=2)
+        return rgba
+    except Exception:
+        if _strict():
+            raise
+        frame = clip.get_frame(t)
+        if frame.dtype != np.uint8:
+            frame = frame.astype(np.uint8)
+        if clip.mask is not None:
+            mask = 255 * clip.mask.get_frame(t)
+            if mask.dtype != np.uint8:
+                mask = mask.astype(np.uint8)
+            frame = np.dstack([frame, mask])
+        return frame

--- a/moviepy/video/tools/gpu_render.py
+++ b/moviepy/video/tools/gpu_render.py
@@ -110,7 +110,11 @@ def _cache_get(cache: dict[int, tuple[weakref.ref, object]], clip) -> object | N
     return None
 
 
-def _cache_set(cache: dict[int, tuple[weakref.ref, object]], clip, value: object) -> None:
+def _cache_set(
+    cache: dict[int, tuple[weakref.ref, object]],
+    clip,
+    value: object,
+) -> None:
     key = id(clip)
 
     def _cleanup(_ref, _key=key, _cache=cache):
@@ -279,7 +283,9 @@ def _composite_rgb_gpu(clip, t):
 
         # Fast-path: if no playing layer has a mask, we can composite entirely
         # in uint8 (no alpha blending), avoiding a full-frame float32 buffer.
-        any_layer_has_mask = any(getattr(layer, "mask", None) is not None for layer in playing)
+        any_layer_has_mask = any(
+            getattr(layer, "mask", None) is not None for layer in playing
+        )
 
         bg_t = t - clip.bg.start
         if isinstance(clip.bg, CompositeVideoClip):
@@ -318,7 +324,11 @@ def _composite_rgb_gpu(clip, t):
                     layer.mask, "is_mask", False
                 ) and hasattr(layer.mask, "img"):
                     layer_mask = _cached_cp_f32_mask_for_imageclip(layer.mask)
-                elif isinstance(layer.mask, CompositeVideoClip) and getattr(layer.mask, "is_mask", False):
+                elif isinstance(layer.mask, CompositeVideoClip) and getattr(
+                    layer.mask,
+                    "is_mask",
+                    False,
+                ):
                     layer_mask = _composite_mask_gpu(layer.mask, ct, dtype=cp.float32)
                 else:
                     layer_mask = _get_mask_frame_gpu_best_effort(layer.mask, ct)
@@ -340,7 +350,12 @@ def _composite_rgb_gpu(clip, t):
                 y2_clip,
                 x1_clip,
                 x2_clip,
-            ) = _coords_for_layer((bg_w, bg_h), (int(fr_u8.shape[1]), int(fr_u8.shape[0])), x_start, y_start)
+            ) = _coords_for_layer(
+                (bg_w, bg_h),
+                (int(fr_u8.shape[1]), int(fr_u8.shape[0])),
+                x_start,
+                y_start,
+            )
 
             if (y2_bg <= y1_bg) or (x2_bg <= x1_bg):
                 continue
@@ -422,7 +437,11 @@ def _composite_mask_gpu(mask_clip, t, *, dtype=None):
 
         for layer in mask_clip.playing_clips(t):
             ct = t - layer.start
-            if isinstance(layer, CompositeVideoClip) and getattr(layer, "is_mask", False):
+            if isinstance(layer, CompositeVideoClip) and getattr(
+                layer,
+                "is_mask",
+                False,
+            ):
                 m = _composite_mask_gpu(layer, ct, dtype=dtype)
             else:
                 m = _get_frame_gpu_best_effort(layer, ct)
@@ -503,7 +522,11 @@ def get_frame_for_export_uint8(clip, t: float):
         # behavior for uint8 masks, and stack via dstack semantics.
         from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
 
-        if isinstance(clip.mask, CompositeVideoClip) and getattr(clip.mask, "is_mask", False):
+        if isinstance(clip.mask, CompositeVideoClip) and getattr(
+            clip.mask,
+            "is_mask",
+            False,
+        ):
             m = _composite_mask_gpu(clip.mask, t, dtype=cp.float64)
         else:
             m = _get_frame_gpu_best_effort(clip.mask, t)
@@ -561,7 +584,11 @@ def get_frame_for_export_uint8_gpu(clip, t: float):
         # behavior for uint8 masks, and stack via dstack semantics.
         from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
 
-        if isinstance(clip.mask, CompositeVideoClip) and getattr(clip.mask, "is_mask", False):
+        if isinstance(clip.mask, CompositeVideoClip) and getattr(
+            clip.mask,
+            "is_mask",
+            False,
+        ):
             m = _composite_mask_gpu(clip.mask, t, dtype=cp.float64)
         else:
             m = _get_frame_gpu_best_effort(clip.mask, t)

--- a/moviepy/video/tools/numba_blend.py
+++ b/moviepy/video/tools/numba_blend.py
@@ -1,0 +1,152 @@
+"""Optional Numba-accelerated blending helpers.
+
+This module is internal-only.
+
+If `numba` is not installed (or fails to import), MoviePy will fall back to
+its NumPy implementation.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def _numba():
+    try:
+        import numba
+
+        return numba
+    except Exception:
+        return None
+
+
+def is_available() -> bool:
+    return _numba() is not None
+
+
+@lru_cache(maxsize=1)
+def _kernels():
+    numba = _numba()
+    if numba is None:
+        return None
+
+    import numpy as np
+
+    njit = numba.njit
+
+    @njit(cache=True, fastmath=True)
+    def blend_over_opaque_u8(
+        bg,
+        frame,
+        alpha,
+        y1_bg,
+        y2_bg,
+        x1_bg,
+        x2_bg,
+        y1_clip,
+        y2_clip,
+        x1_clip,
+        x2_clip,
+    ):
+        """Blend frame over bg in-place assuming bg is fully opaque.
+
+        bg: uint8 HxWx3
+        frame: uint8 hxwx3
+        alpha: float mask hxw in [0,1]
+        """
+        h = y2_bg - y1_bg
+        w = x2_bg - x1_bg
+        for dy in range(h):
+            by = y1_bg + dy
+            cy = y1_clip + dy
+            for dx in range(w):
+                bx = x1_bg + dx
+                cx = x1_clip + dx
+                a = alpha[cy, cx]
+                if a <= 0.0:
+                    continue
+                if a >= 1.0:
+                    bg[by, bx, 0] = frame[cy, cx, 0]
+                    bg[by, bx, 1] = frame[cy, cx, 1]
+                    bg[by, bx, 2] = frame[cy, cx, 2]
+                    continue
+
+                inv = 1.0 - a
+                bg[by, bx, 0] = np.uint8(np.rint(frame[cy, cx, 0] * a + bg[by, bx, 0] * inv))
+                bg[by, bx, 1] = np.uint8(np.rint(frame[cy, cx, 1] * a + bg[by, bx, 1] * inv))
+                bg[by, bx, 2] = np.uint8(np.rint(frame[cy, cx, 2] * a + bg[by, bx, 2] * inv))
+
+    @njit(cache=True, fastmath=True)
+    def blend_over_with_masks_u8(
+        bg,
+        bg_mask,
+        frame,
+        alpha_clip,
+        y1_bg,
+        y2_bg,
+        x1_bg,
+        x2_bg,
+        y1_clip,
+        y2_clip,
+        x1_clip,
+        x2_clip,
+    ):
+        """Blend frame over bg in-place, updating bg_mask in-place.
+
+        bg: uint8 HxWx3
+        bg_mask: float HxW in [0,1]
+        frame: uint8 hxwx3
+        alpha_clip: float hxw in [0,1]
+        """
+        h = y2_bg - y1_bg
+        w = x2_bg - x1_bg
+        for dy in range(h):
+            by = y1_bg + dy
+            cy = y1_clip + dy
+            for dx in range(w):
+                bx = x1_bg + dx
+                cx = x1_clip + dx
+                a_clip = alpha_clip[cy, cx]
+                a_bg = bg_mask[by, bx]
+
+                if a_clip <= 0.0:
+                    continue
+
+                # final_alpha = a_clip + a_bg * (1 - a_clip)
+                final_a = a_clip + a_bg * (1.0 - a_clip)
+                bg_mask[by, bx] = final_a
+
+                safe = final_a
+                if safe == 0.0:
+                    safe = 1.0
+
+                # (frame*a_clip + bg*a_bg*(1-a_clip)) / safe
+                inv_clip = 1.0 - a_clip
+                w_bg = a_bg * inv_clip
+
+                bg[by, bx, 0] = np.uint8(
+                    np.rint((frame[cy, cx, 0] * a_clip + bg[by, bx, 0] * w_bg) / safe)
+                )
+                bg[by, bx, 1] = np.uint8(
+                    np.rint((frame[cy, cx, 1] * a_clip + bg[by, bx, 1] * w_bg) / safe)
+                )
+                bg[by, bx, 2] = np.uint8(
+                    np.rint((frame[cy, cx, 2] * a_clip + bg[by, bx, 2] * w_bg) / safe)
+                )
+
+    return blend_over_opaque_u8, blend_over_with_masks_u8
+
+
+def blend_over_opaque_u8(*args, **kwargs):
+    kernels = _kernels()
+    if kernels is None:
+        raise RuntimeError("Numba kernels are unavailable")
+    return kernels[0](*args, **kwargs)
+
+
+def blend_over_with_masks_u8(*args, **kwargs):
+    kernels = _kernels()
+    if kernels is None:
+        raise RuntimeError("Numba kernels are unavailable")
+    return kernels[1](*args, **kwargs)

--- a/moviepy/video/tools/numba_blend.py
+++ b/moviepy/video/tools/numba_blend.py
@@ -73,9 +73,15 @@ def _kernels():
                     continue
 
                 inv = 1.0 - a
-                bg[by, bx, 0] = np.uint8(np.rint(frame[cy, cx, 0] * a + bg[by, bx, 0] * inv))
-                bg[by, bx, 1] = np.uint8(np.rint(frame[cy, cx, 1] * a + bg[by, bx, 1] * inv))
-                bg[by, bx, 2] = np.uint8(np.rint(frame[cy, cx, 2] * a + bg[by, bx, 2] * inv))
+                bg[by, bx, 0] = np.uint8(
+                    np.rint(frame[cy, cx, 0] * a + bg[by, bx, 0] * inv)
+                )
+                bg[by, bx, 1] = np.uint8(
+                    np.rint(frame[cy, cx, 1] * a + bg[by, bx, 1] * inv)
+                )
+                bg[by, bx, 2] = np.uint8(
+                    np.rint(frame[cy, cx, 2] * a + bg[by, bx, 2] * inv)
+                )
 
     @njit(cache=True, fastmath=True)
     def blend_over_with_masks_u8(

--- a/moviepy/video/tools/scratch.py
+++ b/moviepy/video/tools/scratch.py
@@ -1,0 +1,99 @@
+"""Internal scratch-buffer pool.
+
+This is intentionally *not* a global frame cache.
+
+We only reuse temporary working arrays that never escape to user code.
+Buffers are stored per-thread to avoid cross-thread corruption.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+import numpy as np
+
+
+_tls = threading.local()
+
+
+def _max_cache_bytes() -> int:
+    """Maximum size (bytes) for a single cached scratch buffer.
+
+    Defaults to 64MB to avoid keeping very large 4K float buffers resident.
+    Set env var MOVIEPY_SCRATCH_CACHE_MAX_MB to override (0 disables caching).
+    """
+    val = os.environ.get("MOVIEPY_SCRATCH_CACHE_MAX_MB", "64")
+    try:
+        mb = float(val)
+    except Exception:
+        mb = 64.0
+    if mb <= 0:
+        return 0
+    return int(mb * 1024 * 1024)
+
+
+def _store() -> dict[object, np.ndarray]:
+    store = getattr(_tls, "store", None)
+    if store is None:
+        store = {}
+        _tls.store = store
+    return store
+
+
+def clear() -> None:
+    """Clear all cached scratch buffers for the current thread."""
+    store = getattr(_tls, "store", None)
+    if store is not None:
+        store.clear()
+
+
+def get_array(key: str, shape: tuple[int, ...], dtype) -> np.ndarray:
+    """Get an array of at least `shape` and `dtype` for the current thread.
+
+    The returned array is a view with exactly `shape`.
+    """
+    if any(s < 0 for s in shape):
+        raise ValueError(f"Invalid shape: {shape}")
+
+    dtype = np.dtype(dtype)
+    store_key = (key, dtype.str, len(shape))
+
+    max_bytes = _max_cache_bytes()
+    requested_bytes = int(np.prod(shape, dtype=np.int64)) * dtype.itemsize
+    cache_allowed = (max_bytes > 0) and (requested_bytes <= max_bytes)
+
+    store = _store() if cache_allowed else None
+    arr = store.get(store_key) if store is not None else None
+
+    if (arr is not None) and (max_bytes > 0) and (arr.nbytes > max_bytes):
+        # Cached buffer is now over budget (e.g., env var changed).
+        try:
+            del store[store_key]
+        except Exception:
+            pass
+        arr = None
+
+    if arr is None or arr.dtype != dtype or arr.ndim != len(shape):
+        arr = np.empty(shape, dtype=dtype)
+        if store is not None:
+            store[store_key] = arr
+        return arr
+
+    if any(req > cur for req, cur in zip(shape, arr.shape)):
+        new_shape = tuple(max(req, cur) for req, cur in zip(shape, arr.shape))
+        new_bytes = int(np.prod(new_shape, dtype=np.int64)) * dtype.itemsize
+        if (max_bytes > 0) and (new_bytes > max_bytes):
+            # Grow would exceed cache budget: return an uncached exact-size buffer.
+            return np.empty(shape, dtype=dtype)
+
+        arr = np.empty(new_shape, dtype=dtype)
+        if store is not None:
+            store[store_key] = arr
+
+    slices = tuple(slice(0, s) for s in shape)
+    return arr[slices]
+
+
+def get_float32(key: str, shape: tuple[int, ...]) -> np.ndarray:
+    return get_array(key, shape, np.float32)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,12 +50,21 @@ accelerate = [
 # dependency for CPU video decoding.
 gpu = [
     "cupy-cuda13x>=13.0.0",
+    # Optional: NVIDIA's pip-distributed Video Codec SDK bindings (encode/decode).
+    # Note: runtime requires compatible NVIDIA drivers / CUDA libraries.
+    "pynvvideocodec>=2.0.0; platform_system != 'Darwin'",
+    # On Windows, PyNvVideoCodec wheels currently depend on the CUDA 12 runtime DLL
+    # `cudart64_12.dll`. Installing this package provides it.
+    "nvidia-cuda-runtime-cu12>=12.0; platform_system == 'Windows'",
 ]
 doc = [
     "numpydoc<2.0",
     "Sphinx==6.*",
     "pydata-sphinx-theme==0.13",
     "sphinx_design",
+    # PyNvVideoCodec wheels depend on CUDA 12 runtime DLLs (e.g. cudart64_12.dll).
+    # On Windows, this is most reliably satisfied via the pip runtime package.
+    "nvidia-cuda-runtime-cu12>=12.0.0; platform_system == 'Windows'",
 ]
 test = [
     "coveralls>=3.0,<4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,17 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+accelerate = [
+    "numba>=0.59",
+]
+
+# GPU compositing is optional and best-effort.
+# We ship CuPy GPU kernels; OpenCV-CUDA support requires a custom OpenCV build
+# (PyPI wheels generally don't include CUDA). We still keep OpenCV as a base
+# dependency for CPU video decoding.
+gpu = [
+    "cupy-cuda13x>=13.0.0",
+]
 doc = [
     "numpydoc<2.0",
     "Sphinx==6.*",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths =
+    tests

--- a/tests/test_ffmpeg_writer_cupy.py
+++ b/tests/test_ffmpeg_writer_cupy.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+def test_ffmpeg_write_image_accepts_cupy(util, monkeypatch):
+    cp = pytest.importorskip("cupy")
+
+    from moviepy.video.tools import gpu_render
+
+    if not gpu_render.is_available():
+        pytest.skip("CuPy installed but CUDA runtime not usable")
+
+    from moviepy.video.io.ffmpeg_writer import ffmpeg_write_image
+
+    import numpy as np
+    import os
+
+    img = np.zeros((8, 9, 3), dtype=np.uint8)
+    img[:, :, 0] = 255
+    img_cp = cp.asarray(img)
+
+    filename = os.path.join(util.TMP_DIR, "moviepy_ffmpeg_write_image_cupy.png")
+    ffmpeg_write_image(filename, img_cp, logfile=False)
+
+    assert os.path.isfile(filename)

--- a/tests/test_gpu_render.py
+++ b/tests/test_gpu_render.py
@@ -30,3 +30,280 @@ def test_gpu_render_composite_smoke(monkeypatch):
     assert isinstance(frame, np.ndarray)
     assert frame.dtype == np.uint8
     assert frame.shape == (48, 64, 3)
+
+
+def test_gpu_render_transform_fadein_smoke(monkeypatch):
+    cp = pytest.importorskip("cupy")
+
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_AGGRESSIVE", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER_STRICT", "1")
+
+    from moviepy.video.VideoClip import ColorClip
+    from moviepy.video.fx.FadeIn import FadeIn
+    from moviepy.video.tools import gpu_render
+
+    if not gpu_render.is_available():
+        pytest.skip("CuPy installed but CUDA runtime not usable")
+
+    clip = (
+        ColorClip((32, 24), color=(10, 20, 30))
+        .with_duration(1)
+        .with_fps(5)
+        .with_effects([FadeIn(0.5)])
+    )
+
+    # Ensure the GPU compositor is actually using the internal GPU frame path.
+    called = {"n": 0}
+    orig = getattr(clip, "_gpu_frame_function", None)
+    assert orig is not None
+
+    def wrapped(t):
+        called["n"] += 1
+        return orig(t)
+
+    clip._gpu_frame_function = wrapped
+
+    frame_gpu = gpu_render.get_frame_for_export_uint8_gpu(clip, 0.1)
+    assert called["n"] > 0
+
+    assert hasattr(frame_gpu, "__cuda_array_interface__")
+    frame = cp.asnumpy(frame_gpu)
+    assert frame.dtype == np.uint8
+    assert frame.shape == (24, 32, 3)
+    assert frame[0, 0].tolist() == [2, 4, 6]
+
+
+def test_gpu_render_composite_mask_is_composited_on_gpu(monkeypatch):
+    cp = pytest.importorskip("cupy")
+
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_AGGRESSIVE", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER_STRICT", "1")
+
+    from moviepy.video.VideoClip import ColorClip
+    from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
+    from moviepy.video.tools import gpu_render
+
+    if not gpu_render.is_available():
+        pytest.skip("CuPy installed but CUDA runtime not usable")
+
+    top = ColorClip((20, 10), color=(200, 0, 0)).with_duration(1).with_fps(5)
+    top = top.with_position((5, 7))
+
+    # Transparent composite -> has a CompositeVideoClip mask.
+    comp = CompositeVideoClip([top], size=(64, 48), bg_color=None)
+    assert comp.mask is not None
+    assert isinstance(comp.mask, CompositeVideoClip)
+    assert comp.mask.is_mask
+
+    # Ensure GPU export doesn't call comp.mask.get_frame() / frame_function.
+    comp.mask.frame_function = lambda t: (_ for _ in ()).throw(
+        RuntimeError("mask frame_function should not be called in GPU path")
+    )
+
+    frame_gpu = gpu_render.get_frame_for_export_uint8_gpu(comp, 0)
+    assert hasattr(frame_gpu, "__cuda_array_interface__")
+
+    frame = cp.asnumpy(frame_gpu)
+    assert frame.dtype == np.uint8
+    assert frame.shape == (48, 64, 4)
+    # Outside mask should be transparent.
+    assert frame[0, 0].tolist() == [0, 0, 0, 0]
+    # Inside the top clip region alpha should be fully opaque.
+    assert frame[10, 10, 3] == 255
+
+
+def test_gpu_render_effects_lum_gamma_smoke(monkeypatch):
+    cp = pytest.importorskip("cupy")
+
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_AGGRESSIVE", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER_STRICT", "1")
+
+    import numpy as np
+
+    from moviepy.video.VideoClip import VideoClip
+    from moviepy.video.fx.GammaCorrection import GammaCorrection
+    from moviepy.video.fx.LumContrast import LumContrast
+    from moviepy.video.tools import gpu_render
+
+    if not gpu_render.is_available():
+        pytest.skip("CuPy installed but CUDA runtime not usable")
+
+    def frame_function(_t):
+        frame = np.empty((12, 16, 3), dtype=np.uint8)
+        frame[...] = (100, 150, 200)
+        return frame
+
+    clip = VideoClip(frame_function=frame_function, duration=1).with_fps(5)
+    clip = clip.with_effects([LumContrast(lum=10, contrast=0.2), GammaCorrection(gamma=0.8)])
+
+    called = {"n": 0}
+    orig = getattr(clip, "_gpu_frame_function", None)
+    assert orig is not None
+
+    def wrapped(t):
+        called["n"] += 1
+        return orig(t)
+
+    clip._gpu_frame_function = wrapped
+
+    frame_gpu = gpu_render.get_frame_for_export_uint8_gpu(clip, 0)
+    assert called["n"] > 0
+    assert hasattr(frame_gpu, "__cuda_array_interface__")
+
+    frame = cp.asnumpy(frame_gpu)
+    assert frame.dtype == np.uint8
+    assert frame.shape == (12, 16, 3)
+
+
+def test_gpu_render_nested_composite_does_not_call_inner_get_frame(monkeypatch):
+    cp = pytest.importorskip("cupy")
+
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_AGGRESSIVE", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER_STRICT", "1")
+
+    from moviepy.video.VideoClip import ColorClip
+    from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
+    from moviepy.video.tools import gpu_render
+
+    if not gpu_render.is_available():
+        pytest.skip("CuPy installed but CUDA runtime not usable")
+
+    base = ColorClip((64, 48), color=(10, 20, 30)).with_duration(1).with_fps(5)
+
+    inner_base = ColorClip((64, 48), color=(0, 0, 0)).with_duration(1).with_fps(5)
+    inner_top = (
+        ColorClip((16, 12), color=(200, 0, 0)).with_duration(1).with_fps(5).with_position((8, 9))
+    )
+    inner = CompositeVideoClip([inner_base, inner_top], size=(64, 48), bg_color=(0, 0, 0))
+
+    # Without nested-composite support, the GPU compositor would fall back to
+    # calling inner.get_frame() (CPU) and this would raise.
+    inner.get_frame = lambda _t: (_ for _ in ()).throw(
+        RuntimeError("inner get_frame should not be called in GPU path")
+    )
+
+    outer = CompositeVideoClip(
+        [base, inner.with_position((0, 0))], size=(64, 48), bg_color=(0, 0, 0)
+    )
+
+    frame_gpu = gpu_render.get_frame_for_export_uint8_gpu(outer, 0)
+    assert hasattr(frame_gpu, "__cuda_array_interface__")
+
+    frame = cp.asnumpy(frame_gpu)
+    assert frame.dtype == np.uint8
+    assert frame.shape == (48, 64, 3)
+
+
+def test_gpu_render_imageclip_cupy_img_is_cached(monkeypatch):
+    cp = pytest.importorskip("cupy")
+
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_AGGRESSIVE", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER_STRICT", "1")
+
+    from moviepy.video.VideoClip import ImageClip
+    from moviepy.video.tools import gpu_render
+
+    if not gpu_render.is_available():
+        pytest.skip("CuPy installed but CUDA runtime not usable")
+
+    img_np = np.zeros((12, 16, 3), dtype=np.uint8)
+    img_np[:, :, 0] = 123
+    clip = ImageClip(img_np, transparent=False).with_duration(1).with_fps(5)
+    # Simulate a CuPy-backed ImageClip (constructor expects NumPy/URI).
+    clip.img = cp.asarray(clip.img)
+
+    frame_gpu = gpu_render.get_frame_for_export_uint8_gpu(clip, 0)
+    assert hasattr(frame_gpu, "__cuda_array_interface__")
+    frame = cp.asnumpy(frame_gpu)
+    assert frame.shape == (12, 16, 3)
+    assert frame.dtype == np.uint8
+    assert frame[0, 0].tolist() == [123, 0, 0]
+
+
+def test_save_frame_accepts_cupy_frame(monkeypatch, tmp_path):
+    cp = pytest.importorskip("cupy")
+
+    from moviepy.video.VideoClip import VideoClip
+    from moviepy.video.tools import gpu_render
+
+    if not gpu_render.is_available():
+        pytest.skip("CuPy installed but CUDA runtime not usable")
+
+    def frame_function(_t):
+        frame = cp.zeros((12, 16, 3), dtype=cp.uint8)
+        frame[:, :, 1] = 200
+        return frame
+
+    clip = VideoClip(frame_function=frame_function, duration=1).with_fps(5)
+    out = tmp_path / "cupy_save_frame.png"
+    clip.save_frame(str(out), t=0)
+    assert out.exists()
+
+
+def test_write_images_sequence_accepts_cupy_frame(monkeypatch, tmp_path):
+    cp = pytest.importorskip("cupy")
+
+    from moviepy.video.VideoClip import VideoClip
+    from moviepy.video.tools import gpu_render
+
+    if not gpu_render.is_available():
+        pytest.skip("CuPy installed but CUDA runtime not usable")
+
+    def frame_function(_t):
+        frame = cp.zeros((12, 16, 3), dtype=cp.uint8)
+        frame[:, :, 2] = 255
+        return frame
+
+    clip = VideoClip(frame_function=frame_function, duration=0.41).with_fps(5)
+    fmt = str(tmp_path / "frame%03d.png")
+
+    names = clip.write_images_sequence(fmt, fps=5, with_mask=False, logger=None)
+    assert len(names) >= 2
+    assert (tmp_path / "frame000.png").exists()
+
+
+def test_iter_frames_yields_numpy_when_frame_is_cupy(monkeypatch):
+    cp = pytest.importorskip("cupy")
+
+    from moviepy.video.VideoClip import VideoClip
+    from moviepy.video.tools import gpu_render
+
+    if not gpu_render.is_available():
+        pytest.skip("CuPy installed but CUDA runtime not usable")
+
+    def frame_function(_t):
+        return cp.zeros((6, 8, 3), dtype=cp.uint8)
+
+    clip = VideoClip(frame_function=frame_function, duration=0.41).with_fps(5)
+    frames = list(clip.iter_frames(fps=5, dtype="uint8", logger=None))
+    assert frames
+    assert isinstance(frames[0], np.ndarray)
+    assert frames[0].dtype == np.uint8
+
+
+def test_write_gif_accepts_cupy_frames(monkeypatch, tmp_path):
+    cp = pytest.importorskip("cupy")
+
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_AGGRESSIVE", "1")
+
+    from moviepy.video.VideoClip import VideoClip
+    from moviepy.video.tools import gpu_render
+
+    if not gpu_render.is_available():
+        pytest.skip("CuPy installed but CUDA runtime not usable")
+
+    def frame_function(_t):
+        frame = cp.zeros((12, 16, 3), dtype=cp.uint8)
+        frame[:, :, 0] = 255
+        return frame
+
+    clip = VideoClip(frame_function=frame_function, duration=0.41).with_fps(5)
+    out = tmp_path / "cupy.gif"
+    clip.write_gif(str(out), fps=5, loop=0, logger=None)
+    assert out.exists()

--- a/tests/test_gpu_render.py
+++ b/tests/test_gpu_render.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+
+def test_gpu_render_composite_smoke(monkeypatch):
+    cp = pytest.importorskip("cupy")
+
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_AGGRESSIVE", "1")
+    monkeypatch.setenv("MOVIEPY_GPU_RENDER_STRICT", "1")
+
+    from moviepy.video.VideoClip import ColorClip
+    from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
+    from moviepy.video.tools import gpu_render
+
+    if not gpu_render.is_available():
+        pytest.skip("CuPy installed but CUDA runtime not usable")
+
+    base = ColorClip((64, 48), color=(10, 20, 30)).with_duration(1).with_fps(5)
+    top = ColorClip((20, 10), color=(200, 0, 0)).with_duration(1).with_fps(5)
+    top = top.with_position((5, 7))
+
+    comp = CompositeVideoClip([base, top], size=(64, 48), bg_color=(0, 0, 0))
+
+    frame_gpu = gpu_render.get_frame_for_export_uint8_gpu(comp, 0)
+    # In GPU mode and with a CUDA device, we expect a CuPy array.
+    assert hasattr(frame_gpu, "__cuda_array_interface__")
+
+    frame = cp.asnumpy(frame_gpu)
+    assert isinstance(frame, np.ndarray)
+    assert frame.dtype == np.uint8
+    assert frame.shape == (48, 64, 3)


### PR DESCRIPTION
**Warning: this is completely experimental (not production ready, initially only meant to be used for myself), and NVIDIA focused. I have not tested pure CPU rendering, AMD cards, or Intel QSV.**

Version tested on RTX 3000 series card successfully with no issues among multiple different workflows with notably less RAM usage, **much faster** rendering, less CPU overhead and more GPU utilization.

It isn't the best and fastest potential MoviePy can get to, all of these changes were done under current flow, safety and the least need to update API usage for the end user.

Users who want to try out this experimental version can use `pip install -U --force-reinstall "moviepy[accelerate,gpu] @ git+https://github.com/nycalexander/moviefast.git"` (virtual environment and CUDA Toolkit install recommended)
