### PR TITLE
[PR] Numpy Deprecation Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ docs/build/
 
 # Publishing
 .pypirc
+
+.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This mean you need to specifically set `bg_color=None` if you want to generate a
 - Fix TextClip broken with Pillow > 11.2
 - `pixel_format` parameter was ignored when calling ffmpeg writer, as referenced in PR #2359
 - Fix incorrect handling of lines with a format different from "key: value" during FFmpeg infos parsing (see #2311, #1860, #2418, #2470)
+- Fix `DeprecationWarning` from in-place `ndarray.shape` assignment in `FFMPEG_VideoReader.read_frame()` on numpy >= 2.5
 
 ### Added
 - Possibility to select audio track when reading a file (#2429)

--- a/moviepy/video/io/ffmpeg_reader.py
+++ b/moviepy/video/io/ffmpeg_reader.py
@@ -225,7 +225,7 @@ class FFMPEG_VideoReader:
                 result = np.frombuffer(s, dtype="uint8")
             else:
                 result = np.fromstring(s, dtype="uint8")
-            result.shape = (h, w, len(s) // (w * h))  # reshape((h, w, len(s)//(w*h)))
+            result = result.reshape((h, w, len(s) // (w * h)))
             self.last_read = result
 
         # We have to do this down here because `self.pos` is used in the warning above


### PR DESCRIPTION
## Summary

Fixes a `DeprecationWarning` that numpy >= 2.5 raises on **every single frame decode**.

`FFMPEG_VideoReader.read_frame()` in `moviepy/video/io/ffmpeg_reader.py` built each frame from the raw bytes read off the ffmpeg subprocess, then reshaped the flat buffer by assigning directly to `result.shape`:

```python
result.shape = (h, w, len(s) // (w * h))
```

numpy 2.5 deprecated in-place shape assignment on an `ndarray` in favor of `.reshape()`, so this fired on every frame read:

```
DeprecationWarning: Setting the shape on a NumPy array has been deprecated in NumPy 2.5.
As an alternative, you can create a new view using np.reshape (with copy=False if needed).
```

## Reproduction

Self-contained — it generates its own tiny video, so no external media is needed. On the pre-fix code this prints the `DeprecationWarning` shown above before printing the frame shape; after the fix it prints only the frame shape.

```python
import warnings
warnings.simplefilter("always")

from moviepy import ColorClip, VideoFileClip

clip = ColorClip((64, 64), color=(255, 0, 0), duration=1)
clip.write_videofile("repro.mp4", fps=24, logger=None)

reader_clip = VideoFileClip("repro.mp4")
frame = reader_clip.get_frame(0)  # <-- DeprecationWarning fires here pre-fix
print("frame shape:", frame.shape)
```

## Checklist

- [x] I have provided code that clearly demonstrates the bug and that only works correctly when applying this fix — *not included in the diff; reproduced and verified manually during development instead.*
As shown above and within the https://github.com/Zulko/moviepy/issues/2581


- [x] I have added suitable tests demonstrating a fixed bug or new/changed feature to the test suite in `tests/` — *none added; the existing `test_sequential_frame_pos` exercises the code path but doesn't specifically assert the warning is absent.*
All of the previous tests are running, no new tests needed.

- [x] I have properly documented new or changed features in the documentation or in the docstrings — *CHANGELOG.md entry added.*
- [x] I have properly explained unusual or unexpected code in the comments around it — *N/A, delete: the fix removes a now-redundant comment rather than adding anything that needs explaining.*
Not applicable